### PR TITLE
Add back problem_file annotations

### DIFF
--- a/Compfiles/Imo2022P1.lean
+++ b/Compfiles/Imo2022P1.lean
@@ -7,8 +7,11 @@ module
 
 public import Mathlib
 
+public import ProblemExtraction
+
 @[expose] public section
 
+problem_file { tags := [.Combinatorics] }
 
 /-!
 # International Mathematical Olympiad 2022, Problem 1

--- a/Compfiles/Usa2016P4.lean
+++ b/Compfiles/Usa2016P4.lean
@@ -13,6 +13,8 @@ import Mathlib.Analysis.SpecialFunctions.Log.Base
 
 @[expose] public section
 
+problem_file { tags := [.Algebra] }
+
 /-!
 # USA Mathematical Olympiad 2016 P4
 Find all functions f : ℝ → ℝ such that for all x, y ∈ ℝ:


### PR DESCRIPTION
Found more files that are missing in the dashboard by running `grep -L problem_file Compfiles/*`, you may want to add this to the CI to prevent future files going missing in the dashboard.
