### PR TITLE
Prune remaining `set_option backward.isDefEq.respectTransparency false`

### DIFF
--- a/Compfiles/Imo1964P4.lean
+++ b/Compfiles/Imo1964P4.lean
@@ -52,8 +52,7 @@ theorem lemma1
   have p2 : Person := Nonempty.some (Fintype.card_pos_iff.mp (by lia))
   let Person' := {p3 // p3 ≠ p2}
   have hfcα : 4 < Fintype.card Person' := by
-    set_option backward.isDefEq.respectTransparency false in
-    rw [Fintype.card_subtype_compl, Fintype.card_ofSubsingleton]
+    rw [Fintype.card_subtype_compl]
     exact lt_tsub_of_add_lt_left card_person
   have h1 : Fintype.card Topic * 2 < Fintype.card Person' := by lia
 

--- a/Compfiles/Imo1975P5.lean
+++ b/Compfiles/Imo1975P5.lean
@@ -27,13 +27,6 @@ determine constructible : Bool := true
 
 snip begin
 
-
-@[simp]
-theorem Complex.mk_mem_unitSphere_iff (a b : ℝ) : Complex.mk a b ∈ Submonoid.unitSphere ℂ ↔ a^2+b^2=1 := by
-  rw [Submonoid.unitSphere, <-Submonoid.mem_carrier, mem_sphere_iff_norm, sub_zero, <-sq_eq_sq₀,
-    Complex.norm_eq_sqrt_sq_add_sq, Real.sq_sqrt, one_pow] <;> positivity
-
-
 theorem not_irrational_add {b c : ℝ}: ¬Irrational b → ¬Irrational c → ¬Irrational (b + c) := by
   intro h1 h2
   apply not_imp_not.mpr (Irrational.add_cases)
@@ -68,10 +61,14 @@ theorem cos_θ : Real.cos θ = (4/5:ℚ) := by
   rw [Real.cos_arccos] <;> linarith
 
 
-noncomputable def P (n:ℕ) : Circle := {
-  val := ⟨Real.cos (θ*2*n), Real.sin (θ*2*n)⟩
-  property := by simp
-}
+noncomputable def P (n : ℕ) : Circle := Circle.exp (θ * n * 2)
+
+lemma P_cast_eq {n : ℕ} : (P n : ℂ) = ⟨Real.cos (θ*2*n), Real.sin (θ*2*n)⟩ := by
+  simp_rw [P, Circle.exp]
+  rw [Complex.ext_iff]
+  simp [Complex.exp_re, Complex.exp_im]
+  ring_nf
+  trivial
 
 theorem not_irrational_sin_θ_mul_and_not_irrational_cos_θ_mul (n : ℕ)
     : ¬ Irrational (Real.sin (θ*n)) ∧ ¬ Irrational (Real.cos (θ*n)) := by
@@ -81,11 +78,11 @@ theorem not_irrational_sin_θ_mul_and_not_irrational_cos_θ_mul (n : ℕ)
     rw [Nat.cast_add, mul_add, Real.sin_add, Real.cos_add]
     grind only [= cos_θ, = sin_θ, Rat.not_irrational, not_irrational_mul, not_irrational_add, not_irrational_sub]
 
+lemma Circle.dist_eq (x y : Circle) : dist x y = dist (x : ℂ) y := rfl
 
 theorem not_irrational_dist_P_P (i j : ℕ) : ¬ Irrational (dist (P i) (P j)) := by
-  unfold P
-  set_option backward.isDefEq.respectTransparency false in
-  rw [Subtype.dist_eq, Complex.dist_mk, Real.cos_sub_cos, Real.sin_sub_sin, mul_right_comm]
+  simp_rw [Circle.dist_eq, P_cast_eq]
+  rw [Complex.dist_mk, Real.cos_sub_cos, Real.sin_sub_sin, mul_right_comm]
   repeat rw [mul_pow]
   simp only [even_two, Even.neg_pow]
   rw [<-mul_add]
@@ -122,8 +119,8 @@ theorem P_injective : Function.Injective P := by
   · rw [ne_comm]
     have := this e.symm
     grind only
-  unfold P
-  rw [Ne, Circle.ext_iff]
+
+  simp_rw [Ne, Circle.ext_iff, P_cast_eq]
   simp only [Complex.mk.injEq, not_and]
   intro _
   suffices Real.sin (θ*2*(i-j)) ≠ 0 by

--- a/Compfiles/Imo1975P5.lean
+++ b/Compfiles/Imo1975P5.lean
@@ -123,8 +123,7 @@ theorem P_injective : Function.Injective P := by
     have := this e.symm
     grind only
   unfold P
-  set_option backward.isDefEq.respectTransparency false in
-  rw [Ne, Iff.not (Subtype.ext_iff)]
+  rw [Ne, Circle.ext_iff]
   simp only [Complex.mk.injEq, not_and]
   intro _
   suffices Real.sin (θ*2*(i-j)) ≠ 0 by

--- a/Compfiles/Imo1975P5.lean
+++ b/Compfiles/Imo1975P5.lean
@@ -119,7 +119,6 @@ theorem P_injective : Function.Injective P := by
   · rw [ne_comm]
     have := this e.symm
     grind only
-
   simp_rw [Ne, Circle.ext_iff, P_cast_eq]
   simp only [Complex.mk.injEq, not_and]
   intro _

--- a/Compfiles/Imo1979P6.lean
+++ b/Compfiles/Imo1979P6.lean
@@ -147,19 +147,17 @@ def C_G_symm (n : ℕ) : {w : Octagon.Walk C E // isTerminalWalk w ∧ w.length 
     · simp [h.right]
   }⟩
   left_inv := fun ⟨w, h⟩ => by
-    set_option backward.isDefEq.respectTransparency false in
-    simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Walk.copy_rfl_rfl,
-      Walk.map_map, Subtype.mk.injEq]
-    apply Walk.ext_support
+    simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Subtype.mk.injEq]
     unfold Octagon.mirror
-    simp
+    apply Walk.ext_support
+    set_option backward.isDefEq.respectTransparency false in
+    simp [Walk.copy_rfl_rfl, Walk.map_map]
   right_inv := fun ⟨w, h⟩ => by
-    set_option backward.isDefEq.respectTransparency false in
-    simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Walk.copy_rfl_rfl,
-      Walk.map_map, Subtype.mk.injEq]
+    simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Subtype.mk.injEq]
     apply Walk.ext_support
     unfold Octagon.mirror
-    simp
+    set_option backward.isDefEq.respectTransparency false in
+    simp [Walk.copy_rfl_rfl, Walk.map_map]
 }
 
 def isTerminalWalk_length_cons_equiv {V : Type} {G : SimpleGraph V} {u t : V} (m n : ℕ) (npos : 0 < n) :

--- a/Compfiles/Imo1979P6.lean
+++ b/Compfiles/Imo1979P6.lean
@@ -220,7 +220,6 @@ theorem a_b_recurrence_1 (n : ℕ) (npos : 0 < n) : a (n+2) = 2 * a n + 2 * b n 
       := by
         decide +revert
   unfold a b
-  set_option backward.isDefEq.respectTransparency false in
   calc
     _ = Fintype.card {w : Octagon.Walk A E // isTerminalWalk w ∧ w.length = 2 + n} := by
       rw [Set.ncard_eq_toFinset_card', add_comm]
@@ -240,7 +239,8 @@ theorem a_b_recurrence_1 (n : ℕ) (npos : 0 < n) : a (n+2) = 2 * a n + 2 * b n 
       repeat rw [walks_from_A]
       simp only [Set.ncard_eq_toFinset_card', Set.toFinset_card, Set.coe_setOf]
       rw [<-Fintype.card_eq.mpr (Nonempty.intro (C_G_symm _))]
-      lia
+      ring_nf
+      rfl
 
 theorem a_b_recurrence_2 (n : ℕ) (npos : 0 < n) : b (n+2) = a n + 2 * b n := by
   have walks_from_C (v) : Fintype.card { w : Octagon.Walk C v // E ∉ w.support ∧ w.length = 2 } =
@@ -251,7 +251,6 @@ theorem a_b_recurrence_2 (n : ℕ) (npos : 0 < n) : b (n+2) = a n + 2 * b n := b
       := by
         decide +revert
   unfold a b
-  set_option backward.isDefEq.respectTransparency false in
   calc
     _ = Fintype.card {w : Octagon.Walk C E // isTerminalWalk w ∧ w.length = 2 + n} := by
       rw [Set.ncard_eq_toFinset_card', add_comm]
@@ -270,7 +269,8 @@ theorem a_b_recurrence_2 (n : ℕ) (npos : 0 < n) : b (n+2) = a n + 2 * b n := b
       rw [Finset.sum_singleton]
       repeat rw [walks_from_C]
       simp only [Set.ncard_eq_toFinset_card', Set.toFinset_card, Set.coe_setOf]
-      lia
+      ring_nf
+      rfl
 
 
 theorem a_even (n : ℕ) (npos : 0 < n) : a (2*n) = ((2+√2)^(n-1) - (2-√2)^(n-1)) / √2 := by

--- a/Compfiles/Imo1982P4.lean
+++ b/Compfiles/Imo1982P4.lean
@@ -29,10 +29,10 @@ namespace Imo1982P4
 
 snip begin
 
-set_option backward.isDefEq.respectTransparency false in
 lemma lemma1 {x' y' : ZMod 7}
     (hxy : x' ^ 3 - 3 * x' * y' ^ 2 + y' ^ 3 = 0) : x' = 0 ∧ y' = 0 := by
   fin_cases x' <;> fin_cases y' <;> simp +decide at hxy ⊢
+  rfl
 
 snip end
 

--- a/Compfiles/Imo1983P5.lean
+++ b/Compfiles/Imo1983P5.lean
@@ -154,25 +154,21 @@ theorem generalized (n : ℕ+) :
   ∃ S : Finset ℕ+, S.card = 2 ^ n.val - 1 ∧
   (∀ x ∈ S, x.val ≤ (3 ^ n.val - 1) / 2) ∧
   ∀ x ∈ S, ∀ y ∈ S, ∀ z ∈ S, x < y ∧ y < z → x + z ≠ 2 * y := by
-  set S' := Finset.image base_two_to_base_three (Finset.range (2 ^ n.val) \ Finset.range 1) with hS'
-  use Finset.subtype (fun n ↦ 0 < n) S'
-  constructorm* _ ∧ _
-  · set_option backward.isDefEq.respectTransparency false in
-    rw [Finset.card_subtype]
-    have hS'_filter : ∀ n ∈ S', 0 < n := by
-      simp only [hS', Finset.mem_image, Finset.mem_sdiff, Finset.mem_range, Nat.lt_one_iff,
-                 forall_exists_index, and_imp]
-      intro _ m _ hm0 rfl
-      exact base_two_to_base_three_pos (Nat.pos_of_ne_zero hm0)
-    rw [Finset.card_filter_eq_iff.mpr hS'_filter, Finset.card_image_of_injective _ base_two_to_base_three_inj]
-    rw [Finset.card_sdiff, Finset.range_inter_range, Finset.card_range, Finset.card_range]
+  -- typecast the finset into ℕ+
+  use Finset.map ⟨(⟨base_two_to_base_three ·.val, base_two_to_base_three_pos (by grind)⟩),
+    fun _ _ h => by
+      simp only [Finset.range_one, ← PNat.coe_inj, PNat.mk_coe] at h
+      exact_mod_cast base_two_to_base_three_inj h⟩ (Finset.range (2 ^ n.val) \ Finset.range 1).attach
+  and_intros
+  · rw [Finset.card_map, Finset.card_attach, Finset.card_sdiff]
+    rw [Finset.range_inter_range, Finset.card_range, Finset.card_range]
     congr 1
     exact min_eq_left (Nat.one_le_pow _ _ (by norm_num))
   · intro x hx
-    set_option backward.isDefEq.respectTransparency false in
-    rw [Finset.mem_subtype, hS', Finset.mem_image] at hx
-    rcases hx with ⟨m, hm, hmx⟩
-    rw [PNat.val, ← hmx, base_two_to_base_three, Nat.ofDigits_eq]
+    rw [Finset.mem_map] at hx
+    simp_rw [Finset.mem_attach, true_and, DFunLike.coe] at hx
+    rcases hx with ⟨⟨m, hm⟩, rfl⟩
+    rw [PNat.mk_coe, base_two_to_base_three, Nat.ofDigits_eq]
     have h' : ∀ i ∈ Finset.range (Nat.digits 2 m).length, (Nat.digits 2 m).getI i * 3 ^ i ≤ 3 ^ i := by
       intro i _; nth_rw 2 [← one_mul (3 ^ i)]
       exact Nat.mul_le_mul_right _ (Nat.lt_succ_iff.mp (Nat.getI_digits_lt (b := 2) m i le_rfl))
@@ -188,24 +184,21 @@ theorem generalized (n : ℕ+) :
     exact hm.left
   · rintro x hx y hy z hz h'
     contrapose! h'
-    set_option backward.isDefEq.respectTransparency false in
-    rw [Finset.mem_subtype, hS', Finset.mem_image] at hx hy hz
-    rcases hx with ⟨x', hx', hx'x⟩
-    rcases hy with ⟨y', hy', hy'y⟩
-    rcases hz with ⟨z', hz', hz'z⟩
-    rw [← PNat.coe_inj] at h'
-    rw [← PNat.coe_lt_coe, ← PNat.coe_le_coe]
-    push_cast at h'
-    rw [two_mul] at h'
-    rw [PNat.val] at h' ⊢
+    rw [Finset.mem_map] at hx hy hz
+    simp_rw [Finset.mem_attach, true_and, DFunLike.coe] at hx hy hz
+    rcases hx with ⟨⟨x', hx'⟩, hx'x⟩
+    rcases hy with ⟨⟨y', hy'⟩, hy'y⟩
+    rcases hz with ⟨⟨z', hz'⟩, hz'z⟩
+    rw [← PNat.coe_inj] at hx'x hy'y hz'z
+    simp_rw [PNat.mk_coe] at hx'x hy'y hz'z
+    rw [← PNat.coe_lt_coe, ← PNat.coe_le_coe, PNat.val]
     apply zero_or_one_in_base_three_of_eq_base_two_to_base_three at hx'x
     apply zero_or_one_in_base_three_of_eq_base_two_to_base_three at hy'y
     apply zero_or_one_in_base_three_of_eq_base_two_to_base_three at hz'z
-    have hzx : Subtype.val x = Subtype.val z := by
-      rw [← eq_iff_of_zero_or_one_in_base hx'x hz'z, h']
-      rw [eq_iff_of_zero_or_one_in_base hy'y hy'y]
-    rw [hzx]
-    apply le_of_lt
+    suffices h : (x : ℕ) = z by rw [PNat.coe_inj.mp h]; apply le_of_lt
+    rw [← eq_iff_of_zero_or_one_in_base hx'x hz'z]
+    norm_cast; rw [h']; push_cast; rw [two_mul]
+    rw [eq_iff_of_zero_or_one_in_base hy'y hy'y]
 
 snip end
 
@@ -217,7 +210,7 @@ problem imo1983_p5 :
   have h : 1983 ≤ S'.card := by rw [hS'₁]; norm_num
   rcases Finset.exists_subset_card_eq h with ⟨S, hS₁, hS₂⟩
   use S
-  constructorm* _ ∧ _
+  and_intros
   · exact hS₂
   · exact fun x hx ↦ by rw [← PNat.coe_le_coe]; exact le_trans (hS'₂ x (hS₁ hx)) (by norm_num)
   · exact fun x hx y hy z hz ↦ hS'₃ x (hS₁ hx) y (hS₁ hy) z (hS₁ hz)

--- a/Compfiles/Imo1983P5.lean
+++ b/Compfiles/Imo1983P5.lean
@@ -184,13 +184,10 @@ theorem generalized (n : ℕ+) :
     exact hm.left
   · rintro x hx y hy z hz h'
     contrapose! h'
-    rw [Finset.mem_map] at hx hy hz
-    simp_rw [Finset.mem_attach, true_and, DFunLike.coe] at hx hy hz
-    rcases hx with ⟨⟨x', hx'⟩, hx'x⟩
-    rcases hy with ⟨⟨y', hy'⟩, hy'y⟩
-    rcases hz with ⟨⟨z', hz'⟩, hz'z⟩
-    rw [← PNat.coe_inj] at hx'x hy'y hz'z
-    simp_rw [PNat.mk_coe] at hx'x hy'y hz'z
+    simp_rw [Finset.mem_map, DFunLike.coe, ← PNat.coe_inj, PNat.mk_coe] at hx hy hz
+    rcases hx with ⟨x', -, hx'x⟩
+    rcases hy with ⟨y', -, hy'y⟩
+    rcases hz with ⟨z', -, hz'z⟩
     rw [← PNat.coe_lt_coe, ← PNat.coe_le_coe, PNat.val]
     apply zero_or_one_in_base_three_of_eq_base_two_to_base_three at hx'x
     apply zero_or_one_in_base_three_of_eq_base_two_to_base_three at hy'y

--- a/Compfiles/Imo1985P6.lean
+++ b/Compfiles/Imo1985P6.lean
@@ -162,7 +162,6 @@ lemma aux_7
   (hmo₄ : ∀ (n : ℕ), 0 < n → Continuous (f₀ n)) :
   ∀ (n : ℕ), 0 < n → Function.Surjective (f₀ n) := by
   intro n hn₀
-  set_option backward.isDefEq.respectTransparency false in
   refine Continuous.surjective (hmo₄ n hn₀) ?_ ?_
   · refine Monotone.tendsto_atTop_atTop ?_ ?_
     · exact StrictMono.monotone (hmo₂ n hn₀)

--- a/Compfiles/Imo1986P5.lean
+++ b/Compfiles/Imo1986P5.lean
@@ -94,7 +94,6 @@ problem imo1986_p5 {f : ℝ≥0 → ℝ≥0} : IsGood f ↔ f ∈ SolutionSet :=
     cases lt_or_ge y 2 with
     | inl hy =>
       have hy' : 2 - y ≠ 0 := (tsub_pos_of_lt hy).ne'
-      set_option backward.isDefEq.respectTransparency false in
       rw [div_mul_div_comm, tsub_mul, mul_assoc, div_mul_cancel₀ _ hy', mul_comm x,
         ← mul_tsub, tsub_add_eq_tsub_tsub_swap, mul_div_mul_left _ _ two_ne_zero]
     | inr hy =>

--- a/Compfiles/Imo1989P1.lean
+++ b/Compfiles/Imo1989P1.lean
@@ -29,6 +29,10 @@ snip begin
 
 def n : ℕ := 117
 
+lemma fin_n_card : Fintype.card (Fin n) = 117 := by
+  unfold n
+  simp
+
 def row (j : ℕ) (i : Fin n) : ℕ :=
   if j < 14 then
     if j % 2 = 0 then j * n + i.val + 1
@@ -99,9 +103,8 @@ def P : Finpartition S where
     rw [Finset.sup_image, Function.id_comp, Finset.sup_eq_biUnion]
     apply Finset.eq_of_subset_of_card_le
     · exact Finset.biUnion_subset.mpr fun i _ => A_le_S i
-    · set_option backward.isDefEq.respectTransparency false in
-      rw [Finset.card_biUnion fun i _ j _ hij => A_disjoint hij]
-      simp [A_card, S, n]
+    · rw [Finset.card_biUnion fun i _ j _ hij => A_disjoint hij]
+      simp [A_card, S, ↓fin_n_card]
   bot_notMem := by
     simp only [Finset.mem_image, Finset.mem_univ, true_and]
     rintro ⟨i, hi⟩; exact absurd (hi ▸ A_card i) (by norm_num)
@@ -113,8 +116,8 @@ problem imo1989_p1 : ∃ (P : Finpartition S),
     (∀ p ∈ P.parts, p.card = 17) ∧
     (∀ p ∈ P.parts, ∀ q ∈ P.parts, p.sum id = q.sum id) := by
   refine ⟨P, ?_, ?_, ?_⟩
-  · set_option backward.isDefEq.respectTransparency false in
-    simp [P, Finset.card_image_of_injective _ A_injective, n]
+  · rw [P, Finset.card_image_of_injective _ A_injective, n]
+    simp
   · simp only [show P.parts = Finset.univ.image A from rfl, Finset.forall_mem_image]
     exact fun _ _ => A_card _
   · simp only [show P.parts = Finset.univ.image A from rfl, Finset.forall_mem_image]

--- a/Compfiles/Imo1989P6.lean
+++ b/Compfiles/Imo1989P6.lean
@@ -391,9 +391,10 @@ theorem embed_B.not_Surjective [NeZero n] : ¬ Function.Surjective (embed_B n) :
     simp [Nat.dist_eq_sub_of_le]
   use ⟨x, by unfold T; exists 1, (by grind)⟩
   by_contra ⟨⟨⟨y, k⟩, h⟩, h'⟩
-  unfold embed_B at h'
-  set_option backward.isDefEq.respectTransparency false in
-  simp at h'
+  replace h' : y = x := by
+    unfold embed_B at h'
+    simp only [Set.mem_setOf_eq, Function.Embedding.coeFn_mk] at h'
+    rwa [← Subtype.mk_eq_mk]
   subst y
   unfold B at h
   simp only [Subtype.forall, Set.mem_setOf_eq] at h

--- a/Compfiles/Imo1990P3.lean
+++ b/Compfiles/Imo1990P3.lean
@@ -240,7 +240,6 @@ lemma imo_1990_p3_forward
         rw [Nat.Prime.emultiplicity_self hp₁] at hk₂₁
         rw [FiniteMultiplicity.emultiplicity_eq_multiplicity hn₂] at hk₂₁
         rw [FiniteMultiplicity.emultiplicity_eq_multiplicity hn₃] at hk₂₁
-        set_option backward.isDefEq.respectTransparency false in
         norm_cast at hk₂₁
         rw [hk₂₁]
         exact Nat.add_comm (1 : ℕ) (multiplicity (3 : ℕ) n)

--- a/Compfiles/Imo1990P4.lean
+++ b/Compfiles/Imo1990P4.lean
@@ -158,6 +158,8 @@ theorem PRat.prime_induction (P : ℚ+ → Prop) (base : P 1)
   rw [h] at this
   exact this
 
+theorem PRat.mk_mul_mk (a b : ℚ) (ha : 0 < a) (hb : 0 < b) : (⟨a, ha⟩ : ℚ+) * ⟨b, hb⟩ = ⟨a * b, Rat.mul_pos ha hb⟩ :=
+  Subtype.coe_eq_of_eq_mk rfl
 
 /-! The theorems in the following section are part of the original proof and
   illustrate the thought process behind solving the problem, but we do not need them - they are here just_for_fun.
@@ -258,60 +260,35 @@ theorem PNat.mk_mul_hom_fun.cancel {R : Type} [CommMonoid R]
       apply List.prod_eq_one
       aesop
 
+theorem PNat.mk_mul_hom_fun.inv (g : ℕ → ℚ+) (a : ℕ+) :
+    mk_mul_hom_fun g⁻¹ a = (mk_mul_hom_fun g a)⁻¹ := by
+  simp [mk_mul_hom_fun, List.prod_inv, List.map_map]
+  rfl
+
+theorem PNat.mk_mul_mk (a b : ℕ) (ha : 0 < a) (hb : 0 < b) : (⟨a, ha⟩ : ℕ+) * ⟨b, hb⟩ = ⟨a * b, Nat.mul_pos ha hb⟩ :=
+  Subtype.coe_eq_of_eq_mk rfl
+
+example (q : ℚ) : q.den ≠ 0 := by exact q.den_nz
 
 def PRat.mk_mul_hom_fun (g : ℕ → ℚ+) : ℚ+ →* ℚ+ := {
-  toFun q := ⟨(PNat.mk_mul_hom_fun g ⟨q.val.num.toNat, by simpa using q.prop⟩) * (PNat.mk_mul_hom_fun g⁻¹ ⟨q.val.den, Rat.den_pos ↑q⟩), by {
-    refine (Rat.mul_pos_iff_of_pos_left ?_).mpr ?_ <;> exact (Subtype.prop _)
-  }⟩
+  toFun q := ⟨(PNat.mk_mul_hom_fun g ⟨q.val.num.toNat, by simpa using q.prop⟩) * (PNat.mk_mul_hom_fun g⁻¹ ⟨q.val.den, Rat.den_pos ↑q⟩), by
+    refine (Rat.mul_pos_iff_of_pos_left ?_).mpr ?_ <;> exact Subtype.prop _
+  ⟩
   map_mul' a b := by
-    ext
+    simp_rw [PNat.mk_mul_hom_fun.inv, Positive.coe_inv, ← Rat.div_def, PRat.mk_mul_mk, ← Subtype.coe_inj]
+    field_simp
+    rw [div_eq_div_iff (by simp [@Subtype.coe_eq_iff]) (by simp [@Subtype.coe_eq_iff])]
+    simp_rw [<-Positive.val_mul, <-map_mul]
+    congr 2
     simp only [Positive.val_mul]
-
-    rw [<-Positive.val_mul]
-    rw [mul_mul_mul_comm]
-    simp_rw [<-Positive.val_mul]
-    rw [<-map_mul]
-    rw [<-map_mul]
-
-    rw [←PNat.mk_mul_hom_fun.cancel _ _ (by simp) _ _ ⟨(a.val.num * b.val.num).natAbs.gcd (a.val.den * b.val.den), by positivity⟩]
-    simp only [Positive.val_mul]
-    simp_rw [Rat.den_mul]
-    have (a b : ℕ) (apos : 0 < a) (dvd : b ∣ a) (h1 : _) (h2 : _)
-        : ⟨a / b, h1⟩ * (⟨b, h2⟩ : ℕ+) = (⟨a, apos⟩ : ℕ+) := by
-      ext
-      refine Nat.div_mul_cancel dvd
     set_option backward.isDefEq.respectTransparency false in
-    rw [this]
-    · have : ∀ h1, ∀ h2, (⟨a.val.den, h1⟩ : ℕ+) * (⟨b.val.den, h2⟩ : ℕ+) = (⟨a.val.den * b.val.den, (Nat.mul_pos h1 h2)⟩ : ℕ+) := by
-        intro h1 h2
-        rfl
-      simp_rw [this]
-      congr 1
-
-      simp_rw [Rat.num_mul]
-      have (a : ℤ) (b : ℕ) (apos : 0 < a) (hd : b.cast ∣ a) (h1 : _) (h2 : _)
-          : ⟨(a / b.cast).toNat, h1⟩ * (⟨b, h2⟩ : ℕ+) = (⟨a.toNat, Int.pos_iff_toNat_pos.mp apos⟩ : ℕ+) := by
-        ext
-        simp only [Positive.val_mul]
-        zify
-        rw [<-(@Int.eq_natCast_toNat _).mpr ?_]
-        · rw [Int.ediv_mul_cancel hd]
-          rw [<-(@Int.eq_natCast_toNat _).mpr ?_]
-          exact Int.le_of_lt apos
-        · positivity
-      rw [this]
-      · congr
-        refine Int.toNat_mul ?_ ?_ <;> {
-          refine Rat.num_nonneg.mpr ?_
-          apply le_of_lt ((Subtype.prop _))
-        }
-      · refine Int.mul_pos ?_ ?_ <;> {
-          refine Rat.num_pos.mpr ?_
-          apply (Subtype.prop _)
-        }
-      · exact Rat.normalize.dvd_num rfl
-    · positivity
-    · apply Nat.gcd_dvd_right
+     repeat rw [PNat.mk_mul_mk]
+    rw [← PNat.coe_inj]
+    simp_rw [PNat.mk_coe]
+    zify [Int.toNat_of_nonneg <| Rat.num_nonneg.mpr a.2.le,
+          Int.toNat_of_nonneg <| Rat.num_nonneg.mpr b.2.le,
+          Int.toNat_of_nonneg <| Rat.num_nonneg.mpr <| Rat.mul_nonneg a.2.le b.2.le]
+    rw [← Rat.mul_num_den', mul_assoc]
   map_one' := by
     unfold PNat.mk_mul_hom_fun
     simp only [MulHom.coe_mk, PNat.mk_coe, Positive.val_one, Rat.num_ofNat, Int.toNat_one,

--- a/Compfiles/Imo1990P4.lean
+++ b/Compfiles/Imo1990P4.lean
@@ -268,8 +268,6 @@ theorem PNat.mk_mul_hom_fun.inv (g : ℕ → ℚ+) (a : ℕ+) :
 theorem PNat.mk_mul_mk (a b : ℕ) (ha : 0 < a) (hb : 0 < b) : (⟨a, ha⟩ : ℕ+) * ⟨b, hb⟩ = ⟨a * b, Nat.mul_pos ha hb⟩ :=
   Subtype.coe_eq_of_eq_mk rfl
 
-example (q : ℚ) : q.den ≠ 0 := by exact q.den_nz
-
 def PRat.mk_mul_hom_fun (g : ℕ → ℚ+) : ℚ+ →* ℚ+ := {
   toFun q := ⟨(PNat.mk_mul_hom_fun g ⟨q.val.num.toNat, by simpa using q.prop⟩) * (PNat.mk_mul_hom_fun g⁻¹ ⟨q.val.den, Rat.den_pos ↑q⟩), by
     refine (Rat.mul_pos_iff_of_pos_left ?_).mpr ?_ <;> exact Subtype.prop _

--- a/Compfiles/Imo1991P5.lean
+++ b/Compfiles/Imo1991P5.lean
@@ -195,7 +195,6 @@ lemma angle_eq_angle_add_angle_of_mem_interior
   rw [Fin.sum_univ_three] at hsum hsum'
   use ⟨(basis.coord 0) P, le_of_lt (hP 0)⟩
   use ⟨(basis.coord 2) P, le_of_lt (hP 2)⟩
-  set_option backward.isDefEq.respectTransparency false in
   rw [NNReal.smul_def, NNReal.smul_def, NNReal.toReal, Subtype.val, Subtype.val]
   dsimp
   nth_rw 3 [← hsum]

--- a/Compfiles/Imo1994P5.lean
+++ b/Compfiles/Imo1994P5.lean
@@ -145,18 +145,12 @@ problem imo1994_p5 (f : S → S) :
     exact h4 (op f x x) (h1 x x)
 
   ext x
-  have h6 := h5 x
-  unfold op at h6
+  have h6 := Subtype.mk_eq_mk.mp <| h5 x
   obtain ⟨x, hx⟩ := x
-  set_option backward.isDefEq.respectTransparency false in
-  rw [Subtype.mk_eq_mk] at h6
-  dsimp only at h6
   have h7 : (f ⟨x, hx⟩).val = -x / (1 + x) := by
     have h8 : 0 < 1 + x := by linarith
     field_simp
     linarith
-  rw [←Subtype.val_inj]
-  dsimp only
-  exact h7
+  exact Subtype.val_inj.mp h7
 
 end Imo1994P5

--- a/Compfiles/Imo2005P4.lean
+++ b/Compfiles/Imo2005P4.lean
@@ -61,9 +61,7 @@ determine SolutionSet : Set ℕ+ := { 1 }
 
 problem imo2005_p4 {k : ℕ} (hk : 0 < k) :
     (∀ n : ℕ, 1 ≤ n → IsCoprime (a n) k) ↔ ⟨k, hk⟩ ∈ SolutionSet := by
-  set_option backward.isDefEq.respectTransparency false in
-  rw [Set.mem_singleton_iff,
-      show ((⟨k, hk⟩: ℕ+) = 1) ↔ k = 1 from eq_iff_eq_of_cmp_eq_cmp rfl]
+  rw [Set.mem_singleton_iff, ← PNat.coe_eq_one_iff, PNat.mk_coe]
   constructor; rotate_left
   · -- The property is clearly true for `k = 1`
     rintro rfl n -

--- a/Compfiles/Imo2008P5.lean
+++ b/Compfiles/Imo2008P5.lean
@@ -346,9 +346,7 @@ lemma claim (n k : ℕ) (hn : 0 < n) (hnk : n ≤ k) (_he : Even (k - n))
             constructor
             · intro x y hxy; exact Subtype.ext (Subtype.ext (by simpa using congrArg (·.1) hxy))
             · intro y
-              set_option backward.isDefEq.respectTransparency false in
               exact ⟨⟨⟨y.1, hfi_of_high i y.1 y.2⟩, by simp [s, y.2]⟩, Subtype.ext rfl⟩
-          set_option backward.isDefEq.respectTransparency false in
           have : s.card = Nat.card {j : Fin k | (gfun j).val = n + i} := by
             rw [Nat.card_eq_fintype_card, ← show Fintype.card {x // x ∈ s} = s.card from by simp]
             exact Fintype.card_of_bijective hbij
@@ -357,7 +355,6 @@ lemma claim (n k : ℕ) (hn : 0 < n) (hnk : n ≤ k) (_he : Even (k - n))
       refine ⟨a, ?_⟩
       have hselA : ∀ (i : Fin n) (j : Fin k), j ∈ selected a i ↔ (gfun j).val = n + i := by
         intro i j
-        set_option backward.isDefEq.respectTransparency false in
         constructor
         · intro hj
           rcases hj with ⟨ji, hji, rfl⟩

--- a/Compfiles/Imo2008P5.lean
+++ b/Compfiles/Imo2008P5.lean
@@ -188,75 +188,77 @@ lemma claim (n k : ℕ) (hn : 0 < n) (hnk : n ≤ k) (_he : Even (k - n))
   let selected (cs : S) (i : Fin n) : Set (Fin k) :=
     Subtype.val '' (↑((cs i).1) : Set { j : Fin k | f.val j = ⟨i, by lia⟩ })
 
-  let p : S → {g | ψ n k g = f} :=
-    fun cs ↦
-       let g1 : Fin k → Fin (2 * n) :=
-         fun j ↦
-           let y : Fin (2 * n) := f.val j
-           let y' : Fin n := ⟨y.val, hM j⟩
-           if j ∈ selected cs y' then ⟨y.val + n, by
-             have hy : y.val < n := hM j
-             lia⟩ else y
-       let hg1 : NSequence n k g1 := by
-         obtain ⟨⟨hN, _⟩, _⟩ := f.property
-         have hsel_subset : ∀ i : Fin n, selected cs i ⊆ {j : Fin k | ↑(f.val j) = (i : ℕ)} := by
-           intro i j hj
-           rcases hj with ⟨x, hx, rfl⟩
-           exact congrArg Fin.val x.2
-         have hsel_even : ∀ i : Fin n, Even (Set.ncard (selected cs i)) := by
-           intro i
-           have : Set.ncard (selected cs i) = ((cs i).1).card := by
-             dsimp [selected]
-             set_option backward.isDefEq.respectTransparency false in
-             rw [Set.ncard_image_of_injective _ Subtype.val_injective, Set.ncard_coe_finset]
-           rw [this]; exact (cs i).2
-         have hhigh : ∀ i : Fin n, {j : Fin k | ↑(g1 j) = n + i} = selected cs i := by
-           intro i; ext j; simp only [Set.mem_setOf]
-           constructor
-           · intro hj
-             let y' : Fin n := ⟨(f.val j).val, hM j⟩
-             by_cases hmem : j ∈ selected cs y'
-             · have hg1v : (g1 j).val = (f.val j).val + n := by simp [g1, y', hmem]
-               have : (f.val j).val = i := by lia
-               have : y' = i := Fin.ext this
-               simpa [this] using hmem
-             · have : (f.val j).val = n + ↑i := by simpa [g1, y', hmem] using hj
-               exact absurd (this ▸ hM j) (by lia)
-           · intro hj
-             have hfj : (f.val j).val = i := hsel_subset i hj
-             have : (⟨(f.val j).val, hM j⟩ : Fin n) = i := Fin.ext hfj
-             have hmem : j ∈ selected cs ⟨(f.val j).val, hM j⟩ := by simpa [this] using hj
-             have : (g1 j).val = (f.val j).val + n := by simp [g1, hmem]
-             lia
-         have hred : ∀ j, (f.val j).val =
-             if (g1 j).val < n then (g1 j).val else (g1 j).val - n := by
-           intro j; simp only [g1]; split_ifs with hmem <;> simp_all
-         refine ⟨?_, ?_⟩
-         · intro i hi
-           let i' : Fin n := ⟨i, hi⟩
-           have hcard := fiber_ncard_of_mod_n (f := g1) (g := f.val) hred i hi
-           rw [Nat.card_coe_set_eq, show Set.ncard {j | (g1 j).val = i} =
-             Set.ncard {j | (f.val j).val = i} - Set.ncard {j | (g1 j).val = n + i} by lia]
-           exact Nat.Odd.sub_even (by lia)
-             (by rw [← Nat.card_coe_set_eq]; exact hN i hi)
-             (by rw [hhigh i']; exact hsel_even i')
-         · intro i hi1 hi2
-           let i' : Fin n := ⟨i - n, by lia⟩
-           have hi' : n + ↑i' = i := Nat.add_sub_of_le hi1
-           rw [show {j : Fin k | ↑(g1 j) = i} = {j | ↑(g1 j) = n + ↑i'} from by
-             ext j; simp [hi'], Nat.card_coe_set_eq, hhigh i']
-           exact hsel_even i'
-       let hgg : ψ n k ⟨g1, hg1⟩ = f := by
-         rcases hg1 with ⟨hg1a, hg1b⟩
-         apply Subtype.ext; funext j; apply Fin.ext
-         simp only [ψ]
-         let y' : Fin n := ⟨(f.val j).val, hM j⟩
-         by_cases hmem : j ∈ selected cs y'
-         · have hg1v : (g1 j).val = (f.val j).val + n := by simp [g1, y', hmem]
-           have hnot : ¬ (g1 j).val < n := by lia
-           simp [hg1v]
-         · simp [g1, y', hmem, hM j]
-       ⟨⟨g1, hg1⟩, hgg⟩
+  let selected_fin (cs : S) (i : Fin n) : Finset (Fin k) :=
+    Finset.map ⟨Subtype.val, Subtype.val_injective⟩ ((cs i).1)
+
+  let selected_eq_fin (cs : S) (i : Fin n) : selected cs i = selected_fin cs i := by
+    simp [selected, selected_fin]
+    rfl
+
+  let p (cs : S) : {g | ψ n k g = f} :=
+    let g1 (j : Fin k) : Fin (2 * n) :=
+      let y : Fin (2 * n) := f.val j
+      let y' : Fin n := ⟨y.val, hM j⟩
+      if j ∈ selected cs y' then ⟨y.val + n, by
+        have hy : y.val < n := hM j
+        lia⟩ else y
+    let hg1 : NSequence n k g1 := by
+      obtain ⟨⟨hN, _⟩, _⟩ := f.property
+      have hsel_subset : ∀ i : Fin n, selected cs i ⊆ {j : Fin k | ↑(f.val j) = (i : ℕ)} := by
+        intro i j hj
+        rcases hj with ⟨x, hx, rfl⟩
+        exact congrArg Fin.val x.2
+      have hsel_even : ∀ i : Fin n, Even (Set.ncard (selected cs i)) := by
+        intro i
+        rw [selected_eq_fin, Set.ncard_coe_finset, Finset.card_map]
+        exact (cs i).2
+      have hhigh : ∀ i : Fin n, {j : Fin k | ↑(g1 j) = n + i} = selected cs i := by
+        intro i; ext j; simp only [Set.mem_setOf]
+        constructor
+        · intro hj
+          let y' : Fin n := ⟨(f.val j).val, hM j⟩
+          by_cases hmem : j ∈ selected cs y'
+          · have hg1v : (g1 j).val = (f.val j).val + n := by simp [g1, y', hmem]
+            have : (f.val j).val = i := by lia
+            have : y' = i := Fin.ext this
+            simpa [this] using hmem
+          · have : (f.val j).val = n + ↑i := by simpa [g1, y', hmem] using hj
+            exact absurd (this ▸ hM j) (by lia)
+        · intro hj
+          have hfj : (f.val j).val = i := hsel_subset i hj
+          have : (⟨(f.val j).val, hM j⟩ : Fin n) = i := Fin.ext hfj
+          have hmem : j ∈ selected cs ⟨(f.val j).val, hM j⟩ := by simpa [this] using hj
+          have : (g1 j).val = (f.val j).val + n := by simp [g1, hmem]
+          lia
+      have hred : ∀ j, (f.val j).val =
+          if (g1 j).val < n then (g1 j).val else (g1 j).val - n := by
+        intro j; simp only [g1]; split_ifs with hmem <;> simp_all
+      refine ⟨?_, ?_⟩
+      · intro i hi
+        let i' : Fin n := ⟨i, hi⟩
+        have hcard := fiber_ncard_of_mod_n (f := g1) (g := f.val) hred i hi
+        rw [Nat.card_coe_set_eq, show Set.ncard {j | (g1 j).val = i} =
+          Set.ncard {j | (f.val j).val = i} - Set.ncard {j | (g1 j).val = n + i} by lia]
+        exact Nat.Odd.sub_even (by lia)
+          (by rw [← Nat.card_coe_set_eq]; exact hN i hi)
+          (by rw [hhigh i']; exact hsel_even i')
+      · intro i hi1 hi2
+        let i' : Fin n := ⟨i - n, by lia⟩
+        have hi' : n + ↑i' = i := Nat.add_sub_of_le hi1
+        rw [show {j : Fin k | ↑(g1 j) = i} = {j | ↑(g1 j) = n + ↑i'} from by
+          ext j; simp [hi'], Nat.card_coe_set_eq, hhigh i']
+        exact hsel_even i'
+    let hgg : ψ n k ⟨g1, hg1⟩ = f := by
+      rcases hg1 with ⟨hg1a, hg1b⟩
+      apply Subtype.ext; funext j; apply Fin.ext
+      simp only [ψ]
+      let y' : Fin n := ⟨(f.val j).val, hM j⟩
+      by_cases hmem : j ∈ selected cs y'
+      · have hg1v : (g1 j).val = (f.val j).val + n := by simp [g1, y', hmem]
+        have hnot : ¬ (g1 j).val < n := by lia
+        simp [hg1v]
+      · simp [g1, y', hmem, hM j]
+    ⟨⟨g1, hg1⟩, hgg⟩
   have Scard : Fintype.card S = ∏ i : Fin n, 2 ^ (c i - 1) := by
     unfold S
     rw [Fintype.card_pi]

--- a/Compfiles/Usa2017P1.lean
+++ b/Compfiles/Usa2017P1.lean
@@ -120,9 +120,7 @@ def build : ℕ → solution_set :=
 snip end
 
 problem infinite_solution_set :
-    Infinite { (x, y) : ℕ × ℕ | condition x y } := by
-  refine Infinite.of_injective build (fun _ => ?_)
-  set_option backward.isDefEq.respectTransparency false in
-  simp [build]
+    Infinite { (x, y) : ℕ × ℕ | condition x y } :=
+  Infinite.of_injective build (fun _ _ h => by grind only [Subtype.mk_eq_mk.mp h])
 
 end Usa2017P1


### PR DESCRIPTION
Two files remain (`Imo1979P6`, `Imo1990P4`) that still set `respectTransparency` to `false`. In them I have localized the toggle to apply only to the next immediate tactic.
