### PR TITLE
Normalize left arrow

### DIFF
--- a/Compfiles/Bulgaria1998P2.lean
+++ b/Compfiles/Bulgaria1998P2.lean
@@ -39,7 +39,7 @@ problem bulgaria1998_p2
   let x := ∠ D A C
   have : ∠ D A C = ∠ D C A := EuclideanGeometry.angle_eq_angle_of_dist_eq H1
   let y := ∠ C A B
-  have : ∠ A B C = x + y := by rw [←H2]; sorry -- need to switch to oangles?
+  have : ∠ A B C = x + y := by rw [← H2]; sorry -- need to switch to oangles?
   sorry
 
 

--- a/Compfiles/Bulgaria1998P6.lean
+++ b/Compfiles/Bulgaria1998P6.lean
@@ -453,12 +453,12 @@ problem bulgaria1998_p6
   let b := 2 * x * y
   have h3 : a^2 + b^2  = (2 * z ^ 2 - (x ^ 2 + y ^ 2)) ^ 2 :=
      by linear_combination h2
-  have h4 : IsSquare (a^2 + b^2) := by use 2 * z ^ 2 - (x ^ 2 + y ^ 2); rwa [←sq]
+  have h4 : IsSquare (a^2 + b^2) := by use 2 * z ^ 2 - (x ^ 2 + y ^ 2); rwa [← sq]
   have h5 : IsSquare (a^2 - b^2) := by use (x^2 - y^2); ring
   have h6 : IsSquare ((a^2 + b^2) * (a^2 - b^2)) := IsSquare.mul h4 h5
   rw [show (a^2 + b^2) * (a^2 - b^2) = a^4 - b^4 by ring] at h6
   obtain ⟨c, hc⟩ := h6
-  rw [←sq, ←sq_abs] at hc
+  rw [← sq, ← sq_abs] at hc
   have ha' : 0 < a := by positivity
   have hb' : 0 < b := by positivity
   have hc' : 0 < |c| := by
@@ -472,7 +472,7 @@ problem bulgaria1998_p6
         exact (pow_left_inj₀ hap hbp two_ne_zero).mp hc3
       rw [hab] at h4
       obtain ⟨r, hr⟩ := h4
-      rw [←two_mul, ←sq] at hr
+      rw [← two_mul, ← sq] at hr
       have h10 : b^2 ∣ r^2 := Dvd.intro_left _ hr
       rw [Int.pow_dvd_pow_iff two_ne_zero] at h10
       obtain ⟨e, rfl⟩ := h10
@@ -483,13 +483,13 @@ problem bulgaria1998_p6
       have h13 : e < 2 := by
         by_contra! H
         have h20 : 2^2 ≤ e^2 := by gcongr
-        rw [←h12] at h20
+        rw [← h12] at h20
         norm_num at h20
       have h14 : -2 < e := by
         by_contra! H
         replace H : 2 ≤ -e := Int.le_neg_of_le_neg H
         have h20 : 2^2 ≤ (-e)^2 := by gcongr
-        rw [neg_sq, ←h12] at h20
+        rw [neg_sq, ← h12] at h20
         norm_num at h20
       interval_cases e <;> linarith
     · exact (Int.not_lt.mpr (abs_nonneg c) hc3).elim

--- a/Compfiles/Hungary1998P6.lean
+++ b/Compfiles/Hungary1998P6.lean
@@ -69,7 +69,7 @@ problem hungary1998_p6 (x y : ℤ) (z : ℕ) (hz : 1 < z) :
     simp [Finset.sum_range_succ]
 
   have h5 : ∑ i ∈ Finset.range 100, (i:ℤ) = 99 * 100 / 2 := by
-    rw [←Nat.cast_sum, Finset.sum_range_id]; decide
+    rw [← Nat.cast_sum, Finset.sum_range_id]; decide
 
   have h6 : ∑ i ∈ Finset.range 99, ((i:ℤ) + 1)^2 = (99 * 100 * 199)/6 := by
     rw [cast_sum_square, sum_range_square]; decide
@@ -88,7 +88,7 @@ problem hungary1998_p6 (x y : ℤ) (z : ℕ) (hz : 1 < z) :
           ∑ i ∈ Finset.range 99, (2 * x * ((i:ℤ) + 1)) +
          ∑ i ∈ Finset.range 99, (((i:ℤ) + 1)^2) := by rw [Finset.sum_add_distrib]
     _ = 99 * x^2 + 2 * x * (99 * 100 / 2) + (99 * 100 * 199)/6
-        := by rw [h2, ←Finset.mul_sum, h4, h5, h6]
+        := by rw [h2, ← Finset.mul_sum, h4, h5, h6]
     _ = 3 * (11 * (3 * x^2 + 300 * x + 50 * 199)) := by rw [hnn1, hnn2]; ring
 
   -- which implies that 3∣y.

--- a/Compfiles/Imo1962P2.lean
+++ b/Compfiles/Imo1962P2.lean
@@ -40,7 +40,7 @@ lemma lemma2 {x : ℝ} (hx4 : 0 ≤ 3 - x) (hx5 : 0 ≤ x + 1) :
    _ = (3 - x) - 2 * Real.sqrt (3 - x) * Real.sqrt (x + 1)
        + (x + 1) := by rw [Real.sq_sqrt hx4, add_left_cancel_iff, Real.sq_sqrt hx5]
    _ = 4 - 2 * (Real.sqrt (3 - x) * Real.sqrt (x + 1)) := by ring
-   _ = 4 - 2 * Real.sqrt ((3 - x) * (x + 1)) := by rw[←Real.sqrt_mul hx4]
+   _ = 4 - 2 * Real.sqrt ((3 - x) * (x + 1)) := by rw[← Real.sqrt_mul hx4]
 
 snip end
 

--- a/Compfiles/Imo1963P1.lean
+++ b/Compfiles/Imo1963P1.lean
@@ -44,7 +44,7 @@ problem imo1963_p1 : ∀ (p x : ℝ), (x ^ 2 - p) ≥ 0 → (x ^ 2 - 1) ≥ 0 �
   intro p x h1 h2
   simp only [f, ge_iff_le, Set.mem_ite_empty_right, Set.mem_singleton_iff]
   apply @iff_comm (c := x ≥ 0)
-  · intro h; rw [←h]; positivity
+  · intro h; rw [← h]; positivity
   · rintro ⟨⟨-, hx12⟩, rfl⟩
     apply le_of_lt
     apply div_pos_iff.mpr
@@ -67,11 +67,11 @@ problem imo1963_p1 : ∀ (p x : ℝ), (x ^ 2 - p) ≥ 0 → (x ^ 2 - 1) ≥ 0 �
   apply @iff_comm (c := p + 4 - 4 * x ^ 2 ≥ 0)
   · intro h; rw [ge_iff_le]
     apply (div_le_div_iff_of_pos_right (by norm_num : (0 : ℝ) < (4 : ℝ))).mp
-    norm_num; rw [←h]; positivity
+    norm_num; rw [← h]; positivity
   · rintro ⟨hx, rfl⟩
     have tmp : 0 < (4 - 2 * p) := by linarith only [hx]
     rw [div_pow, mul_pow, Real.sq_sqrt (le_of_lt tmp)]; norm_num
-    rw [←mul_le_mul_iff_left₀ tmp, mul_assoc, div_mul]
+    rw [← mul_le_mul_iff_left₀ tmp, mul_assoc, div_mul]
     have := tmp.ne.symm
     rw [mul_div_cancel_right₀ _ tmp.ne.symm]
     nlinarith
@@ -82,10 +82,10 @@ problem imo1963_p1 : ∀ (p x : ℝ), (x ^ 2 - p) ≥ 0 → (x ^ 2 - 1) ≥ 0 �
   rw [mul_pow, Real.sq_sqrt h1, Real.sq_sqrt h2]
   rw [div_pow]
   norm_num
-  conv => lhs; rw [←mul_right_cancel_iff_of_pos (by norm_num : (0 : ℝ) < (16 : ℝ))]; norm_num
-          rw [sub_sq, mul_pow, ←pow_mul];
+  conv => lhs; rw [← mul_right_cancel_iff_of_pos (by norm_num : (0 : ℝ) < (16 : ℝ))]; norm_num
+          rw [sub_sq, mul_pow, ← pow_mul];
           simp only [mul_add, add_mul, mul_sub_left_distrib, mul_sub_right_distrib]; norm_num
-          rw [←pow_add]; norm_num
+          rw [← pow_add]; norm_num
   trans x ^ 2 * 4 * (4 - 2 * p) = (p - 4) ^ 2
   · constructor
     · intro h; linear_combination (norm := (field_simp; ring_nf)) 1 * h
@@ -112,9 +112,9 @@ problem imo1963_p1 : ∀ (p x : ℝ), (x ^ 2 - p) ≥ 0 → (x ^ 2 - 1) ≥ 0 �
   constructor
   · intro hx
     refine ⟨?_, hx⟩
-    rw [hx, ←tmp2] at xp
+    rw [hx, ← tmp2] at xp
     simp only [ge_iff_le, sub_nonneg] at xp
-    rw [←mul_le_mul_iff_left₀ (by positivity : (0 < ((4 : ℝ) * ((4 : ℝ) - (2 : ℝ) * p))))] at xp
+    rw [← mul_le_mul_iff_left₀ (by positivity : (0 < ((4 : ℝ) * ((4 : ℝ) - (2 : ℝ) * p))))] at xp
     rw [mul_div] at xp
     rw [div_mul_cancel₀ _ (by positivity)] at xp
     ring_nf at xp

--- a/Compfiles/Imo1964P1.lean
+++ b/Compfiles/Imo1964P1.lean
@@ -59,7 +59,7 @@ problem imo_1964_p1b (n : ℕ) : ¬ 7 ∣ (2^n + 1) := by
   intro h
   apply Nat.mod_eq_zero_of_dvd at h
   have h1: 2 ^ 3 % 7 = 1 := by rfl
-  mod_cases h2 : n % 3 <;> rw [←Nat.div_add_mod n 3, h2] at h
+  mod_cases h2 : n % 3 <;> rw [← Nat.div_add_mod n 3, h2] at h
   · rw [Nat.zero_mod, add_zero, Nat.add_mod, Nat.pow_mod, pow_mul,
         Nat.pow_mod, h1, one_pow (M := ℕ)] at h
     contradiction

--- a/Compfiles/Imo1964P2.lean
+++ b/Compfiles/Imo1964P2.lean
@@ -67,11 +67,11 @@ problem imo1964_p2
   -- The only thing we need to know about a,b,c is that they
   -- are nonnegative.
   have ha' : 0 ≤ dist (T.points 1) (T.points 2) := dist_nonneg
-  rw [←ha] at ha'; clear ha
+  rw [← ha] at ha'; clear ha
   have hb' : 0 ≤ dist (T.points 2) (T.points 0) := dist_nonneg
-  rw [←hb] at hb'; clear hb
+  rw [← hb] at hb'; clear hb
   have hc' : 0 ≤ dist (T.points 0) (T.points 1) := dist_nonneg
-  rw [←hc] at hc'; clear hc
+  rw [← hc] at hc'; clear hc
   clear T
 
   have h1 :

--- a/Compfiles/Imo1964P4.lean
+++ b/Compfiles/Imo1964P4.lean
@@ -98,13 +98,13 @@ theorem lemma1
       obtain ⟨⟨p3, p3_ne⟩, p3_mem_α, p3_eq⟩ := hp3'
       obtain ⟨⟨p4, p4_ne⟩, p4_mem_α, p4_eq⟩ := hp4'
       dsimp at p3_eq p4_eq
-      rw [←p3_eq, ←p4_eq]
+      rw [← p3_eq, ← p4_eq]
       have hne : p3 ≠ p4 := by rwa [p3_eq, p4_eq]
       have h8 := h6 ⟨⟨p3, p3_ne⟩, p3_mem_α⟩ ⟨⟨p4, p4_ne⟩, p4_mem_α⟩
                     (by simp[hne, Person'])
       let t3': Topic' := ⟨discusses p3 p4, h8⟩
       have h9 := ht3 t3'
-      rw [←h9]
+      rw [← h9]
 
 snip end
 
@@ -211,7 +211,7 @@ problem imo1964_p4
       obtain ⟨⟨⟨p3', p3_mem_person'⟩, p3_mem_α⟩, p3_mem_s, hp3eq⟩ := hp3
       obtain ⟨⟨⟨p4', p4_mem_person'⟩, p4_mem_α⟩, p4_mem_s, hp4eq⟩ := hp4
       simp only [DFunLike.coe] at hp3eq hp4eq
-      rw [←hp3eq, ←hp4eq]
+      rw [← hp3eq, ← hp4eq]
       have hne : p3' ≠ p4' := by rwa[hp3eq, hp4eq]
       have h6 := hs2 ⟨⟨p3', p3_mem_person'⟩, p3_mem_α⟩ p3_mem_s
                      ⟨⟨p4', p4_mem_person'⟩, p4_mem_α⟩ p4_mem_s

--- a/Compfiles/Imo1965P1.lean
+++ b/Compfiles/Imo1965P1.lean
@@ -36,14 +36,14 @@ problem imo1965_p1 :
   -- We follow https://artofproblemsolving.com/wiki/index.php/1965_IMO_Problems/Problem_1.
   have h0 : ∀ x, (√(1 + sin (2*x)) - √(1 - sin (2*x)))^2 = 2 - 2*|cos (2*x)| := by
     intro x
-    rw [←sqrt_sq_eq_abs (cos (2 * x)), cos_sq', sub_sq, sq_sqrt, sq_sqrt, mul_assoc,
-      ←sqrt_mul]
+    rw [← sqrt_sq_eq_abs (cos (2 * x)), cos_sq', sub_sq, sq_sqrt, sq_sqrt, mul_assoc,
+      ← sqrt_mul]
     · ring_nf
     repeat { linarith [sin_le_one (2 * x), neg_one_le_sin (2 * x)] }
   have : ∀ x, |√(1 + sin (2*x)) - √(1 - sin (2*x))| ≤ √2 := by
     intro x
     apply nonneg_le_nonneg_of_sq_le_sq (by norm_num)
-    simp [←pow_two, h0]
+    simp [← pow_two, h0]
   simp only [Set.mem_Icc]
   simp_rw [this, and_true]
   symm; ext x; constructor
@@ -61,7 +61,7 @@ problem imo1965_p1 :
       have cosx_nonneg : 0 ≤ cos x := by
         apply cos_nonneg_of_neg_pi_div_two_le_of_le <;> linarith
       have cosx2_nonneg : 0 ≤ 2 * cos x := by linarith
-      rw [←abs_of_nonneg cosx2_nonneg, ←sq_le_sq, h0, abs_of_nonpos cos2x_nonpos, cos_two_mul]
+      rw [← abs_of_nonneg cosx2_nonneg, ← sq_le_sq, h0, abs_of_nonpos cos2x_nonpos, cos_two_mul]
       linarith
     · trans 0; swap;
       · simp
@@ -69,13 +69,13 @@ problem imo1965_p1 :
       apply cos_nonpos_of_pi_div_two_le_of_le h3
       linarith
     · have cos2x_nonpos : cos (2*x) ≤ 0 := by
-        rw [←cos_neg, ←cos_add_two_pi, ←cos_add_two_pi]
+        rw [← cos_neg, ← cos_add_two_pi, ← cos_add_two_pi]
         apply cos_nonpos_of_pi_div_two_le_of_le <;> linarith
       have cosx_nonneg : 0 ≤ cos x := by
-        rw [←cos_neg, ←cos_add_two_pi]
+        rw [← cos_neg, ← cos_add_two_pi]
         apply cos_nonneg_of_neg_pi_div_two_le_of_le <;> linarith
       have cosx2_nonneg : 0 ≤ 2 * cos x := by linarith
-      rw [←abs_of_nonneg cosx2_nonneg, ←sq_le_sq, h0, abs_of_nonpos cos2x_nonpos, cos_two_mul]
+      rw [← abs_of_nonneg cosx2_nonneg, ← sq_le_sq, h0, abs_of_nonpos cos2x_nonpos, cos_two_mul]
       linarith
   rintro ⟨⟨h1, h2⟩, h3⟩
   by_contra h4
@@ -83,15 +83,15 @@ problem imo1965_p1 :
   have cos2x_nonneg : 0 ≤ cos (2*x) := by
     rcases h4 with h4 | h4
     · apply cos_nonneg_of_neg_pi_div_two_le_of_le <;> linarith
-    · rw [←cos_sub_two_pi, ←cos_sub_two_pi]
+    · rw [← cos_sub_two_pi, ← cos_sub_two_pi]
       apply cos_nonneg_of_neg_pi_div_two_le_of_le <;> linarith
   have cosx_nonneg : 0 ≤ cos x := by
     rcases h4 with h4 | h4
     · apply cos_nonneg_of_neg_pi_div_two_le_of_le <;> linarith
-    · rw [←cos_neg, ←cos_add_two_pi]
+    · rw [← cos_neg, ← cos_add_two_pi]
       apply cos_nonneg_of_neg_pi_div_two_le_of_le <;> linarith
   have cosx2_nonneg : 0 ≤ 2 * cos x := by linarith
-  rw [←abs_of_nonneg cosx2_nonneg, ←sq_le_sq, h0, abs_of_nonneg cos2x_nonneg, cos_two_mul] at h3
+  rw [← abs_of_nonneg cosx2_nonneg, ← sq_le_sq, h0, abs_of_nonneg cos2x_nonneg, cos_two_mul] at h3
   ring_nf at h3
   suffices (cos (π/4))^2 < (cos x)^2 by
     rw [cos_pi_div_four, div_pow] at this; norm_num at this
@@ -101,5 +101,5 @@ problem imo1965_p1 :
   · simp [cos_pi_div_four]; positivity
   rcases h4 with h5 | h5
   · apply cos_lt_cos_of_nonneg_of_le_pi_div_two h1 (by linarith) h5
-  rw [←cos_neg x, ←cos_add_two_pi (-x)]
+  rw [← cos_neg x, ← cos_add_two_pi (-x)]
   apply cos_lt_cos_of_nonneg_of_le_pi_div_two <;> linarith

--- a/Compfiles/Imo1965P2.lean
+++ b/Compfiles/Imo1965P2.lean
@@ -111,7 +111,7 @@ problem imo1965_p2 (x : Fin 3 → ℝ) (a : Fin 3 → Fin 3 → ℝ)
   have h3' : 0 < a 0 1 + a 0 2 + a 0 0 := by
     have h4 : ∑ j : Fin 3, a 0 j = a 0 1 + a 0 2 + a 0 0 := by
       rw [Fin.sum_univ_three, add_rotate]
-    rw [←h4]
+    rw [← h4]
     exact hc 0
   have h4 : - a 0 1 + - a 0 2 < a 0 0 := by linarith only [h3']
   have h5 : 0 < - a 0 1 := neg_pos.mpr (hab 0 1)

--- a/Compfiles/Imo1968P2.lean
+++ b/Compfiles/Imo1968P2.lean
@@ -35,17 +35,17 @@ lemma prod_digits_le {x b : ℕ} (hb : 2 ≤ b) (xpos : 0 < x) :
     List.prod (Nat.digits b x) ≤ x := by
   have h1 : Nat.digits b x ≠ [] :=
     Nat.digits_ne_nil_iff_ne_zero.mpr (Nat.pos_iff_ne_zero.mp xpos)
-  rw [←List.dropLast_append_getLast h1, List.prod_append, List.prod_singleton]
+  rw [← List.dropLast_append_getLast h1, List.prod_append, List.prod_singleton]
 
   have h3 := Nat.ofDigits_digits b x
   rw [Nat.ofDigits_eq_sum_mapIdx] at h3
   have h4 : List.mapIdx (fun i a => a * b ^ i) (Nat.digits b x) ≠ [] :=
     List.mapIdx_ne_nil_iff.mpr h1
 
-  rw [←List.dropLast_append_getLast (List.mapIdx_ne_nil_iff.mpr h1),
+  rw [← List.dropLast_append_getLast (List.mapIdx_ne_nil_iff.mpr h1),
       List.sum_append, List.sum_singleton] at h3
   have h6 : List.getLast (List.mapIdx (fun i a => a * b ^ i) (Nat.digits b x)) h4 ≤ x :=
-     by nth_rewrite 2 [←h3]; exact Nat.le_add_left _ _
+     by nth_rewrite 2 [← h3]; exact Nat.le_add_left _ _
   have h7 : List.getLast (List.mapIdx (fun i a => a * b ^ i) (Nat.digits b x)) h4 =
        b ^ (List.dropLast (Nat.digits b x)).length * List.getLast (Nat.digits b x) h1 := by
     rw [lemma0 _ h1, mul_comm]

--- a/Compfiles/Imo1968P5.lean
+++ b/Compfiles/Imo1968P5.lean
@@ -57,7 +57,7 @@ problem imo1968_p5a (f : ℝ → ℝ) (a : ℝ) (hf : P a f) :
   intro x
   obtain ⟨_, ha2⟩ := hf2 (x + a)
   have h4 : f (x + a) - f (x + a) ^ 2 = f (x + a) * (1 - f (x + a)) := by ring
-  rw [two_mul, ←add_assoc, ha2, h4]
+  rw [two_mul, ← add_assoc, ha2, h4]
   rw [h3]
   rw [Real.sqrt_sq_eq_abs]
   have h2' := abs_of_nonneg (h2 (x-a))
@@ -81,9 +81,9 @@ problem imo1968_p5b :
       · norm_num [solution_func, Int.even_add_one.mpr hodd, hodd]
   · rintro ⟨c, hc⟩
     have h1 : Function.const ℝ c 0 = c := rfl
-    rw [←hc] at h1
+    rw [← hc] at h1
     have h1' : Function.const ℝ c 1 = c := rfl
-    rw [←hc] at h1'
+    rw [← hc] at h1'
     have h2 : solution_func 0 = 1 := by simp
     have h3 : c = 1 := h1.symm.trans h2
     have h4 : solution_func 1 = 1/2 := by

--- a/Compfiles/Imo1970P3.lean
+++ b/Compfiles/Imo1970P3.lean
@@ -76,7 +76,7 @@ lemma term_bound (seq : IncreasingSequenceFromOne) (k : ℕ) :
       rw [isUnit_iff_ne_zero]
       let j := k - 1
       have hj : j = k-1 := rfl
-      rw [←hj]
+      rw [← hj]
       have := seq_pos seq j
       linarith
     ring_nf
@@ -104,7 +104,7 @@ lemma term_bound (seq : IncreasingSequenceFromOne) (k : ℕ) :
           exact (div_le_one (ck_pos k)).mpr hcseq
       _ = 2 := one_add_one_eq_two
 
-  rw [h1, h2, ←mul_assoc]
+  rw [h1, h2, ← mul_assoc]
   apply mul_le_mul_of_nonneg_right h3
   rw [sub_nonneg]
   exact one_div_le_one_div_of_le (ck_pos (k - 1)) hcseq
@@ -241,12 +241,12 @@ problem imo1970_p3 :
     calc
       c < d * (1 + d) * (1 - d ^ N) := by
         -- divide both sides by d * (1 + d)
-        rw [←inv_mul_lt_iff₀ daux]
+        rw [← inv_mul_lt_iff₀ daux]
         suffices d ^ N < 1 - (d * (1 + d))⁻¹ * c by linarith
-        rw [←Real.log_lt_log_iff]
+        rw [← Real.log_lt_log_iff]
         · rw [Real.log_pow d N]
           suffices Real.log (1 - (d * (1 + d))⁻¹ * c) / Real.log d < ↑N by
-            rwa [←div_lt_iff_of_neg (Real.log_neg dpos d_lt_one)]
+            rwa [← div_lt_iff_of_neg (Real.log_neg dpos d_lt_one)]
           calc
             _ < 1 + Real.log (1 - (d * (1 + d))⁻¹ * c) / Real.log d := lt_one_add _
             _ = 1 + Real.log (1 - c / (d * (1 + d))) / Real.log d := by field_simp
@@ -260,7 +260,7 @@ problem imo1970_p3 :
         apply tsub_le_tsub (le_refl 1)
         exact pow_le_pow_of_le_one d_nonneg d_leq_one hn
       _ = ∑ x ∈ Finset.range n, (1 - d^2) * d^(x + 1) := by
-        rw [←Finset.mul_sum]
+        rw [← Finset.mul_sum]
         have : ∑ i ∈ Finset.range n, d ^ (i + 1) = d * ∑ i ∈ Finset.range n, d ^ i := by
           rw [Finset.mul_sum]
           congr
@@ -271,13 +271,13 @@ problem imo1970_p3 :
           _ = (1 - d ^ 2) * (d * ((1 - d ^ n) * (1 - d)⁻¹)) := by
             field_simp
             ring_nf
-          _ = (1 - d ^ 2) * (d * (-(1 - d ^ n) / -(1 - d))) := by rw [←div_eq_mul_inv, neg_div_neg_eq]
+          _ = (1 - d ^ 2) * (d * (-(1 - d ^ n) / -(1 - d))) := by rw [← div_eq_mul_inv, neg_div_neg_eq]
           _ = _ := by ring_nf
       _ = _ := by
         congr
         ext x
         have : √(d ^ ((-1 + -(x:ℝ)) * 2)) = d ^ ((-1 + -(x:ℝ))) := by
-          rw [Real.sqrt_eq_rpow, ←Real.rpow_mul d_nonneg]
+          rw [Real.sqrt_eq_rpow, ← Real.rpow_mul d_nonneg]
           ring_nf
         rw [this]
         field_simp

--- a/Compfiles/Imo1971P3.lean
+++ b/Compfiles/Imo1971P3.lean
@@ -126,10 +126,10 @@ theorem a_pairwise_coprime : pairwise_coprime_f (Set.range a) := by
     and_intros
     · exact h1
     · apply dvd_trans h2
-      rw [<-hi1]
+      rw [←hi1]
       exact Nat.gcd_dvd_right _ _
     · apply dvd_trans h2
-      rw [<-hi2]
+      rw [←hi2]
       exact Nat.gcd_dvd_left _ _
   have pOdd : Odd p := by
     apply Odd.of_dvd_nat _ ph1
@@ -143,7 +143,7 @@ theorem a_pairwise_coprime : pairwise_coprime_f (Set.range a) := by
     rw [bh, pow_mul]
     apply Int.prime_dvd_pow_sub_one php
     refine IsCoprime.pow_left ?_
-    rw [<-Nat.cast_ofNat, Nat.isCoprime_iff_coprime]
+    rw [←Nat.cast_ofNat, Nat.isCoprime_iff_coprime]
     apply pOdd.coprime_two_left
   have : ↑p ∣ B - (2 ^ a i2 - 3) := by
     zify at ph2

--- a/Compfiles/Imo1971P3.lean
+++ b/Compfiles/Imo1971P3.lean
@@ -126,10 +126,10 @@ theorem a_pairwise_coprime : pairwise_coprime_f (Set.range a) := by
     and_intros
     · exact h1
     · apply dvd_trans h2
-      rw [←hi1]
+      rw [← hi1]
       exact Nat.gcd_dvd_right _ _
     · apply dvd_trans h2
-      rw [←hi2]
+      rw [← hi2]
       exact Nat.gcd_dvd_left _ _
   have pOdd : Odd p := by
     apply Odd.of_dvd_nat _ ph1
@@ -143,7 +143,7 @@ theorem a_pairwise_coprime : pairwise_coprime_f (Set.range a) := by
     rw [bh, pow_mul]
     apply Int.prime_dvd_pow_sub_one php
     refine IsCoprime.pow_left ?_
-    rw [←Nat.cast_ofNat, Nat.isCoprime_iff_coprime]
+    rw [← Nat.cast_ofNat, Nat.isCoprime_iff_coprime]
     apply pOdd.coprime_two_left
   have : ↑p ∣ B - (2 ^ a i2 - 3) := by
     zify at ph2

--- a/Compfiles/Imo1973P3.lean
+++ b/Compfiles/Imo1973P3.lean
@@ -151,7 +151,7 @@ problem imo1973_p3
   · refine mem_lowerBounds.mpr ?_
     simp only [Prod.exists, Set.mem_ofPred_eq, forall_exists_index, and_imp]
     intro x a b h₀ h₁
-    rw [←h₁]
+    rw [← h₁]
     refine aux_1 a b ?_
     simpa only [hS, Set.mem_ofPred_eq] using h₀
 

--- a/Compfiles/Imo1973P6.lean
+++ b/Compfiles/Imo1973P6.lean
@@ -61,9 +61,9 @@ theorem Q_row_neighbour_quot (k) (_ : k+1<n) (j) (hq : q ∈ Set.Ioo 0 1) : ∃ 
     Q n q ⟨k+1, by lia⟩ j = f * Q n q ⟨k, by lia⟩ j := by
   simp only [Finset.mem_insert, Finset.mem_singleton, exists_eq_or_imp, ↓existsAndEq, true_and]
   unfold Q
-  repeat rw [<-mul_inv_eq_iff_eq_mul₀ (by grind [pow_ne_zero])]
-  rw [<-zpow_natCast, <-zpow_natCast, <-div_eq_mul_inv]
-  rw [<-zpow_sub₀ (by grind only [= Set.mem_Ioo])]
+  repeat rw [←mul_inv_eq_iff_eq_mul₀ (by grind [pow_ne_zero])]
+  rw [←zpow_natCast, ←zpow_natCast, ←div_eq_mul_inv]
+  rw [←zpow_sub₀ (by grind only [= Set.mem_Ioo])]
   nth_rw 2 [show q = q^(1 : ℤ) by simp]
   rw [show q⁻¹ = q^(-1 : ℤ) by simp]
   repeat rw [zpow_right_inj₀ (by grind) (by grind)]
@@ -107,7 +107,7 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
   have nnz : NeZero n := NeZero.of_gt this
   rw [Set.mem_Ioo] at hq
   have q_lt_inv_q : q < 1 / q := by
-    rw [lt_div_iff₀, <-sq, sq_lt_one_iff₀] <;> linarith
+    rw [lt_div_iff₀, ←sq, sq_lt_one_iff₀] <;> linarith
   and_intros
   -- (a) --
   · intro k
@@ -188,13 +188,13 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
       unfold X Y
       rw [mulVec_apply_eq_sum]
       simp only [of_apply]
-      rw [<-Finset.sum_union XY_disj, <-XY_union]
+      rw [←Finset.sum_union XY_disj, ←XY_union]
     have hk1 (_t) : (Matrix.of (Q n q) *ᵥ a) ⟨k+1, _t⟩ = q*X + q⁻¹*Y := by
       unfold X Y
       rw [mulVec_apply_eq_sum]
       simp only [of_apply]
       rw [Finset.mul_sum, Finset.mul_sum]
-      rw [<-XY_union, Finset.sum_union XY_disj]
+      rw [←XY_union, Finset.sum_union XY_disj]
       congr 1 <;> { apply Finset.sum_bij (fun x _ => x) <;> [simp; simp; simp; grind] }
     constructor
     · rw [lt_div_iff₀ (by grind only)]
@@ -208,7 +208,7 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
       field_simp
       exact q_lt_inv_q
   -- (c) --
-  · simp_rw [mulVec, <-sum_dotProduct]
+  · simp_rw [mulVec, ←sum_dotProduct]
     rw [dotProduct, Finset.mul_sum]
     simp_rw [Finset.sum_apply]
     have h (i) : (∑ j, Q n q j i) * a i < (1 + q) / (1 - q) * a i := by
@@ -225,7 +225,7 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
             simp
           · simp
         _ = ∑ j ≤ i.val, q ^ (j - i.val : ℤ).natAbs + ∑ j ∈ Finset.Ioo i.val n, q ^ (j - i.val : ℤ).natAbs := by
-          rw [<-Finset.sum_union]
+          rw [←Finset.sum_union]
           · congr
             refine Finset.ext_iff.mpr ?_
             simp only [Finset.mem_range, Finset.mem_union, Finset.mem_Iic, Finset.mem_Ioo]
@@ -291,8 +291,8 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
         _ < _ := by
           rw [Nat.Iio_eq_range, geom_sum_eq (ne_of_lt hq.right)]
           apply lt_of_mul_lt_mul_of_nonneg_right (a:=1-q) ?_ (by linarith)
-          rw [IsUnit.div_mul_cancel, <-mul_assoc, mul_div_assoc', <-neg_div_neg_eq, neg_sub,
-            add_mul, <-neg_mul, IsUnit.div_mul_cancel, one_mul]
+          rw [IsUnit.div_mul_cancel, ←mul_assoc, mul_div_assoc', ←neg_div_neg_eq, neg_sub,
+            add_mul, ←neg_mul, IsUnit.div_mul_cancel, one_mul]
           · ring_nf
             simp only [sub_lt_self_iff, Nat.ofNat_pos, mul_pos_iff_of_pos_right]
             rw [mul_pow_sub_one nnz.out]

--- a/Compfiles/Imo1973P6.lean
+++ b/Compfiles/Imo1973P6.lean
@@ -61,9 +61,9 @@ theorem Q_row_neighbour_quot (k) (_ : k+1<n) (j) (hq : q ∈ Set.Ioo 0 1) : ∃ 
     Q n q ⟨k+1, by lia⟩ j = f * Q n q ⟨k, by lia⟩ j := by
   simp only [Finset.mem_insert, Finset.mem_singleton, exists_eq_or_imp, ↓existsAndEq, true_and]
   unfold Q
-  repeat rw [←mul_inv_eq_iff_eq_mul₀ (by grind [pow_ne_zero])]
-  rw [←zpow_natCast, ←zpow_natCast, ←div_eq_mul_inv]
-  rw [←zpow_sub₀ (by grind only [= Set.mem_Ioo])]
+  repeat rw [← mul_inv_eq_iff_eq_mul₀ (by grind [pow_ne_zero])]
+  rw [← zpow_natCast, ← zpow_natCast, ← div_eq_mul_inv]
+  rw [← zpow_sub₀ (by grind only [= Set.mem_Ioo])]
   nth_rw 2 [show q = q^(1 : ℤ) by simp]
   rw [show q⁻¹ = q^(-1 : ℤ) by simp]
   repeat rw [zpow_right_inj₀ (by grind) (by grind)]
@@ -107,7 +107,7 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
   have nnz : NeZero n := NeZero.of_gt this
   rw [Set.mem_Ioo] at hq
   have q_lt_inv_q : q < 1 / q := by
-    rw [lt_div_iff₀, ←sq, sq_lt_one_iff₀] <;> linarith
+    rw [lt_div_iff₀, ← sq, sq_lt_one_iff₀] <;> linarith
   and_intros
   -- (a) --
   · intro k
@@ -188,13 +188,13 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
       unfold X Y
       rw [mulVec_apply_eq_sum]
       simp only [of_apply]
-      rw [←Finset.sum_union XY_disj, ←XY_union]
+      rw [← Finset.sum_union XY_disj, ← XY_union]
     have hk1 (_t) : (Matrix.of (Q n q) *ᵥ a) ⟨k+1, _t⟩ = q*X + q⁻¹*Y := by
       unfold X Y
       rw [mulVec_apply_eq_sum]
       simp only [of_apply]
       rw [Finset.mul_sum, Finset.mul_sum]
-      rw [←XY_union, Finset.sum_union XY_disj]
+      rw [← XY_union, Finset.sum_union XY_disj]
       congr 1 <;> { apply Finset.sum_bij (fun x _ => x) <;> [simp; simp; simp; grind] }
     constructor
     · rw [lt_div_iff₀ (by grind only)]
@@ -208,7 +208,7 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
       field_simp
       exact q_lt_inv_q
   -- (c) --
-  · simp_rw [mulVec, ←sum_dotProduct]
+  · simp_rw [mulVec, ← sum_dotProduct]
     rw [dotProduct, Finset.mul_sum]
     simp_rw [Finset.sum_apply]
     have h (i) : (∑ j, Q n q j i) * a i < (1 + q) / (1 - q) * a i := by
@@ -225,7 +225,7 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
             simp
           · simp
         _ = ∑ j ≤ i.val, q ^ (j - i.val : ℤ).natAbs + ∑ j ∈ Finset.Ioo i.val n, q ^ (j - i.val : ℤ).natAbs := by
-          rw [←Finset.sum_union]
+          rw [← Finset.sum_union]
           · congr
             refine Finset.ext_iff.mpr ?_
             simp only [Finset.mem_range, Finset.mem_union, Finset.mem_Iic, Finset.mem_Ioo]
@@ -291,8 +291,8 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
         _ < _ := by
           rw [Nat.Iio_eq_range, geom_sum_eq (ne_of_lt hq.right)]
           apply lt_of_mul_lt_mul_of_nonneg_right (a:=1-q) ?_ (by linarith)
-          rw [IsUnit.div_mul_cancel, ←mul_assoc, mul_div_assoc', ←neg_div_neg_eq, neg_sub,
-            add_mul, ←neg_mul, IsUnit.div_mul_cancel, one_mul]
+          rw [IsUnit.div_mul_cancel, ← mul_assoc, mul_div_assoc', ← neg_div_neg_eq, neg_sub,
+            add_mul, ← neg_mul, IsUnit.div_mul_cancel, one_mul]
           · ring_nf
             simp only [sub_lt_self_iff, Nat.ofNat_pos, mul_pos_iff_of_pos_right]
             rw [mul_pow_sub_one nnz.out]

--- a/Compfiles/Imo1974P1.lean
+++ b/Compfiles/Imo1974P1.lean
@@ -83,15 +83,15 @@ problem imo1974_p1
 
   -- Each round, the players win p+q+r counters in total.
   have h_total i : C i 0 + C i 1 + C i 2 = p + q + r := by
-    rw [←Fin.sum_univ_three]
+    rw [← Fin.sum_univ_three]
     unfold C
-    rw [←Fintype.sum_equiv (game i)⁻¹ _ _ (fun _ ↦ rfl)]
+    rw [← Fintype.sum_equiv (game i)⁻¹ _ _ (fun _ ↦ rfl)]
     simp [Fin.sum_univ_three]
 
   -- The total score, 39, equals n(p+q+r).
   have h1 : n*(p+q+r) = 39 := calc
     _ = ∑ k ∈ Finset.range n, (p+q+r) := by simp
-    _ = ∑ k ∈ Finset.range n, (C k 0 + C k 1 + C k 2) := by congr; ext i; rw [←h_total]
+    _ = ∑ k ∈ Finset.range n, (C k 0 + C k 1 + C k 2) := by congr; ext i; rw [← h_total]
     _ = ∑ k ∈ Finset.range n, (C k 0)
       + ∑ k ∈ Finset.range n, (C k 1)
       + ∑ k ∈ Finset.range n, (C k 2) := by repeat rw [Finset.sum_add_distrib]
@@ -114,7 +114,7 @@ problem imo1974_p1
   simp only [Finset.range_val, Multiset.range_succ, Multiset.range_zero, Multiset.cons_zero,
     Fin.isValue, Multiset.map_cons, Multiset.map_singleton, Multiset.sum_cons,
     Multiset.sum_singleton] at hA hB hC
-  rw [←Nat.add_assoc] at hA hB hC
+  rw [← Nat.add_assoc] at hA hB hC
 
   -- Show 2+r ≤ 10, and thus r ≤ 8:
   have h5 : 2+r ≤ 10 := calc
@@ -161,7 +161,7 @@ problem imo1974_p1
 
   -- So (game 0) 2 ≠ 0 (bijective).
   have hg020 : game 0 2 ≠ 0 := by
-    intro h; rw [←h] at hg01
+    intro h; rw [← h] at hg01
     have := Equiv.injective (game 0) hg01
     simp only [Fin.isValue, Fin.reduceEq] at this
 

--- a/Compfiles/Imo1975P5.lean
+++ b/Compfiles/Imo1975P5.lean
@@ -84,12 +84,12 @@ theorem not_irrational_dist_P_P (i j : ℕ) : ¬ Irrational (dist (P i) (P j)) :
   rw [Complex.dist_mk, Real.cos_sub_cos, Real.sin_sub_sin, mul_right_comm]
   repeat rw [mul_pow]
   simp only [even_two, Even.neg_pow]
-  rw [←mul_add]
+  rw [← mul_add]
   simp only [Real.sin_sq_add_cos_sq, mul_one, Nat.ofNat_nonneg, pow_succ_nonneg, Real.sqrt_mul,
     Real.sqrt_sq]
   rw [Real.sqrt_sq_eq_abs]
   apply not_irrational_mul (not_irrational_ofNat _)
-  rw [irrational_abs_iff, mul_right_comm _ 2 _, mul_right_comm _ 2 _, ←sub_mul, mul_div_cancel_right₀ _ (by simp), Real.sin_sub]
+  rw [irrational_abs_iff, mul_right_comm _ 2 _, mul_right_comm _ 2 _, ← sub_mul, mul_div_cancel_right₀ _ (by simp), Real.sin_sub]
   apply not_irrational_sub <;> apply not_irrational_mul <;> simp [not_irrational_sin_θ_mul_and_not_irrational_cos_θ_mul]
 
 

--- a/Compfiles/Imo1975P5.lean
+++ b/Compfiles/Imo1975P5.lean
@@ -84,12 +84,12 @@ theorem not_irrational_dist_P_P (i j : ℕ) : ¬ Irrational (dist (P i) (P j)) :
   rw [Complex.dist_mk, Real.cos_sub_cos, Real.sin_sub_sin, mul_right_comm]
   repeat rw [mul_pow]
   simp only [even_two, Even.neg_pow]
-  rw [<-mul_add]
+  rw [←mul_add]
   simp only [Real.sin_sq_add_cos_sq, mul_one, Nat.ofNat_nonneg, pow_succ_nonneg, Real.sqrt_mul,
     Real.sqrt_sq]
   rw [Real.sqrt_sq_eq_abs]
   apply not_irrational_mul (not_irrational_ofNat _)
-  rw [irrational_abs_iff, mul_right_comm _ 2 _, mul_right_comm _ 2 _, <-sub_mul, mul_div_cancel_right₀ _ (by simp), Real.sin_sub]
+  rw [irrational_abs_iff, mul_right_comm _ 2 _, mul_right_comm _ 2 _, ←sub_mul, mul_div_cancel_right₀ _ (by simp), Real.sin_sub]
   apply not_irrational_sub <;> apply not_irrational_mul <;> simp [not_irrational_sin_θ_mul_and_not_irrational_cos_θ_mul]
 
 

--- a/Compfiles/Imo1975P6.lean
+++ b/Compfiles/Imo1975P6.lean
@@ -39,7 +39,7 @@ determine solution_set : Set (ℝ[X][Y]) := {P | ∃ n : ℕ, P = (C X - 2 * Y)*
 snip begin
 
 lemma mul_pow_eq_pow_succ {n : ℕ} (hn : 0 < n) (t : ℝ) : t * t^(n - 1) = t^n := by
-  rw [←(pow_mul_comm' t (n - 1)), ←pow_succ, Nat.sub_add_cancel hn]
+  rw [←(pow_mul_comm' t (n - 1)), ← pow_succ, Nat.sub_add_cancel hn]
 
 lemma eq_if_continuous_and_eq_almost_everywhere {f g : ℝ → ℝ} (hf : Continuous f) (hg : Continuous g)
     (h : ∀ x : ℚ, f x = g x) : ∀ x, f x = g x := by
@@ -97,7 +97,7 @@ lemma linear_rat {f : ℝ → ℝ} (h : ∀ (n : ℤ) {x : ℝ}, f (n * x) = n *
   have h1 := h x.num (x := 1 / x.den)
   have h2 : ((x.den : ℤ) : ℝ) = (x.den : ℝ) := AddCommGroupWithOne.intCast_ofNat x.den
   have h3 : (x.num : ℝ) * (1 / x.den) = x := by rw [Field.ratCast_def x] ; ring
-  rwa [h3, ←h2, linear_inv h x.den, ←mul_assoc, h2, h3, mul_comm] at h1
+  rwa [h3, ← h2, linear_inv h x.den, ← mul_assoc, h2, h3, mul_comm] at h1
 
 snip end
 

--- a/Compfiles/Imo1976P2.lean
+++ b/Compfiles/Imo1976P2.lean
@@ -50,7 +50,7 @@ theorem all_real_roots (P : ℝ[X]) (rs : Finset ℝ) (hrs : ∀ x ∈ rs, IsRoo
     simp only [Finset.image_val, Multiset.mem_dedup, Multiset.mem_map, Finset.mem_val] at hr
     let ⟨x, ⟨hx1, hx2⟩⟩ := hr
     refine mem_aroots.mpr ⟨nontrivial, ?_⟩
-    rw [←hx2, ←Complex.coe_algebraMap, aeval_algebraMap_apply_eq_algebraMap_eval, hrs _ hx1]
+    rw [← hx2, ← Complex.coe_algebraMap, aeval_algebraMap_apply_eq_algebraMap_eval, hrs _ hx1]
     simp
   · rw [IsAlgClosed.card_aroots_eq_natDegree]
     rw [Finset.image_val, Multiset.dedup_eq_self.mpr, Multiset.card_map, Finset.card_val]
@@ -72,7 +72,7 @@ theorem root_of_sign_flip {α : Type} [ConditionallyCompleteLinearOrder α] [Top
           positivity
         · simp at fann
           have := hs fann
-          rw [←neg_mul_neg]
+          rw [← neg_mul_neg]
           apply le_mul_of_le_mul_of_nonneg_right (b:=-f b)
           · exact mul_self_nonneg _
           · simp [le_of_lt fafb]
@@ -89,7 +89,7 @@ theorem root_of_sign_flip {α : Type} [ConditionallyCompleteLinearOrder α] [Top
           positivity
         · simp at fann
           have := hs fann
-          rw [←neg_mul_neg]
+          rw [← neg_mul_neg]
           apply le_mul_of_le_mul_of_nonneg_left (c:=-f a)
           · exact mul_self_nonneg _
           · simp [fafb]
@@ -100,7 +100,7 @@ theorem root_of_sign_flip {α : Type} [ConditionallyCompleteLinearOrder α] [Top
 theorem P_natDegree (n : ℕ) (npos : 0 < n) : (P n).natDegree = 2^n := by
   fun_induction P
   · simp at npos
-  · simp [←C_ofNat]
+  · simp [← C_ofNat]
   · expose_names
     rw [natDegree_comp]
     rw [ih1, ih2, pow_succ _ (j+1)]
@@ -142,7 +142,7 @@ theorem NicePlotOfP.findRoot.spec_gt {n} {npos} (pl : NicePlotOfP n npos) (i:ℕ
   let := Exists.choose_spec (NicePlotOfP.findRoot pl i hi)
   conv =>
     lhs
-    rw [show i' = ⟨i, by lia⟩ by simp_rw [←e]]
+    rw [show i' = ⟨i, by lia⟩ by simp_rw [← e]]
   exact (Set.mem_Ioo.mpr this.left).left
 
 theorem NicePlotOfP.findRoot.spec_lt {n} {npos} (pl : NicePlotOfP n npos) (i:ℕ) (hi : i+1 < pl.k) (i') (e : i'.val = i+1)  :
@@ -150,7 +150,7 @@ theorem NicePlotOfP.findRoot.spec_lt {n} {npos} (pl : NicePlotOfP n npos) (i:ℕ
   let := Exists.choose_spec (NicePlotOfP.findRoot pl i hi)
   conv =>
     rhs
-    rw [show i' = ⟨i+1, hi⟩ by simp_rw [←e]]
+    rw [show i' = ⟨i+1, hi⟩ by simp_rw [← e]]
   exact (Set.mem_Ioo.mpr this.left).right
 
 theorem NicePlotOfP.findRoot.spec_root {n} {npos} (pl : NicePlotOfP n npos) (i:ℕ) (hi : i+1 < pl.k) :
@@ -212,7 +212,7 @@ noncomputable def makePlot (n : ℕ) (npos : 0 < n) : NicePlotOfP n npos :=
         have pa' :Even (i.val+1) := by grind only [= Nat.even_iff]
         simp only [pa, ↓reduceDIte, pa']
         apply NicePlotOfP.findRoot.spec_lt
-        rw [←mul_left_inj' (c:=2) (by simp), add_mul]
+        rw [← mul_left_inj' (c:=2) (by simp), add_mul]
         rw [Nat.div_two_mul_two_of_even, Nat.div_two_mul_two_of_even] <;> grind only [= Nat.even_iff]
     y_eq := by
       intro i
@@ -228,7 +228,7 @@ noncomputable def makePlot (n : ℕ) (npos : 0 < n) : NicePlotOfP n npos :=
         rw [@NicePlotOfP.y_eq (n+1)]
         simp only [eval_sub, eval_pow, eval_X, eval_ofNat]
         rw [(neg_one_pow_eq_one_iff_even (by norm_num)).mpr pa]
-        rw [mul_pow, ←pow_mul]
+        rw [mul_pow, ← pow_mul]
         rw [(neg_one_pow_eq_one_iff_even (by linarith)).mpr _]
         · norm_num
         · simp
@@ -241,7 +241,7 @@ noncomputable def makePlot (n : ℕ) (npos : 0 < n) : NicePlotOfP n npos :=
         rw [eval_comp]
         simp only [eval_sub, eval_pow, eval_X, eval_ofNat]
         rw [show eval _ (P (n + 1)) = 0 by {
-          rw [←IsRoot]
+          rw [← IsRoot]
           apply NicePlotOfP.findRoot.spec_root
         }]
         rw [(neg_one_pow_eq_neg_one_iff_odd (by norm_num)).mpr (Nat.not_even_iff_odd.mp pa)]
@@ -282,7 +282,7 @@ theorem P_intersect_X {n : ℕ} {npos : 0 < n} (pl : NicePlotOfP n npos) (i : �
     · rw [(neg_one_pow_eq_one_iff_even _).mpr _, (neg_one_pow_eq_neg_one_iff_odd _).mpr _] <;> grind
     · rw [(neg_one_pow_eq_neg_one_iff_odd _).mpr _, (neg_one_pow_eq_one_iff_even _).mpr _] <;> grind
   have : -2 ≤ a ∧ a < 2 := by
-    rw [←pl.x_first, ←pl.x_last]
+    rw [← pl.x_first, ← pl.x_last]
     and_intros
     · apply pl.strictMono.monotone
       simp
@@ -290,11 +290,11 @@ theorem P_intersect_X {n : ℕ} {npos : 0 < n} (pl : NicePlotOfP n npos) (i : �
       grind only [= Finset.mem_range, = Lean.Grind.toInt_fin]
   have : 0 < i → -2 < a  := by
     intro ih'
-    rw [←pl.x_first]
+    rw [← pl.x_first]
     apply pl.strictMono
     grind only [= Finset.mem_range, = Lean.Grind.toInt_fin]
   have : -2 < b ∧ b < 2 := by
-    rw [←pl.x_first, ←pl.x_last]
+    rw [← pl.x_first, ← pl.x_last]
     and_intros <;> {
       apply pl.strictMono
       grind only [= Finset.mem_range, = Lean.Grind.toInt_fin, pl.len]
@@ -386,13 +386,13 @@ problem imo1976_p2 (n : ℕ) (npos : 0 < n) :
           apply pl.strictMono.monotone
           grind [NicePlotOfP.len]
         _ = _ := by
-          rw [←pl.x_last]
+          rw [← pl.x_last]
   · simp only [Set.mem_Ioo, Finset.singleton_union,
       Finset.mem_insert, Finset.mem_image, Finset.mem_attach, true_and, Subtype.exists,
       IsRoot.def, forall_eq_or_imp, forall_exists_index]
     and_intros
     · rw [eval_sub, eval_X]
-      nth_rw 1 [←pl.x_last, pl.y_eq]
+      nth_rw 1 [← pl.x_last, pl.y_eq]
       simp [pl.len, P_natDegree _ npos]
       rw [(neg_one_pow_eq_one_iff_even _).mpr (Nat.even_pow.mpr ⟨even_two, by omega⟩)] <;> norm_num
     · intro r i hi er

--- a/Compfiles/Imo1976P2.lean
+++ b/Compfiles/Imo1976P2.lean
@@ -50,7 +50,7 @@ theorem all_real_roots (P : ℝ[X]) (rs : Finset ℝ) (hrs : ∀ x ∈ rs, IsRoo
     simp only [Finset.image_val, Multiset.mem_dedup, Multiset.mem_map, Finset.mem_val] at hr
     let ⟨x, ⟨hx1, hx2⟩⟩ := hr
     refine mem_aroots.mpr ⟨nontrivial, ?_⟩
-    rw [<-hx2, <-Complex.coe_algebraMap, aeval_algebraMap_apply_eq_algebraMap_eval, hrs _ hx1]
+    rw [←hx2, ←Complex.coe_algebraMap, aeval_algebraMap_apply_eq_algebraMap_eval, hrs _ hx1]
     simp
   · rw [IsAlgClosed.card_aroots_eq_natDegree]
     rw [Finset.image_val, Multiset.dedup_eq_self.mpr, Multiset.card_map, Finset.card_val]
@@ -72,7 +72,7 @@ theorem root_of_sign_flip {α : Type} [ConditionallyCompleteLinearOrder α] [Top
           positivity
         · simp at fann
           have := hs fann
-          rw [<-neg_mul_neg]
+          rw [←neg_mul_neg]
           apply le_mul_of_le_mul_of_nonneg_right (b:=-f b)
           · exact mul_self_nonneg _
           · simp [le_of_lt fafb]
@@ -89,7 +89,7 @@ theorem root_of_sign_flip {α : Type} [ConditionallyCompleteLinearOrder α] [Top
           positivity
         · simp at fann
           have := hs fann
-          rw [<-neg_mul_neg]
+          rw [←neg_mul_neg]
           apply le_mul_of_le_mul_of_nonneg_left (c:=-f a)
           · exact mul_self_nonneg _
           · simp [fafb]
@@ -100,7 +100,7 @@ theorem root_of_sign_flip {α : Type} [ConditionallyCompleteLinearOrder α] [Top
 theorem P_natDegree (n : ℕ) (npos : 0 < n) : (P n).natDegree = 2^n := by
   fun_induction P
   · simp at npos
-  · simp [<-C_ofNat]
+  · simp [←C_ofNat]
   · expose_names
     rw [natDegree_comp]
     rw [ih1, ih2, pow_succ _ (j+1)]
@@ -142,7 +142,7 @@ theorem NicePlotOfP.findRoot.spec_gt {n} {npos} (pl : NicePlotOfP n npos) (i:ℕ
   let := Exists.choose_spec (NicePlotOfP.findRoot pl i hi)
   conv =>
     lhs
-    rw [show i' = ⟨i, by lia⟩ by simp_rw [<-e]]
+    rw [show i' = ⟨i, by lia⟩ by simp_rw [←e]]
   exact (Set.mem_Ioo.mpr this.left).left
 
 theorem NicePlotOfP.findRoot.spec_lt {n} {npos} (pl : NicePlotOfP n npos) (i:ℕ) (hi : i+1 < pl.k) (i') (e : i'.val = i+1)  :
@@ -150,7 +150,7 @@ theorem NicePlotOfP.findRoot.spec_lt {n} {npos} (pl : NicePlotOfP n npos) (i:ℕ
   let := Exists.choose_spec (NicePlotOfP.findRoot pl i hi)
   conv =>
     rhs
-    rw [show i' = ⟨i+1, hi⟩ by simp_rw [<-e]]
+    rw [show i' = ⟨i+1, hi⟩ by simp_rw [←e]]
   exact (Set.mem_Ioo.mpr this.left).right
 
 theorem NicePlotOfP.findRoot.spec_root {n} {npos} (pl : NicePlotOfP n npos) (i:ℕ) (hi : i+1 < pl.k) :
@@ -212,7 +212,7 @@ noncomputable def makePlot (n : ℕ) (npos : 0 < n) : NicePlotOfP n npos :=
         have pa' :Even (i.val+1) := by grind only [= Nat.even_iff]
         simp only [pa, ↓reduceDIte, pa']
         apply NicePlotOfP.findRoot.spec_lt
-        rw [<-mul_left_inj' (c:=2) (by simp), add_mul]
+        rw [←mul_left_inj' (c:=2) (by simp), add_mul]
         rw [Nat.div_two_mul_two_of_even, Nat.div_two_mul_two_of_even] <;> grind only [= Nat.even_iff]
     y_eq := by
       intro i
@@ -228,7 +228,7 @@ noncomputable def makePlot (n : ℕ) (npos : 0 < n) : NicePlotOfP n npos :=
         rw [@NicePlotOfP.y_eq (n+1)]
         simp only [eval_sub, eval_pow, eval_X, eval_ofNat]
         rw [(neg_one_pow_eq_one_iff_even (by norm_num)).mpr pa]
-        rw [mul_pow, <-pow_mul]
+        rw [mul_pow, ←pow_mul]
         rw [(neg_one_pow_eq_one_iff_even (by linarith)).mpr _]
         · norm_num
         · simp
@@ -241,7 +241,7 @@ noncomputable def makePlot (n : ℕ) (npos : 0 < n) : NicePlotOfP n npos :=
         rw [eval_comp]
         simp only [eval_sub, eval_pow, eval_X, eval_ofNat]
         rw [show eval _ (P (n + 1)) = 0 by {
-          rw [<-IsRoot]
+          rw [←IsRoot]
           apply NicePlotOfP.findRoot.spec_root
         }]
         rw [(neg_one_pow_eq_neg_one_iff_odd (by norm_num)).mpr (Nat.not_even_iff_odd.mp pa)]
@@ -251,7 +251,7 @@ noncomputable def makePlot (n : ℕ) (npos : 0 < n) : NicePlotOfP n npos :=
     x_last := by
       simp only
       rw [dite_eq_left_iff.mpr]
-      · rw [<-@NicePlotOfP.x_last (n+1) (Nat.zero_lt_succ n) ?_]
+      · rw [←@NicePlotOfP.x_last (n+1) (Nat.zero_lt_succ n) ?_]
         · congr 2
           · rfl
           · rfl
@@ -282,7 +282,7 @@ theorem P_intersect_X {n : ℕ} {npos : 0 < n} (pl : NicePlotOfP n npos) (i : �
     · rw [(neg_one_pow_eq_one_iff_even _).mpr _, (neg_one_pow_eq_neg_one_iff_odd _).mpr _] <;> grind
     · rw [(neg_one_pow_eq_neg_one_iff_odd _).mpr _, (neg_one_pow_eq_one_iff_even _).mpr _] <;> grind
   have : -2 ≤ a ∧ a < 2 := by
-    rw [<-pl.x_first, <-pl.x_last]
+    rw [←pl.x_first, ←pl.x_last]
     and_intros
     · apply pl.strictMono.monotone
       simp
@@ -290,11 +290,11 @@ theorem P_intersect_X {n : ℕ} {npos : 0 < n} (pl : NicePlotOfP n npos) (i : �
       grind only [= Finset.mem_range, = Lean.Grind.toInt_fin]
   have : 0 < i → -2 < a  := by
     intro ih'
-    rw [<-pl.x_first]
+    rw [←pl.x_first]
     apply pl.strictMono
     grind only [= Finset.mem_range, = Lean.Grind.toInt_fin]
   have : -2 < b ∧ b < 2 := by
-    rw [<-pl.x_first, <-pl.x_last]
+    rw [←pl.x_first, ←pl.x_last]
     and_intros <;> {
       apply pl.strictMono
       grind only [= Finset.mem_range, = Lean.Grind.toInt_fin, pl.len]
@@ -386,13 +386,13 @@ problem imo1976_p2 (n : ℕ) (npos : 0 < n) :
           apply pl.strictMono.monotone
           grind [NicePlotOfP.len]
         _ = _ := by
-          rw [<-pl.x_last]
+          rw [←pl.x_last]
   · simp only [Set.mem_Ioo, Finset.singleton_union,
       Finset.mem_insert, Finset.mem_image, Finset.mem_attach, true_and, Subtype.exists,
       IsRoot.def, forall_eq_or_imp, forall_exists_index]
     and_intros
     · rw [eval_sub, eval_X]
-      nth_rw 1 [<-pl.x_last, pl.y_eq]
+      nth_rw 1 [←pl.x_last, pl.y_eq]
       simp [pl.len, P_natDegree _ npos]
       rw [(neg_one_pow_eq_one_iff_even _).mpr (Nat.even_pow.mpr ⟨even_two, by omega⟩)] <;> norm_num
     · intro r i hi er

--- a/Compfiles/Imo1977P2.lean
+++ b/Compfiles/Imo1977P2.lean
@@ -64,7 +64,7 @@ problem imo1977_p2 :
     and_intros <;> {
       intro _
       unfold example_16
-      rw [←sum_successive_terms_intCast]
+      rw [← sum_successive_terms_intCast]
       simp only [gt_iff_lt, Int.cast_pos, Int.cast_lt_zero]
       decide +revert
     }
@@ -107,7 +107,7 @@ problem imo1977_p2 :
       apply Fintype.sum_neg
       exact lt_of_strongLT rneg
     have : 0 < (1 ᵥ* A) ⬝ᵥ 1 := by
-      rw [←Matrix.dotProduct_mulVec, one_dotProduct]
+      rw [← Matrix.dotProduct_mulVec, one_dotProduct]
       apply Fintype.sum_pos
       exact lt_of_strongLT cpos
     linarith

--- a/Compfiles/Imo1977P2.lean
+++ b/Compfiles/Imo1977P2.lean
@@ -64,7 +64,7 @@ problem imo1977_p2 :
     and_intros <;> {
       intro _
       unfold example_16
-      rw [<-sum_successive_terms_intCast]
+      rw [←sum_successive_terms_intCast]
       simp only [gt_iff_lt, Int.cast_pos, Int.cast_lt_zero]
       decide +revert
     }
@@ -107,7 +107,7 @@ problem imo1977_p2 :
       apply Fintype.sum_neg
       exact lt_of_strongLT rneg
     have : 0 < (1 ᵥ* A) ⬝ᵥ 1 := by
-      rw [<-Matrix.dotProduct_mulVec, one_dotProduct]
+      rw [←Matrix.dotProduct_mulVec, one_dotProduct]
       apply Fintype.sum_pos
       exact lt_of_strongLT cpos
     linarith

--- a/Compfiles/Imo1977P4.lean
+++ b/Compfiles/Imo1977P4.lean
@@ -85,13 +85,13 @@ problem imo1977_p4 (f : ℝ → ℝ) (a b A B : ℝ)
         _ = R * (p * p + q * q) := by
           rw [hθ_cos, hθ_sin]
         _ = R * 1 := by
-          have h₁₂ : p * p + q * q = 1 := by simp only [←sq, hpq_sq]
+          have h₁₂ : p * p + q * q = 1 := by simp only [← sq, hpq_sq]
           rw [h₁₂]
         _ = R := by ring
 
     have h₁₁ : A * Real.cos θ + B * Real.sin θ > 1 := by
       have h₁₂ : R > 1 := by
-        rw [hR_def, gt_iff_lt, ←one_lt_sq_iff₀ (a := √(A^2 + B^2)) (by positivity)]
+        rw [hR_def, gt_iff_lt, ← one_lt_sq_iff₀ (a := √(A^2 + B^2)) (by positivity)]
         rw [Real.sq_sqrt (by positivity)]
         exact h
       linarith only [h₁₀, h₁₂]
@@ -193,14 +193,14 @@ problem imo1977_p4 (f : ℝ → ℝ) (a b A B : ℝ)
           ring_nf
         _ = R * 1 := by
           have h₆ : p ^ 2 + q ^ 2 = 1 := hpq_sq
-          have h₇ : p * p + q * q = 1 := by simp only [←sq, h₆]
+          have h₇ : p * p + q * q = 1 := by simp only [← sq, h₆]
           rw [h₇]
         _ = R := by ring
 
     have h₆ : C * Real.cos θ - D * Real.sin θ > 2 := by
       have h₇ : R > 2 := by
         have h₉ : C ^ 2 + D ^ 2 > 4 := hC_sq_add_D_sq_gt_4
-        rw [←hR_sq, show 4 = (2:ℝ)^2 by norm_num] at h₉
+        rw [← hR_sq, show 4 = (2:ℝ)^2 by norm_num] at h₉
         exact (sq_lt_sq₀ (by positivity) (by positivity)).mp h₉
       lia
 

--- a/Compfiles/Imo1978P1.lean
+++ b/Compfiles/Imo1978P1.lean
@@ -76,7 +76,7 @@ problem imo1978_p1 (m n : ℕ)
     have h6 : IsCoprime ((2:ℤ)^3) (989 ^ m') := by
       refine IsCoprime.pow_left ?_
       rw [Prime.coprime_iff_not_dvd Int.prime_two, Int.two_dvd_ne_zero]
-      rw [←Int.odd_iff, Int.odd_pow]
+      rw [← Int.odd_iff, Int.odd_pow]
       exact Or.inl ⟨494, rfl⟩
     replace h4 := IsCoprime.dvd_of_dvd_mul_right h6 h4
     rw [pow_dvd_pow_iff (by norm_num) Int.prime_two.2.1] at h4
@@ -85,8 +85,8 @@ problem imo1978_p1 (m n : ℕ)
   -- and 125 divides 1978^(n'-m') - 1.
   have h6 : (125 : ℤ) ∣ 1978^(n'-m') - 1 := by
     obtain ⟨k, hk⟩ : ∃ k, k + 3 = m' := ⟨m' - 3, by lia⟩
-    rw [←hk] at h4
-    nth_rw 1 [←hk] at h3
+    rw [← hk] at h4
+    nth_rw 1 [← hk] at h3
     have h7 : (1978:ℤ) ^ (k + 3) * (1978 ^ (n' - m') - 1) =
         8 * (1978 ^ k * 989 ^ 3 * (1978 ^ (n' - m') - 1)) := by ring
     rw [h7] at h3

--- a/Compfiles/Imo1978P6.lean
+++ b/Compfiles/Imo1978P6.lean
@@ -84,7 +84,7 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
       · rw [Finset.disjoint_iff_inter_eq_empty] at ih2
         contrapose! ih2
         use y.val
-        rw [Finset.mem_inter, ←SetLike.mem_coe]
+        rw [Finset.mem_inter, ← SetLike.mem_coe]
         simp only [Finset.coe_image, Subtype.coe_prop, ih2, and_self]
       · calc
           _ ≤ Δ'.card ⌈/⌉ (N - Cdone.card) := by
@@ -97,7 +97,7 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
             apply Finset.card_le_card_of_injOn (f:=Subtype.val)
             · unfold C' at *
               intro x hx
-              simp [←Subtype.val_inj] at hx ⊢
+              simp [← Subtype.val_inj] at hx ⊢
               exact hx
             · exact Set.injOn_subtype_val
     · apply lt_of_le_of_lt (b:=(N - Cdone.card) * (Δ'.card ⌈/⌉ (N - Cdone.card) - 1))
@@ -117,10 +117,10 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
         apply Nat.lt_of_add_one_le
         rw [Nat.ceilDiv_eq_add_pred_div, Nat.mul_sub, mul_one]
         have := Nat.mul_div_le (Δ'.card + (N - Cdone.card) - 1) (N - Cdone.card)
-        rw [Nat.le_sub_iff_add_le, ←Nat.sub_le_iff_le_add, Nat.sub_add_comm] at this
+        rw [Nat.le_sub_iff_add_le, ← Nat.sub_le_iff_le_add, Nat.sub_add_comm] at this
         · exact this
         · suffices 1 ≤ (Δ'.card + (N - Cdone.card) - 1) / (N - Cdone.card) by exact Nat.le_mul_of_pos_right _ this
-          rw [←Nat.div_self NsCdpos]
+          rw [← Nat.div_self NsCdpos]
           apply Nat.div_le_div_right
           rw [Nat.div_self NsCdpos]
           lia
@@ -129,7 +129,7 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
     rw [Finset.union_singleton, Finset.card_insert_of_notMem hy1, cc]
   use Cdone ∪ {y}, cc'
   have Cyne : (Δ' ∩ members_of C y).Nonempty := by
-    rw [←Finset.card_pos, Nat.lt_iff_add_one_le]
+    rw [← Finset.card_pos, Nat.lt_iff_add_one_le]
     trans k ⌈/⌉ (N - Cdone.card)
     · by_contra!
       rw [add_comm, Nat.lt_one_add_iff] at this
@@ -192,12 +192,12 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
             grind
           use ?_
           · have := (h2 ⟨x.val+xmin.val, xsx⟩ ?_).snd
-            · simp_rw [←add_assoc, add_comm, add_assoc]
+            · simp_rw [← add_assoc, add_comm, add_assoc]
               simp_rw [add_comm] at this
               apply this
             · apply hs1
           · have := (h2 ⟨x.val+xmin.val, xsx⟩ ?_).snd
-            · simp_rw [←add_assoc, add_comm, add_assoc]
+            · simp_rw [← add_assoc, add_comm, add_assoc]
               simp_rw [add_comm] at this
               grind only
             · apply hs1
@@ -216,13 +216,13 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
     by_cases! xvx'v : ¬ x'.val ≤ x.val
     · grind only
     have hb0 : b0.val + 1 < M := by grind only [= Finset.mem_Icc, = Finset.mem_filter]
-    rw [Ne, Subtype.ext_iff, eq_comm, ←add_left_inj b0.val]
+    rw [Ne, Subtype.ext_iff, eq_comm, ← add_left_inj b0.val]
     rw [show x.val + b0.val = (⟨x.val+b0.val, h2⟩ : Name).val by simp]
     apply h <;> grind only [= Finset.mem_filter]
   · unfold Δ
     rw [Finset.card_map, Finset.card_attach, Finset.card_erase_of_mem (by apply Finset.min'_mem)]
     apply Nat.sub_le_sub_right
-    rw [←cc]
+    rw [← cc]
     apply le_trans hy2
     apply Finset.card_le_card
     simp

--- a/Compfiles/Imo1978P6.lean
+++ b/Compfiles/Imo1978P6.lean
@@ -84,7 +84,7 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
       · rw [Finset.disjoint_iff_inter_eq_empty] at ih2
         contrapose! ih2
         use y.val
-        rw [Finset.mem_inter, <-SetLike.mem_coe]
+        rw [Finset.mem_inter, ←SetLike.mem_coe]
         simp only [Finset.coe_image, Subtype.coe_prop, ih2, and_self]
       · calc
           _ ≤ Δ'.card ⌈/⌉ (N - Cdone.card) := by
@@ -97,7 +97,7 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
             apply Finset.card_le_card_of_injOn (f:=Subtype.val)
             · unfold C' at *
               intro x hx
-              simp [<-Subtype.val_inj] at hx ⊢
+              simp [←Subtype.val_inj] at hx ⊢
               exact hx
             · exact Set.injOn_subtype_val
     · apply lt_of_le_of_lt (b:=(N - Cdone.card) * (Δ'.card ⌈/⌉ (N - Cdone.card) - 1))
@@ -117,10 +117,10 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
         apply Nat.lt_of_add_one_le
         rw [Nat.ceilDiv_eq_add_pred_div, Nat.mul_sub, mul_one]
         have := Nat.mul_div_le (Δ'.card + (N - Cdone.card) - 1) (N - Cdone.card)
-        rw [Nat.le_sub_iff_add_le, <-Nat.sub_le_iff_le_add, Nat.sub_add_comm] at this
+        rw [Nat.le_sub_iff_add_le, ←Nat.sub_le_iff_le_add, Nat.sub_add_comm] at this
         · exact this
         · suffices 1 ≤ (Δ'.card + (N - Cdone.card) - 1) / (N - Cdone.card) by exact Nat.le_mul_of_pos_right _ this
-          rw [<-Nat.div_self NsCdpos]
+          rw [←Nat.div_self NsCdpos]
           apply Nat.div_le_div_right
           rw [Nat.div_self NsCdpos]
           lia
@@ -129,7 +129,7 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
     rw [Finset.union_singleton, Finset.card_insert_of_notMem hy1, cc]
   use Cdone ∪ {y}, cc'
   have Cyne : (Δ' ∩ members_of C y).Nonempty := by
-    rw [<-Finset.card_pos, Nat.lt_iff_add_one_le]
+    rw [←Finset.card_pos, Nat.lt_iff_add_one_le]
     trans k ⌈/⌉ (N - Cdone.card)
     · by_contra!
       rw [add_comm, Nat.lt_one_add_iff] at this
@@ -192,12 +192,12 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
             grind
           use ?_
           · have := (h2 ⟨x.val+xmin.val, xsx⟩ ?_).snd
-            · simp_rw [<-add_assoc, add_comm, add_assoc]
+            · simp_rw [←add_assoc, add_comm, add_assoc]
               simp_rw [add_comm] at this
               apply this
             · apply hs1
           · have := (h2 ⟨x.val+xmin.val, xsx⟩ ?_).snd
-            · simp_rw [<-add_assoc, add_comm, add_assoc]
+            · simp_rw [←add_assoc, add_comm, add_assoc]
               simp_rw [add_comm] at this
               grind only
             · apply hs1
@@ -216,13 +216,13 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
     by_cases! xvx'v : ¬ x'.val ≤ x.val
     · grind only
     have hb0 : b0.val + 1 < M := by grind only [= Finset.mem_Icc, = Finset.mem_filter]
-    rw [Ne, Subtype.ext_iff, eq_comm, <-add_left_inj b0.val]
+    rw [Ne, Subtype.ext_iff, eq_comm, ←add_left_inj b0.val]
     rw [show x.val + b0.val = (⟨x.val+b0.val, h2⟩ : Name).val by simp]
     apply h <;> grind only [= Finset.mem_filter]
   · unfold Δ
     rw [Finset.card_map, Finset.card_attach, Finset.card_erase_of_mem (by apply Finset.min'_mem)]
     apply Nat.sub_le_sub_right
-    rw [<-cc]
+    rw [←cc]
     apply le_trans hy2
     apply Finset.card_le_card
     simp

--- a/Compfiles/Imo1979P1.lean
+++ b/Compfiles/Imo1979P1.lean
@@ -33,7 +33,7 @@ lemma lemma3 : ∑ i ∈ Finset.range 1319, (-(1:ℚ))^i / (i + 1) =
          2 * ∑ i ∈ Finset.range 659, (1:ℚ) / (2 * (i + 1)) := by
   have h2 := Finset.sum_filter_add_sum_filter_not
            (Finset.range 1319) (Even ·) (λ i ↦ (1:ℚ) / (i + 1))
-  rw [←h2]
+  rw [← h2]
   let g : ℕ ↪ ℕ :=
     ⟨fun x ↦ 2 * x + 1, by intro a b hab; lia⟩
 
@@ -46,7 +46,7 @@ lemma lemma3 : ∑ i ∈ Finset.range 1319, (-(1:ℚ))^i / (i + 1) =
       obtain ⟨b, hb1, hb2⟩ := ha
       rw [Finset.mem_range] at hb1
       replace hb2 : 2 * b + 1 = a := hb2
-      rw [←hb2]
+      rw [← hb2]
       constructor
       · lia
       · exact Nat.not_even_iff_odd.mpr ⟨b, rfl⟩
@@ -71,9 +71,9 @@ lemma lemma3 : ∑ i ∈ Finset.range 1319, (-(1:ℚ))^i / (i + 1) =
      1 / ((x:ℚ) + 1) =
       ∑ i ∈ Finset.range 659, 1 / (2 * ((i:ℚ) + 1)) := by
     rw [h5]
-    rw [←h6, h4]
+    rw [← h6, h4]
   rw [h3, two_mul, add_sub_add_right_eq_sub]
-  rw [←h3, ←h4, h6, ←h5, ←h3]
+  rw [← h3, ← h4, h6, ← h5, ← h3]
   have h7 :
    ∑ i ∈ Finset.filter (fun x ↦ Even x) (Finset.range 1319), 1 / ((i:ℚ) + 1) =
     ∑ i ∈ Finset.filter (fun x ↦ Even x) (Finset.range 1319),
@@ -84,7 +84,7 @@ lemma lemma3 : ∑ i ∈ Finset.range 1319, (-(1:ℚ))^i / (i + 1) =
     have h9: (-1 : ℚ)^x = 1 := Even.neg_one_pow hx.2
     rw [h9]
   rw [h7]; clear h7
-  rw [Rat.sub_eq_add_neg, ←Finset.sum_neg_distrib]
+  rw [Rat.sub_eq_add_neg, ← Finset.sum_neg_distrib]
   have h10 : ∑ x ∈ Finset.filter (fun x ↦ ¬Even x) (Finset.range 1319),
                -(1 / ((x:ℚ) + 1)) =
               ∑ x ∈ Finset.filter (fun x ↦ ¬Even x) (Finset.range 1319),
@@ -103,7 +103,7 @@ lemma lemma4 (n m : ℕ) (f : ℕ → ℚ) :
   rw [Finset.sum_Ico_eq_sum_range, add_tsub_cancel_left]
   rw [two_mul, Finset.sum_range_add, Finset.sum_add_distrib]
   congr 1
-  rw [←Finset.sum_range_reflect (fun x ↦ f (n + (m + x)))]
+  rw [← Finset.sum_range_reflect (fun x ↦ f (n + (m + x)))]
   refine Finset.sum_congr rfl fun x hx => ?_
   rw [Finset.mem_range] at hx
   congr 1; lia
@@ -112,7 +112,7 @@ lemma lemma9' (i : ℕ) (hi : i ∈ Finset.range 330) :
      (((∏ j ∈ Finset.range 330,
          (660 + j) * (1319 - j)):ℕ):ℚ) / ((660 + (i:ℚ)) * (1319 - (i:ℚ)))
        = ∏ j ∈ (Finset.range 330).erase i, (660 + j) * (1319 - j) := by
-  rw [←Finset.prod_erase_mul _ _ hi]
+  rw [← Finset.prod_erase_mul _ _ hi]
   rw [Finset.mem_range] at hi
   push_cast
   have h1 : (((1319 - i):ℕ):ℚ) = 1319 - (i:ℚ) := by
@@ -194,7 +194,7 @@ problem imo1979_p1 (p q : ℤ) (hp : 0 < p) (hq : 0 < q)
   rw [Finset.sum_congr rfl h4] at h; clear h4
   rw [show (1979 : ℚ) = 1979 * 1 by simp +arith] at h
   simp_rw [mul_div_assoc] at h
-  rw [←Finset.mul_sum] at h
+  rw [← Finset.mul_sum] at h
   let s : ℕ := ∏ i ∈ Finset.range 330, (660 + i) * (1319 - i)
   let sq := (s : ℚ)
   have hpp : Nat.Prime 1979 := by norm_num1

--- a/Compfiles/Imo1979P6.lean
+++ b/Compfiles/Imo1979P6.lean
@@ -83,7 +83,7 @@ theorem Walk.drop_append_of_length_eq {V : Type} {G : SimpleGraph V} {u v w : V}
 theorem isTerminalWalk_copy {V : Type} {G : SimpleGraph V} {u v u' v' : V} (h1 : u = u') (h2 : v = v') (w : G.Walk u v) : isTerminalWalk w → isTerminalWalk (w.copy h1 h2) := by
   unfold isTerminalWalk
   intro h
-  simp [←h2, h]
+  simp [← h2, h]
 
 theorem isTerminalWalk_map {V V' : Type} {G : SimpleGraph V} {G' : SimpleGraph V'} (f : G ↪g G') {u v : V} (w : G.Walk u v) :
     isTerminalWalk w → isTerminalWalk (w.map f.toHom) := by
@@ -101,7 +101,7 @@ theorem isTerminalWalk_of_isSubwalk {V : Type} {G : SimpleGraph V} {u u' t : V} 
   unfold isTerminalWalk at htw ⊢
   rw [Walk.isSubwalk_iff_support_isInfix, List.IsInfix] at hsub
   let ⟨ru, rv, h⟩ := hsub
-  rw [←h, List.append_assoc, List.dropLast_append_of_ne_nil (by simp), List.dropLast_append] at htw
+  rw [← h, List.append_assoc, List.dropLast_append_of_ne_nil (by simp), List.dropLast_append] at htw
   contrapose! htw
   split_ifs with h
   · exact List.mem_append_right ru htw
@@ -238,7 +238,7 @@ theorem a_b_recurrence_1 (n : ℕ) (npos : 0 < n) : a (n+2) = 2 * a n + 2 * b n 
       rw [Finset.sum_singleton]
       repeat rw [walks_from_A]
       simp only [Set.ncard_eq_toFinset_card', Set.toFinset_card, Set.coe_ofPred]
-      rw [←Fintype.card_eq.mpr (Nonempty.intro (C_G_symm _))]
+      rw [← Fintype.card_eq.mpr (Nonempty.intro (C_G_symm _))]
       ring_nf
 
 theorem a_b_recurrence_2 (n : ℕ) (npos : 0 < n) : b (n+2) = a n + 2 * b n := by

--- a/Compfiles/Imo1979P6.lean
+++ b/Compfiles/Imo1979P6.lean
@@ -83,7 +83,7 @@ theorem Walk.drop_append_of_length_eq {V : Type} {G : SimpleGraph V} {u v w : V}
 theorem isTerminalWalk_copy {V : Type} {G : SimpleGraph V} {u v u' v' : V} (h1 : u = u') (h2 : v = v') (w : G.Walk u v) : isTerminalWalk w → isTerminalWalk (w.copy h1 h2) := by
   unfold isTerminalWalk
   intro h
-  simp [<-h2, h]
+  simp [←h2, h]
 
 theorem isTerminalWalk_map {V V' : Type} {G : SimpleGraph V} {G' : SimpleGraph V'} (f : G ↪g G') {u v : V} (w : G.Walk u v) :
     isTerminalWalk w → isTerminalWalk (w.map f.toHom) := by
@@ -101,7 +101,7 @@ theorem isTerminalWalk_of_isSubwalk {V : Type} {G : SimpleGraph V} {u u' t : V} 
   unfold isTerminalWalk at htw ⊢
   rw [Walk.isSubwalk_iff_support_isInfix, List.IsInfix] at hsub
   let ⟨ru, rv, h⟩ := hsub
-  rw [<-h, List.append_assoc, List.dropLast_append_of_ne_nil (by simp), List.dropLast_append] at htw
+  rw [←h, List.append_assoc, List.dropLast_append_of_ne_nil (by simp), List.dropLast_append] at htw
   contrapose! htw
   split_ifs with h
   · exact List.mem_append_right ru htw
@@ -238,7 +238,7 @@ theorem a_b_recurrence_1 (n : ℕ) (npos : 0 < n) : a (n+2) = 2 * a n + 2 * b n 
       rw [Finset.sum_singleton]
       repeat rw [walks_from_A]
       simp only [Set.ncard_eq_toFinset_card', Set.toFinset_card, Set.coe_ofPred]
-      rw [<-Fintype.card_eq.mpr (Nonempty.intro (C_G_symm _))]
+      rw [←Fintype.card_eq.mpr (Nonempty.intro (C_G_symm _))]
       ring_nf
 
 theorem a_b_recurrence_2 (n : ℕ) (npos : 0 < n) : b (n+2) = a n + 2 * b n := by

--- a/Compfiles/Imo1981P2.lean
+++ b/Compfiles/Imo1981P2.lean
@@ -97,7 +97,7 @@ instance : DecidableRel (G n r).Adj := fun u v =>
 theorem bipartite_edge {α β : Type} {G : SimpleGraph (α ⊕ β)} (hbip : G ≤ completeBipartiteGraph α β) (e : Sym2 (α ⊕ β)) (he : e ∈ G.edgeSet)
     : ∃ (a : α) (b : β), e = s(Sum.inl a, Sum.inr b) := by
   obtain ⟨u,v,h⟩ : ∃ u v, e = s(u,v) := by
-    rw [←Sym2.exists]
+    rw [← Sym2.exists]
     use e
   subst e
   rw [mem_edgeSet] at he
@@ -118,7 +118,7 @@ theorem G.bipartite : G n r ≤ completeBipartiteGraph _ _ := by
   grind [G, completeBipartiteGraph_adj]
 
 theorem G.card_edgeFinset : #(G n r).edgeFinset = Nat.choose (n+1) (r+1) := by
-  rw [show n+1 = #(Icc 0 n) by simp, ←card_powersetCard, eq_comm]
+  rw [show n+1 = #(Icc 0 n) by simp, ← card_powersetCard, eq_comm]
   apply card_bij (fun s h => s(.inl ⟨s, h⟩, .inr ⟨eraseMin s, by grind only [eraseMin_mem_powersetCard]⟩))
   · intro s hs
     rw [mem_edgeFinset, mem_edgeSet]
@@ -148,7 +148,7 @@ theorem G.degree_b (rpos : 1 ≤ r) (b : powersetCard r (Icc 1 n)) : (G n r).deg
     have h_bd' : m ≤ n := by
       grind only [= mem_powersetCard, = subset_iff, = mem_Icc]
     congr
-    rw [degree, ←Finset.card_range m, eq_comm]
+    rw [degree, ← Finset.card_range m, eq_comm]
     apply card_bij (fun i hi => Sum.inl ⟨insert i b.val, by grind⟩)
     · intro i hi
       rw [mem_neighborFinset, G]
@@ -167,11 +167,11 @@ theorem G.degree_b (rpos : 1 ≤ r) (b : powersetCard r (Icc 1 n)) : (G n r).deg
         have := heq.left
         have := heq.right
         subst b_1 v
-        simp_rw [←hv]
+        simp_rw [← hv]
         have ane : a.val.Nonempty := by
           grind only [= mem_powersetCard, card_ne_zero]
         use a.val.min' ane, ?_
-        · rw [Sum.inl.injEq, ←Subtype.val_inj]
+        · rw [Sum.inl.injEq, ← Subtype.val_inj]
           simp
         · simp only [mem_range]
           apply Finset.min'_lt_of_mem_erase_min'
@@ -192,13 +192,13 @@ problem imo1981_p2 (rpos : 1 ≤ r) (hrn : r ≤ n) : F n r = (n+1)/(r+1) := by
     enter [1, 1]
     norm_cast
     arg 1
-    rw [←Finset.sum_attach]
+    rw [← Finset.sum_attach]
     arg 2
     intro v
-    rw [←G.degree_b _ _ rpos, ←WithTop.coe_natCast, WithTop.some, Option.getD_some, Nat.cast_id, ←Function.Embedding.inr_apply]
+    rw [← G.degree_b _ _ rpos, ← WithTop.coe_natCast, WithTop.some, Option.getD_some, Nat.cast_id, ← Function.Embedding.inr_apply]
   conv =>
     enter [1, 1, 1]
-    rw [←Finset.sum_map _ Function.Embedding.inr (fun v => (G n r).degree v)]
+    rw [← Finset.sum_map _ Function.Embedding.inr (fun v => (G n r).degree v)]
     rw [isBipartiteWith_sum_degrees_eq_card_edges' (s:=Finset.univ.map Function.Embedding.inl) ?bip]
     case bip => tactic =>
       unfold G
@@ -208,7 +208,7 @@ problem imo1981_p2 (rpos : 1 ≤ r) (hrn : r ≤ n) : F n r = (n+1)/(r+1) := by
         simp
         grind
   rw [G.card_edgeFinset]
-  rw [←mul_div_mul_left (c:=↑(n+1)) _ _ (by grind only), ←Nat.cast_mul, ←Nat.cast_mul, Nat.add_one_mul_choose_eq]
+  rw [← mul_div_mul_left (c:=↑(n+1)) _ _ (by grind only), ← Nat.cast_mul, ← Nat.cast_mul, Nat.add_one_mul_choose_eq]
   qify
   have : (n + 1).choose (r + 1) ≠ 0 := by
     rw [Nat.choose_ne_zero_iff]

--- a/Compfiles/Imo1981P2.lean
+++ b/Compfiles/Imo1981P2.lean
@@ -97,7 +97,7 @@ instance : DecidableRel (G n r).Adj := fun u v =>
 theorem bipartite_edge {α β : Type} {G : SimpleGraph (α ⊕ β)} (hbip : G ≤ completeBipartiteGraph α β) (e : Sym2 (α ⊕ β)) (he : e ∈ G.edgeSet)
     : ∃ (a : α) (b : β), e = s(Sum.inl a, Sum.inr b) := by
   obtain ⟨u,v,h⟩ : ∃ u v, e = s(u,v) := by
-    rw [<-Sym2.exists]
+    rw [←Sym2.exists]
     use e
   subst e
   rw [mem_edgeSet] at he
@@ -118,7 +118,7 @@ theorem G.bipartite : G n r ≤ completeBipartiteGraph _ _ := by
   grind [G, completeBipartiteGraph_adj]
 
 theorem G.card_edgeFinset : #(G n r).edgeFinset = Nat.choose (n+1) (r+1) := by
-  rw [show n+1 = #(Icc 0 n) by simp, <-card_powersetCard, eq_comm]
+  rw [show n+1 = #(Icc 0 n) by simp, ←card_powersetCard, eq_comm]
   apply card_bij (fun s h => s(.inl ⟨s, h⟩, .inr ⟨eraseMin s, by grind only [eraseMin_mem_powersetCard]⟩))
   · intro s hs
     rw [mem_edgeFinset, mem_edgeSet]
@@ -148,7 +148,7 @@ theorem G.degree_b (rpos : 1 ≤ r) (b : powersetCard r (Icc 1 n)) : (G n r).deg
     have h_bd' : m ≤ n := by
       grind only [= mem_powersetCard, = subset_iff, = mem_Icc]
     congr
-    rw [degree, <-Finset.card_range m, eq_comm]
+    rw [degree, ←Finset.card_range m, eq_comm]
     apply card_bij (fun i hi => Sum.inl ⟨insert i b.val, by grind⟩)
     · intro i hi
       rw [mem_neighborFinset, G]
@@ -167,11 +167,11 @@ theorem G.degree_b (rpos : 1 ≤ r) (b : powersetCard r (Icc 1 n)) : (G n r).deg
         have := heq.left
         have := heq.right
         subst b_1 v
-        simp_rw [<-hv]
+        simp_rw [←hv]
         have ane : a.val.Nonempty := by
           grind only [= mem_powersetCard, card_ne_zero]
         use a.val.min' ane, ?_
-        · rw [Sum.inl.injEq, <-Subtype.val_inj]
+        · rw [Sum.inl.injEq, ←Subtype.val_inj]
           simp
         · simp only [mem_range]
           apply Finset.min'_lt_of_mem_erase_min'
@@ -192,13 +192,13 @@ problem imo1981_p2 (rpos : 1 ≤ r) (hrn : r ≤ n) : F n r = (n+1)/(r+1) := by
     enter [1, 1]
     norm_cast
     arg 1
-    rw [<-Finset.sum_attach]
+    rw [←Finset.sum_attach]
     arg 2
     intro v
-    rw [<-G.degree_b _ _ rpos, <-WithTop.coe_natCast, WithTop.some, Option.getD_some, Nat.cast_id, <-Function.Embedding.inr_apply]
+    rw [←G.degree_b _ _ rpos, ←WithTop.coe_natCast, WithTop.some, Option.getD_some, Nat.cast_id, ←Function.Embedding.inr_apply]
   conv =>
     enter [1, 1, 1]
-    rw [<-Finset.sum_map _ Function.Embedding.inr (fun v => (G n r).degree v)]
+    rw [←Finset.sum_map _ Function.Embedding.inr (fun v => (G n r).degree v)]
     rw [isBipartiteWith_sum_degrees_eq_card_edges' (s:=Finset.univ.map Function.Embedding.inl) ?bip]
     case bip => tactic =>
       unfold G
@@ -208,7 +208,7 @@ problem imo1981_p2 (rpos : 1 ≤ r) (hrn : r ≤ n) : F n r = (n+1)/(r+1) := by
         simp
         grind
   rw [G.card_edgeFinset]
-  rw [<-mul_div_mul_left (c:=↑(n+1)) _ _ (by grind only), <-Nat.cast_mul, <-Nat.cast_mul, Nat.add_one_mul_choose_eq]
+  rw [←mul_div_mul_left (c:=↑(n+1)) _ _ (by grind only), ←Nat.cast_mul, ←Nat.cast_mul, Nat.add_one_mul_choose_eq]
   qify
   have : (n + 1).choose (r + 1) ≠ 0 := by
     rw [Nat.choose_ne_zero_iff]

--- a/Compfiles/Imo1981P4.lean
+++ b/Compfiles/Imo1981P4.lean
@@ -43,12 +43,12 @@ theorem dvd_factorial {n k : ℕ} (h : last_divides_lcm_remaining n k) : k+n ∣
   have := dvd_trans h (lcm_dvd_prod (Icc (k+1) (k+n-1)) id)
   rw [Nat.dvd_iff_mod_eq_zero, prod_nat_mod] at this
   zify at this
-  rw [prod_bij (t:=Finset.range (n-1)) (g:=fun x => -(x+1:ℤ) % (↑k + ↑n)) (fun i _ => k+n-i-1), <-prod_int_mod, prod_neg] at this
-  · rw [<-Int.dvd_iff_emod_eq_zero] at this
+  rw [prod_bij (t:=Finset.range (n-1)) (g:=fun x => -(x+1:ℤ) % (↑k + ↑n)) (fun i _ => k+n-i-1), ←prod_int_mod, prod_neg] at this
+  · rw [←Int.dvd_iff_emod_eq_zero] at this
     conv at this =>
       lhs
       norm_cast
-    rw [<-ZMod.intCast_zmod_eq_zero_iff_dvd] at this
+    rw [←ZMod.intCast_zmod_eq_zero_iff_dvd] at this
     simp only [Int.reduceNeg, Int.cast_mul, Int.cast_pow, Int.cast_neg, Int.cast_one, neg_one_pow_mul_eq_zero_iff] at this
     rw [ZMod.intCast_zmod_eq_zero_iff_dvd] at this
     rw [Nat.factorial_eq_prod_range_add_one]
@@ -125,7 +125,7 @@ theorem ge_5 (n d : ℕ) (hge : 5 ≤ n) (hd : d = 1 ∨ d = 2) : last_divides_l
           lia
   · zify
     repeat rw [Nat.cast_sub (by lia)]
-    rw [sub_mul, mul_sub, mul_sub, <-sub_nonneg]
+    rw [sub_mul, mul_sub, mul_sub, ←sub_nonneg]
     apply hd.elim <;> {
       intro _
       subst d
@@ -183,12 +183,12 @@ problem imo1981_p4 (n : ℕ) :
           omega
         · zify
           repeat rw [Nat.cast_sub (by lia)]
-          rw [sub_mul, mul_sub, mul_sub, <-sub_nonneg]
+          rw [sub_mul, mul_sub, mul_sub, ←sub_nonneg]
           simp
           nlinarith
         · zify
           repeat rw [Nat.cast_sub (by lia)]
-          rw [sub_mul, mul_sub, mul_sub, <-sub_nonneg]
+          rw [sub_mul, mul_sub, mul_sub, ←sub_nonneg]
           simp
           nlinarith
 

--- a/Compfiles/Imo1981P4.lean
+++ b/Compfiles/Imo1981P4.lean
@@ -43,12 +43,12 @@ theorem dvd_factorial {n k : ℕ} (h : last_divides_lcm_remaining n k) : k+n ∣
   have := dvd_trans h (lcm_dvd_prod (Icc (k+1) (k+n-1)) id)
   rw [Nat.dvd_iff_mod_eq_zero, prod_nat_mod] at this
   zify at this
-  rw [prod_bij (t:=Finset.range (n-1)) (g:=fun x => -(x+1:ℤ) % (↑k + ↑n)) (fun i _ => k+n-i-1), ←prod_int_mod, prod_neg] at this
-  · rw [←Int.dvd_iff_emod_eq_zero] at this
+  rw [prod_bij (t:=Finset.range (n-1)) (g:=fun x => -(x+1:ℤ) % (↑k + ↑n)) (fun i _ => k+n-i-1), ← prod_int_mod, prod_neg] at this
+  · rw [← Int.dvd_iff_emod_eq_zero] at this
     conv at this =>
       lhs
       norm_cast
-    rw [←ZMod.intCast_zmod_eq_zero_iff_dvd] at this
+    rw [← ZMod.intCast_zmod_eq_zero_iff_dvd] at this
     simp only [Int.reduceNeg, Int.cast_mul, Int.cast_pow, Int.cast_neg, Int.cast_one, neg_one_pow_mul_eq_zero_iff] at this
     rw [ZMod.intCast_zmod_eq_zero_iff_dvd] at this
     rw [Nat.factorial_eq_prod_range_add_one]
@@ -125,7 +125,7 @@ theorem ge_5 (n d : ℕ) (hge : 5 ≤ n) (hd : d = 1 ∨ d = 2) : last_divides_l
           lia
   · zify
     repeat rw [Nat.cast_sub (by lia)]
-    rw [sub_mul, mul_sub, mul_sub, ←sub_nonneg]
+    rw [sub_mul, mul_sub, mul_sub, ← sub_nonneg]
     apply hd.elim <;> {
       intro _
       subst d
@@ -183,12 +183,12 @@ problem imo1981_p4 (n : ℕ) :
           omega
         · zify
           repeat rw [Nat.cast_sub (by lia)]
-          rw [sub_mul, mul_sub, mul_sub, ←sub_nonneg]
+          rw [sub_mul, mul_sub, mul_sub, ← sub_nonneg]
           simp
           nlinarith
         · zify
           repeat rw [Nat.cast_sub (by lia)]
-          rw [sub_mul, mul_sub, mul_sub, ←sub_nonneg]
+          rw [sub_mul, mul_sub, mul_sub, ← sub_nonneg]
           simp
           nlinarith
 

--- a/Compfiles/Imo1981P6.lean
+++ b/Compfiles/Imo1981P6.lean
@@ -69,7 +69,7 @@ problem imo1981_p6 (f : ℕ → ℕ → ℕ)
     | succ y ih =>
       rw [h3, h20]
       rw [show 2 * f (2 + 1) y + 3 + 3 = 2 * (f 3 y + 3) by ring]
-      rw [ih, ←Nat.pow_succ']
+      rw [ih, ← Nat.pow_succ']
   have h6 : ∀ y, f 4 (y + 1) + 3 = 2^(f 4 y + 3) := by
     intro y
     induction y with

--- a/Compfiles/Imo1982P1.lean
+++ b/Compfiles/Imo1982P1.lean
@@ -60,7 +60,7 @@ problem imo1982_p1 (f : ℕ → ℕ)
     · have h10 := h6 (k + l) (Nat.add_pos_left hk l)
       have h11 : 3 * (k + l) + 3 = 3 * (k + Nat.succ l) := by lia
       have h12 : f (3 * k) + Nat.succ l = f (3 * k) + l + 1 := by lia
-      rw [←h11, h12]
+      rw [← h11, h12]
       lia
   have h8 : ∀ k, 0 < k → k ≤ 3333 → f (3 * k) = k := by
      intro k hk0 hk1
@@ -85,16 +85,16 @@ problem imo1982_p1 (f : ℕ → ℕ)
       have h12 : 2 * k + 2 ≤ f (6 * k + 4) := by
         have h14 : 3 * k + 2 + (3 * k + 2) = 6 * k + 4 := by ring
         have h15 : k + 1 + (k + 1) = 2 * k + 2 := by ring
-        rw [←h14, ←h15]
+        rw [← h14, ← h15]
         exact h30 _ _ (Nat.succ_pos _) (Nat.le_of_eq h11.symm)
       have h13 : 4 * k + 4 ≤ f (12 * k + 8) := by
         have h14 : 6 * k + 4 + (6 * k + 4) = 12 * k + 8 := by ring
         have h15 : 2 * k + 2 + (2 * k + 2) = 4 * k + 4 := by ring
-        rw [←h14, ←h15]
+        rw [← h14, ← h15]
         exact h30 _ _ (Nat.succ_pos _) h12
       have h14 : f (12 * k + 8) ≤ f (12 * k + 9) := by
         have h15 : 12 * k + 8 + 1 = 12 * k + 9 := by ring
-        rw [←h15]
+        rw [← h15]
         exact h20 _ (Nat.succ_pos _)
       have h15 : f (12 * k + 9) = 4 * k + 3 := by
          have h16 : 3 * (4 * k + 3) = 12 * k + 9 := by ring

--- a/Compfiles/Imo1982P4.lean
+++ b/Compfiles/Imo1982P4.lean
@@ -56,13 +56,13 @@ problem imo1982_p4 (n : ℕ)
         lia
       replace hxy : (x : ZMod 7) ^ 3 - 3 * (x : ZMod 7) * (y : ZMod 7) ^ 2 +
                       (y : ZMod 7) ^ 3 = 0 := by
-        rw [←ZMod.intCast_eq_intCast_iff] at hxy
+        rw [← ZMod.intCast_eq_intCast_iff] at hxy
         norm_cast
       have ⟨h1, h2⟩ := lemma1 hxy
       constructor
-      · rw [ZMod.intCast_zmod_eq_zero_iff_dvd, ←Int.modEq_zero_iff_dvd] at h1
+      · rw [ZMod.intCast_zmod_eq_zero_iff_dvd, ← Int.modEq_zero_iff_dvd] at h1
         exact h1
-      · rw [ZMod.intCast_zmod_eq_zero_iff_dvd, ←Int.modEq_zero_iff_dvd] at h2
+      · rw [ZMod.intCast_zmod_eq_zero_iff_dvd, ← Int.modEq_zero_iff_dvd] at h2
         exact h2
     have h₄ : (x : ℤ) % 7 = 0 := h₂
     have h₅ : (y : ℤ) % 7 = 0 := h₃

--- a/Compfiles/Imo1983P6.lean
+++ b/Compfiles/Imo1983P6.lean
@@ -41,7 +41,7 @@ lemma cauchy_schwarz_equals {ι: Type*} (s : Finset ι)
       (∑ i ∈ s, f i^2) * (t * t) + ((- 2) * ∑ i ∈ s, f i * g i) * t + ∑ i ∈ s, g i^2 := by
     intro t
     unfold q
-    simp only [Finset.mul_sum, Finset.sum_mul, ←Finset.sum_add_distrib]
+    simp only [Finset.mul_sum, Finset.sum_mul, ← Finset.sum_add_distrib]
     apply Finset.sum_congr rfl
     intro i hi
     ring
@@ -59,7 +59,7 @@ lemma cauchy_schwarz_equals {ι: Type*} (s : Finset ι)
     specialize H ii hii
     contradiction
   obtain ⟨t0, ht0, -⟩ := (discrim_eq_zero_iff h3).mp h2
-  rw [←h1] at ht0
+  rw [← h1] at ht0
   unfold q at ht0
   use t0
   rw [Finset.sum_mul_self_eq_zero_iff] at ht0
@@ -156,17 +156,17 @@ problem imo1983_p6 (T : Affine.Triangle ℝ (EuclideanSpace ℝ (Fin 2))) :
   intro a b c
   have h₁ : c < a + b := by
     have := AffineIndependent.not_wbtw_of_injective (0 : Fin 3) 2 1 (by decide) T.independent
-    rw [←dist_lt_dist_add_dist_iff, dist_comm (T.points 2)] at this
+    rw [← dist_lt_dist_add_dist_iff, dist_comm (T.points 2)] at this
     linarith
 
   have h₂ : b < a + c := by
     have := AffineIndependent.not_wbtw_of_injective (0 : Fin 3) 1 2 (by decide) T.independent
-    rw [←dist_lt_dist_add_dist_iff] at this
+    rw [← dist_lt_dist_add_dist_iff] at this
     linarith
 
   have h₃ : a < b + c := by
     have := AffineIndependent.not_wbtw_of_injective (1 : Fin 3) 0 2 (by decide) T.independent
-    rw [←dist_lt_dist_add_dist_iff, dist_comm (T.points 1) (T.points 0)] at this
+    rw [← dist_lt_dist_add_dist_iff, dist_comm (T.points 1) (T.points 0)] at this
     linarith
 
   -- https://prase.cz/kalva/imo/isoln/isoln836.html
@@ -196,7 +196,7 @@ problem imo1983_p6 (T : Affine.Triangle ℝ (EuclideanSpace ℝ (Fin 2))) :
     rw [h1] at hsum; clear h1
     simp only [mul_pow] at hsum
     simp only [Real.sq_sqrt hx.le, Real.sq_sqrt hy.le, Real.sq_sqrt hz.le] at hsum
-    rw [pow_two (z + x + y), ←mul_assoc] at hsum
+    rw [pow_two (z + x + y), ← mul_assoc] at hsum
     have h2 : 0 < z + x + y := by positivity
     rw [show x^2 * x = x^3 from rfl, show y^2 * y = y^3 from rfl,
         show z^2 * z = z^3 from rfl] at hsum
@@ -216,6 +216,6 @@ problem imo1983_p6 (T : Affine.Triangle ℝ (EuclideanSpace ℝ (Fin 2))) :
       · linarith
     exact lemma1 hx hy hz hxyz
   · rintro ⟨h1, h2⟩
-    simp [←h1, ←h2]
+    simp [← h1, ← h2]
 
 end Imo1983P6

--- a/Compfiles/Imo1984P1.lean
+++ b/Compfiles/Imo1984P1.lean
@@ -64,16 +64,16 @@ problem imo1984_p1  (x y z : ℝ)
   wlog hxy : x ≤ y generalizing x y z
   · rw [show (1 - 2 * x) * (1 - 2 * y) * (1 - 2 * z) = (1 - 2 * y) * (1 - 2 * x) * (1 - 2 * z)
         by linarith]
-    exact this y x z ⟨hy0, hx0, hz0⟩ (by rw [←h₁]; linarith) hy0 hx0 hz0 (by linarith)
+    exact this y x z ⟨hy0, hx0, hz0⟩ (by rw [← h₁]; linarith) hy0 hx0 hz0 (by linarith)
   · wlog hxz : x ≤ z generalizing x y z
     · rw [show (1 - 2 * x) * (1 - 2 * y) * (1 - 2 * z) = (1 - 2 * z) * (1 - 2 * x) * (1 - 2 * y)
           by linarith]
       exact this z x y ⟨hz0, hx0, hy0⟩
-            (by rw [←h₁]; linarith) hz0 hx0 hy0 (by linarith) ((le_of_not_ge hxz).trans hxy)
+            (by rw [← h₁]; linarith) hz0 hx0 hy0 (by linarith) ((le_of_not_ge hxz).trans hxy)
     · wlog hyz : y ≤ z generalizing x y z
       · rw [show (1 - 2 * x) * (1 - 2 * y) * (1 - 2 * z) = (1 - 2 * x) * (1 - 2 * z) * (1 - 2 * y)
             by linarith]
-        exact this x z y ⟨hx0, hz0, hy0⟩ (by rw [←h₁]; linarith) hx0 hz0 hy0 hxz hxy (by linarith)
+        exact this x z y ⟨hx0, hz0, hy0⟩ (by rw [← h₁]; linarith) hx0 hz0 hy0 hxz hxy (by linarith)
       · constructor
         · suffices habs : abs ((1 - 2 * x) * (1 - 2 * y) * (1 - 2 * z)) ≤ 1 by
             have ⟨i, _⟩ := abs_le.mp habs; linarith only [i]
@@ -88,13 +88,13 @@ problem imo1984_p1  (x y z : ℝ)
           · trans 0; rotate_left
             · norm_num
             apply nonpos_of_neg_nonneg
-            rw [←mul_neg]
+            rw [← mul_neg]
             apply mul_nonneg
             · positivity
             · linarith
           · apply le_trans (geom_mean_le_arith_mean_3 h1 h2 h3)
             rw [show (x + y + z - 2 * x + (x + y + z - 2 * y) + (x + y + z - 2 * z)) = 1
-                by rw [←h₁]; ring_nf]
+                by rw [← h₁]; ring_nf]
             norm_num
 
 end Imo1984P1

--- a/Compfiles/Imo1985P4.lean
+++ b/Compfiles/Imo1985P4.lean
@@ -304,7 +304,7 @@ problem imo1985_p4 (M : Finset ℕ) (Mcard : M.card = 1985) (Mpos : ∀ m ∈ M,
     (Mdivisors : ∀ m ∈ M, ∀ n, n ∈ m.primeFactors → n ≤ 23)
     : ∃ M' : Finset ℕ, M' ⊆ M ∧ M'.card = 4 ∧ ∃ k, M'.prod id = k^4 := by
   replace Mdivisors : ∀ m ∈ M, ∀ n, n.Prime ∧ n ∣ m → n ≤ 23 := fun m hm n ↦ by
-    rw [←Nat.mem_primeFactors_of_ne_zero (Mpos m hm).ne.symm]
+    rw [← Nat.mem_primeFactors_of_ne_zero (Mpos m hm).ne.symm]
     grind
   let k := 8
   have h₁ : Nat.nth Nat.Prime k = 23 := by

--- a/Compfiles/Imo1987P4.lean
+++ b/Compfiles/Imo1987P4.lean
@@ -62,7 +62,7 @@ problem imo1987_p4 : ¬∃ f : ℕ → ℕ, ∀ n, f (f n) = n + 1987 := by
   have ab_range : A ∪ B = {n | n < 2 * m + 1} := by
     rw [ab_union]
     ext x
-    rw [Set.mem_ofPred_eq, ←not_iff_not, ←Set.compl_eq_univ_sdiff]
+    rw [Set.mem_ofPred_eq, ← not_iff_not, ← Set.compl_eq_univ_sdiff]
     rw [Set.notMem_compl_iff, not_lt]
     simp only [Set.mem_image, Set.mem_univ, true_and, exists_exists_eq_and, hf]
     rw [le_iff_exists_add']
@@ -78,7 +78,7 @@ problem imo1987_p4 : ¬∃ f : ℕ → ℕ, ∀ n, f (f n) = n + 1987 := by
   -- has an odd number of elements.
 
   have ab_card : Set.ncard (A ∪ B) = 2 * m + 1 := by
-    rw [ab_range, Set.Iio_def, ←Finset.coe_range, Set.ncard_coe_finset]
+    rw [ab_range, Set.Iio_def, ← Finset.coe_range, Set.ncard_coe_finset]
     exact Finset.card_range (2 * m + 1)
 
   have ab_finite : (A ∪ B).Finite := by

--- a/Compfiles/Imo1987P6.lean
+++ b/Compfiles/Imo1987P6.lean
@@ -147,7 +147,7 @@ problem imo1987_p6
       replace ieq5 := Real.lt_sq_of_sqrt_lt ieq5 |> (div_lt_iff₀ (by norm_num)).1
       replace ieq5: (p) < (3*r^2 + 6*r +3) := cast_lt.1 <| by
         have casteq: ((r:ℝ)+1)^2 * 3 = ((3*r^2+6*r+3:ℕ):ℝ) := by simp;ring_nf
-        rw [←casteq]
+        rw [← casteq]
         exact ieq5
       lia
     have hN0 : N = kk^2+kk+p := rfl
@@ -158,13 +158,13 @@ problem imo1987_p6
       _ = 4*r^2 + 2* r*s + s^2 + 7*r+s+2 := by ring_nf
       _ < 4*r^2 +4*s^2 +8*r*s+4*r+4*s+1 := by lia
       _ = _ := by ring
-    rw [←hksr] at hN1
+    rw [← hksr] at hN1
 
     have hP : ∀ i , kk < i → i ≤ 2*(kk) → Coprime N i := by
       by_contra H
       push Not at H
       obtain ⟨j, hj1,hj2,hj3⟩ := H
-      have hj1' : s+r +1 ≤ j := by rw [←hksr]; apply succ_le_of_lt hj1
+      have hj1' : s+r +1 ≤ j := by rw [← hksr]; apply succ_le_of_lt hj1
       let  ss :=  j-(s+r+1)
       have hss0 : j =  ss + (s+r+1) := Nat.eq_add_of_sub_eq hj1' (by rfl)
 
@@ -173,7 +173,7 @@ problem imo1987_p6
 
       have hss1 : ss ≤ k := by
         apply Nat.le_of_add_le_add_right (b :=s+r+1)
-        rw [←hss0,←hksr]
+        rw [← hss0,← hksr]
         calc
         _ ≤ _ := hj2
         _ = _ := by lia
@@ -182,11 +182,11 @@ problem imo1987_p6
         unfold f
         rw [hN0]
         zify
-        rw [Int.natCast_sub hj2,hss0,←hksr]
+        rw [Int.natCast_sub hj2,hss0,← hksr]
         push_cast
         ring_nf
       change ¬N.gcd j = 1 at hj3
-      rw [hfss, ←Nat.coprime_iff_gcd_eq_one, Nat.coprime_add_mul_right_left] at hj3
+      rw [hfss, ← Nat.coprime_iff_gcd_eq_one, Nat.coprime_add_mul_right_left] at hj3
       have hss2 : f ss ∣ j := Nat.Prime.dvd_iff_not_coprime hss1 |>.2 hj3
       have hfss1: p ≤ f ss := Nat.le_add_left p (ss ^ 2 + ss)
       have hp1 : p - 2 < p := sub_le_lemma hp (by lia)
@@ -200,7 +200,7 @@ problem imo1987_p6
         calc
           p ≤ ss^2 + p := Nat.le_add_left _ _
           _ = _ := hfss3
-          _ = _ := by rw [←hksr]
+          _ = _ := by rw [← hksr]
       have hc2: p ≤ p-1 := by
         calc
         _ ≤ _ := hc1

--- a/Compfiles/Imo1988P4.lean
+++ b/Compfiles/Imo1988P4.lean
@@ -560,7 +560,7 @@ lemma p_eq_X_sub_C_rset_prod : p = ∏ r ∈ rset, (X - C r) := by
   have := @C_leadingCoeff_mul_prod_multiset_X_sub_C _ _ _ p ?_
   · simp [p_leadingCoeff, ← rset_eq_p_roots] at this
     exact this.symm
-  · rw [←rset_eq_p_roots, card_val, rset_card]; exact p_natDegree.symm
+  · rw [← rset_eq_p_roots, card_val, rset_card]; exact p_natDegree.symm
 
 lemma roots_sum : ∑ r ∈ rset, r = 4473 := by
   have : (∏ r ∈ rset, (X - C r)).nextCoeff = -4473 := by rw [← p_eq_X_sub_C_rset_prod]; exact p_nextCoeff

--- a/Compfiles/Imo1989P6.lean
+++ b/Compfiles/Imo1989P6.lean
@@ -81,7 +81,7 @@ theorem partial_cycle.apply_of_eq [NeZero n] (x : Perm $ Finset.Icc 1 (2 * n)) (
   unfold partial_cycle perm_fin_equiv instOne
   simp only [equivCongr_symm, coe_fn_mk, equivCongr_apply_apply, symm_symm, Perm.coe_mul,
     Function.comp_apply, symm_apply_apply]
-  rw [←h, Fin.cycleRange_self]
+  rw [← h, Fin.cycleRange_self]
   unfold fin_equiv
   simp
 
@@ -97,7 +97,7 @@ theorem partial_cycle.apply_of_gt [NeZero n] (x : Perm $ Finset.Icc 1 (2 * n)) (
     apply one_le_val
 
 theorem partial_cycle.apply_of_lt [NeZero n] (x : Perm $ Finset.Icc 1 (2 * n)) (k i : Finset.Icc 1 (2 * n)) (h : i < k)
-    : (partial_cycle n k x) i = ⟨x ⟨i + 1, by rw [←Subtype.coe_lt_coe] at h; grind⟩, by simp⟩ := by
+    : (partial_cycle n k x) i = ⟨x ⟨i + 1, by rw [← Subtype.coe_lt_coe] at h; grind⟩, by simp⟩ := by
   unfold partial_cycle perm_fin_equiv
   simp only [equivCongr_symm, coe_fn_mk, equivCongr_apply_apply, symm_symm, Perm.coe_mul,
     Function.comp_apply, symm_apply_apply]
@@ -108,7 +108,7 @@ theorem partial_cycle.apply_of_lt [NeZero n] (x : Perm $ Finset.Icc 1 (2 * n)) (
     rw [Fin.val_add_one_of_lt']
     · simp
     · simp only [one_le_val, Nat.sub_add_cancel]
-      rw [←Subtype.coe_lt_coe] at h
+      rw [← Subtype.coe_lt_coe] at h
       apply lt_of_lt_of_le h
       exact val_le_2n n k
   · unfold fin_equiv
@@ -140,12 +140,12 @@ theorem partial_cycle.symm.apply_of_gt [NeZero n] (x : Perm $ Finset.Icc 1 (2 * 
   apply one_le_val
 
 theorem partial_cycle.symm.apply_of_le [NeZero n] (x : Perm $ Finset.Icc 1 (2 * n)) (k i : Finset.Icc 1 (2 * n)) (h1 : i ≤ k) (h2 : 1 < i)
-    : ((partial_cycle n k).symm x) i = ⟨x ⟨i - 1, by rw [instOne, ←Subtype.coe_lt_coe] at h2; grind⟩, by simp⟩ := by
+    : ((partial_cycle n k).symm x) i = ⟨x ⟨i - 1, by rw [instOne, ← Subtype.coe_lt_coe] at h2; grind⟩, by simp⟩ := by
   unfold partial_cycle perm_fin_equiv
   simp only [equivCongr_symm, coe_fn_symm_mk, equivCongr_apply_apply, symm_symm, Perm.coe_mul,
     Function.comp_apply, symm_apply_apply]
-  suffices (fin_equiv n) i = (((fin_equiv n) k).cycleRange) ((fin_equiv n) ⟨i - 1, by rw [instOne, ←Subtype.coe_lt_coe] at h2; grind⟩) by grind
-  simp_rw [←Subtype.coe_lt_coe] at h1 h2
+  suffices (fin_equiv n) i = (((fin_equiv n) k).cycleRange) ((fin_equiv n) ⟨i - 1, by rw [instOne, ← Subtype.coe_lt_coe] at h2; grind⟩) by grind
+  simp_rw [← Subtype.coe_lt_coe] at h1 h2
   rw [Fin.cycleRange_of_lt]
   · unfold fin_equiv
     simp only [coe_fn_mk]
@@ -174,7 +174,7 @@ def transform_A_to_B [NeZero n] : (A n) → (B n) := fun x ↦ by
     · contrapose! ndiff
       replace ndiff : k = 1 := by exact SetLike.coe_eq_coe.mp ndiff
       rw [show x_1 = (x.val 1) by rfl]
-      rw [show x_k = (x.val 1) by rw [←ndiff]; unfold k; simp]
+      rw [show x_k = (x.val 1) by rw [← ndiff]; unfold k; simp]
       simp
       grind only [= Finset.mem_Icc]
     · unfold A T at x
@@ -184,16 +184,16 @@ def transform_A_to_B [NeZero n] : (A n) → (B n) := fun x ↦ by
       contrapose! this
       use (by grind)
       rw [show (x.val ⟨1, _⟩) = x_1 by rfl]
-      rw [show (x.val ⟨2, _⟩) = x_k by unfold k at this; simp_rw [←this]; simp]
+      rw [show (x.val ⟨2, _⟩) = x_k by unfold k at this; simp_rw [← this]; simp]
       exact ndiff
   }⟩
   use ⟨(partial_cycle n ⟨k-1, by grind⟩) x, k_sub_1⟩
   intro j
   constructor
   · intro jeq
-    simp_rw [←jeq]
+    simp_rw [← jeq]
     nth_rw 1 [partial_cycle.apply_of_eq _ _ _ _ (by unfold k_sub_1; simp)]
-    nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; grind)]
+    nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [← Subtype.coe_lt_coe]; grind)]
     unfold k_sub_1
     simp only [one_le_val, Nat.sub_add_cancel, Subtype.coe_eta]
     rw [show (x.val 1) = x_1 by rfl]
@@ -207,25 +207,25 @@ def transform_A_to_B [NeZero n] : (A n) → (B n) := fun x ↦ by
     apply this.elim3
     · intro jeq
       simp_rw [jeq]
-      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; lia)]
+      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [← Subtype.coe_lt_coe]; lia)]
       nth_rw 1 [partial_cycle.apply_of_eq _ _ _ _ (by rw [← Subtype.coe_inj]; lia)]
       unfold x_1 at ndiff
       rw [Nat.dist_comm]
       rw [unique_ndiff] at ⊢ ndiff
-      rw [←ndiff]
+      rw [← ndiff]
       simp
       rw [show x_k = (x.val k) by unfold k; simp]
-      have : ⟨k-2+1, by grind⟩ ≠ k := by rw [←Subtype.coe_ne_coe]; grind
+      have : ⟨k-2+1, by grind⟩ ≠ k := by rw [← Subtype.coe_ne_coe]; grind
       contrapose! this
       apply x.val.injective this
     · intro jlt
-      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; simp; lia)]
-      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; simp; lia)]
+      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [← Subtype.coe_lt_coe]; simp; lia)]
+      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [← Subtype.coe_lt_coe]; simp; lia)]
       apply not_exists.mp $ (not_exists.mp $ Set.mem_ofPred_eq.mp x.prop) _
       grind only [= Finset.mem_Icc]
     · intro jgt
-      nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; simp; lia)]
-      nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; simp; lia)]
+      nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [← Subtype.coe_lt_coe]; simp; lia)]
+      nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [← Subtype.coe_lt_coe]; simp; lia)]
       apply not_exists.mp $ (not_exists.mp $ Set.mem_ofPred_eq.mp x.prop) _
       grind only [= Finset.mem_Icc]
 
@@ -246,10 +246,10 @@ def transform_B_to_A [NeZero n] : (B n) → (A n) := fun ⟨⟨x, k⟩, h⟩ ↦
   by_cases c1 : i = 1
   · subst c1
     nth_rw 1 [partial_cycle.symm.apply_of_eq _ _ _ _ (by rfl)]
-    nth_rw 1 [partial_cycle.symm.apply_of_le _ _ _ _ (by simp; grind) (by rw [←Subtype.coe_lt_coe]; exact Nat.lt_add_one _)]
+    nth_rw 1 [partial_cycle.symm.apply_of_le _ _ _ _ (by simp; grind) (by rw [← Subtype.coe_lt_coe]; exact Nat.lt_add_one _)]
     simp only [Nat.reduceAdd, Nat.add_one_sub_one]
     rw [unique_ndiff] at ⊢ ndiff
-    rw [←ndiff]
+    rw [← ndiff]
     unfold x_k_1
     simp only [SetLike.coe_eq_coe]
     by_contra
@@ -263,14 +263,14 @@ def transform_B_to_A [NeZero n] : (B n) → (A n) := fun ⟨⟨x, k⟩, h⟩ ↦
     simp only [ne_eq]
     rw [Nat.dist_comm] at ⊢ ndiff
     rw [unique_ndiff] at ⊢ ndiff
-    rw [←ndiff]
+    rw [← ndiff]
     unfold x_k
     simp
     rw [Nat.sub_one_eq_self]
     exact Nat.ne_zero_of_lt ib1
   by_cases c2 : i < k
   · nth_rw 1 [partial_cycle.symm.apply_of_le _ _ _ _ (by simp; grind) (by exact_mod_cast igt)]
-    nth_rw 1 [partial_cycle.symm.apply_of_le _ _ _ _ (by simpa using c2) (by rw [←Subtype.coe_lt_coe]; exact Nat.lt_add_of_pos_left ib1)]
+    nth_rw 1 [partial_cycle.symm.apply_of_le _ _ _ _ (by simpa using c2) (by rw [← Subtype.coe_lt_coe]; exact Nat.lt_add_of_pos_left ib1)]
     simp only [add_tsub_cancel_right]
     unfold B at h
     simp only [Subtype.forall, Set.mem_ofPred_eq] at h
@@ -297,12 +297,12 @@ def A_equiv_B [NeZero n] : Equiv (A n) (B n) := {
     unfold transform_A_to_B transform_B_to_A
     refine SetCoe.ext ?_
     simp only
-    rw [←Perm.mul_apply, Perm.mul_def, trans_eq_refl_iff_eq_symm.mpr] <;> simp
+    rw [← Perm.mul_apply, Perm.mul_def, trans_eq_refl_iff_eq_symm.mpr] <;> simp
   right_inv := fun ⟨⟨x, k⟩, h⟩ ↦ by
     unfold transform_A_to_B transform_B_to_A
     simp only [Subtype.mk.injEq, Prod.mk.injEq]
     and_intros
-    · rw [←Perm.mul_apply, Perm.mul_def, trans_eq_refl_iff_eq_symm.mpr]
+    · rw [← Perm.mul_apply, Perm.mul_def, trans_eq_refl_iff_eq_symm.mpr]
       · simp
       · congr
         simp_rw [partial_cycle.symm.apply_of_eq n _ _ 1 rfl]
@@ -310,7 +310,7 @@ def A_equiv_B [NeZero n] : Equiv (A n) (B n) := {
         simp only [Subtype.forall, Set.mem_ofPred_eq] at h
         replace h := (h k (by grind)).mp rfl
         rw [unique_ndiff] at h
-        simp_rw [←h]
+        simp_rw [← h]
         simp only [Subtype.coe_eta]
         refine (Nat.eq_sub_of_add_eq ?_)
         let k_add_1 : Finset.Icc 1 (2*n) := ⟨k+1, by grind⟩
@@ -323,9 +323,9 @@ def A_equiv_B [NeZero n] : Equiv (A n) (B n) := {
       simp only [Subtype.forall, Set.mem_ofPred_eq] at h
       replace h := (h k (by grind)).mp rfl
       rw [unique_ndiff] at h
-      simp_rw [←h]
+      simp_rw [← h]
       simp only [Subtype.coe_eta]
-      rw [←Subtype.val_inj]
+      rw [← Subtype.val_inj]
       refine Eq.symm (Nat.eq_sub_of_add_eq ?_)
       let k_add_1 : Finset.Icc 1 (2*n) := ⟨k+1, by grind⟩
       simp_rw [show ↑k + 1 = k_add_1.val by grind]
@@ -404,7 +404,7 @@ theorem embed_B.not_Surjective [NeZero n] : ¬ Function.Surjective (embed_B n) :
   split_ifs at this <;> grind
 
 theorem embed_B.card [NeZero n] : (B n).ncard < {x | T n x}.ncard := by
-  rw [←Set.ncard_coe, ←Set.ncard_image_of_injective Set.univ (embed_B n).injective]
+  rw [← Set.ncard_coe, ← Set.ncard_image_of_injective Set.univ (embed_B n).injective]
   apply Set.ncard_lt_card
   simp only [Set.coe_ofPred, Set.image_univ, ne_eq]
   rw [Set.range_eq_univ]

--- a/Compfiles/Imo1989P6.lean
+++ b/Compfiles/Imo1989P6.lean
@@ -81,7 +81,7 @@ theorem partial_cycle.apply_of_eq [NeZero n] (x : Perm $ Finset.Icc 1 (2 * n)) (
   unfold partial_cycle perm_fin_equiv instOne
   simp only [equivCongr_symm, coe_fn_mk, equivCongr_apply_apply, symm_symm, Perm.coe_mul,
     Function.comp_apply, symm_apply_apply]
-  rw [<-h, Fin.cycleRange_self]
+  rw [←h, Fin.cycleRange_self]
   unfold fin_equiv
   simp
 
@@ -97,7 +97,7 @@ theorem partial_cycle.apply_of_gt [NeZero n] (x : Perm $ Finset.Icc 1 (2 * n)) (
     apply one_le_val
 
 theorem partial_cycle.apply_of_lt [NeZero n] (x : Perm $ Finset.Icc 1 (2 * n)) (k i : Finset.Icc 1 (2 * n)) (h : i < k)
-    : (partial_cycle n k x) i = ⟨x ⟨i + 1, by rw [<-Subtype.coe_lt_coe] at h; grind⟩, by simp⟩ := by
+    : (partial_cycle n k x) i = ⟨x ⟨i + 1, by rw [←Subtype.coe_lt_coe] at h; grind⟩, by simp⟩ := by
   unfold partial_cycle perm_fin_equiv
   simp only [equivCongr_symm, coe_fn_mk, equivCongr_apply_apply, symm_symm, Perm.coe_mul,
     Function.comp_apply, symm_apply_apply]
@@ -108,7 +108,7 @@ theorem partial_cycle.apply_of_lt [NeZero n] (x : Perm $ Finset.Icc 1 (2 * n)) (
     rw [Fin.val_add_one_of_lt']
     · simp
     · simp only [one_le_val, Nat.sub_add_cancel]
-      rw [<-Subtype.coe_lt_coe] at h
+      rw [←Subtype.coe_lt_coe] at h
       apply lt_of_lt_of_le h
       exact val_le_2n n k
   · unfold fin_equiv
@@ -140,12 +140,12 @@ theorem partial_cycle.symm.apply_of_gt [NeZero n] (x : Perm $ Finset.Icc 1 (2 * 
   apply one_le_val
 
 theorem partial_cycle.symm.apply_of_le [NeZero n] (x : Perm $ Finset.Icc 1 (2 * n)) (k i : Finset.Icc 1 (2 * n)) (h1 : i ≤ k) (h2 : 1 < i)
-    : ((partial_cycle n k).symm x) i = ⟨x ⟨i - 1, by rw [instOne, <-Subtype.coe_lt_coe] at h2; grind⟩, by simp⟩ := by
+    : ((partial_cycle n k).symm x) i = ⟨x ⟨i - 1, by rw [instOne, ←Subtype.coe_lt_coe] at h2; grind⟩, by simp⟩ := by
   unfold partial_cycle perm_fin_equiv
   simp only [equivCongr_symm, coe_fn_symm_mk, equivCongr_apply_apply, symm_symm, Perm.coe_mul,
     Function.comp_apply, symm_apply_apply]
-  suffices (fin_equiv n) i = (((fin_equiv n) k).cycleRange) ((fin_equiv n) ⟨i - 1, by rw [instOne, <-Subtype.coe_lt_coe] at h2; grind⟩) by grind
-  simp_rw [<-Subtype.coe_lt_coe] at h1 h2
+  suffices (fin_equiv n) i = (((fin_equiv n) k).cycleRange) ((fin_equiv n) ⟨i - 1, by rw [instOne, ←Subtype.coe_lt_coe] at h2; grind⟩) by grind
+  simp_rw [←Subtype.coe_lt_coe] at h1 h2
   rw [Fin.cycleRange_of_lt]
   · unfold fin_equiv
     simp only [coe_fn_mk]
@@ -174,7 +174,7 @@ def transform_A_to_B [NeZero n] : (A n) → (B n) := fun x ↦ by
     · contrapose! ndiff
       replace ndiff : k = 1 := by exact SetLike.coe_eq_coe.mp ndiff
       rw [show x_1 = (x.val 1) by rfl]
-      rw [show x_k = (x.val 1) by rw [<-ndiff]; unfold k; simp]
+      rw [show x_k = (x.val 1) by rw [←ndiff]; unfold k; simp]
       simp
       grind only [= Finset.mem_Icc]
     · unfold A T at x
@@ -184,16 +184,16 @@ def transform_A_to_B [NeZero n] : (A n) → (B n) := fun x ↦ by
       contrapose! this
       use (by grind)
       rw [show (x.val ⟨1, _⟩) = x_1 by rfl]
-      rw [show (x.val ⟨2, _⟩) = x_k by unfold k at this; simp_rw [<-this]; simp]
+      rw [show (x.val ⟨2, _⟩) = x_k by unfold k at this; simp_rw [←this]; simp]
       exact ndiff
   }⟩
   use ⟨(partial_cycle n ⟨k-1, by grind⟩) x, k_sub_1⟩
   intro j
   constructor
   · intro jeq
-    simp_rw [<-jeq]
+    simp_rw [←jeq]
     nth_rw 1 [partial_cycle.apply_of_eq _ _ _ _ (by unfold k_sub_1; simp)]
-    nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [<-Subtype.coe_lt_coe]; grind)]
+    nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; grind)]
     unfold k_sub_1
     simp only [one_le_val, Nat.sub_add_cancel, Subtype.coe_eta]
     rw [show (x.val 1) = x_1 by rfl]
@@ -207,25 +207,25 @@ def transform_A_to_B [NeZero n] : (A n) → (B n) := fun x ↦ by
     apply this.elim3
     · intro jeq
       simp_rw [jeq]
-      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [<-Subtype.coe_lt_coe]; lia)]
+      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; lia)]
       nth_rw 1 [partial_cycle.apply_of_eq _ _ _ _ (by rw [← Subtype.coe_inj]; lia)]
       unfold x_1 at ndiff
       rw [Nat.dist_comm]
       rw [unique_ndiff] at ⊢ ndiff
-      rw [<-ndiff]
+      rw [←ndiff]
       simp
       rw [show x_k = (x.val k) by unfold k; simp]
-      have : ⟨k-2+1, by grind⟩ ≠ k := by rw [<-Subtype.coe_ne_coe]; grind
+      have : ⟨k-2+1, by grind⟩ ≠ k := by rw [←Subtype.coe_ne_coe]; grind
       contrapose! this
       apply x.val.injective this
     · intro jlt
-      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [<-Subtype.coe_lt_coe]; simp; lia)]
-      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [<-Subtype.coe_lt_coe]; simp; lia)]
+      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; simp; lia)]
+      nth_rw 1 [partial_cycle.apply_of_lt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; simp; lia)]
       apply not_exists.mp $ (not_exists.mp $ Set.mem_ofPred_eq.mp x.prop) _
       grind only [= Finset.mem_Icc]
     · intro jgt
-      nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [<-Subtype.coe_lt_coe]; simp; lia)]
-      nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [<-Subtype.coe_lt_coe]; simp; lia)]
+      nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; simp; lia)]
+      nth_rw 1 [partial_cycle.apply_of_gt _ _ _ _ (by rw [←Subtype.coe_lt_coe]; simp; lia)]
       apply not_exists.mp $ (not_exists.mp $ Set.mem_ofPred_eq.mp x.prop) _
       grind only [= Finset.mem_Icc]
 
@@ -246,10 +246,10 @@ def transform_B_to_A [NeZero n] : (B n) → (A n) := fun ⟨⟨x, k⟩, h⟩ ↦
   by_cases c1 : i = 1
   · subst c1
     nth_rw 1 [partial_cycle.symm.apply_of_eq _ _ _ _ (by rfl)]
-    nth_rw 1 [partial_cycle.symm.apply_of_le _ _ _ _ (by simp; grind) (by rw [<-Subtype.coe_lt_coe]; exact Nat.lt_add_one _)]
+    nth_rw 1 [partial_cycle.symm.apply_of_le _ _ _ _ (by simp; grind) (by rw [←Subtype.coe_lt_coe]; exact Nat.lt_add_one _)]
     simp only [Nat.reduceAdd, Nat.add_one_sub_one]
     rw [unique_ndiff] at ⊢ ndiff
-    rw [<-ndiff]
+    rw [←ndiff]
     unfold x_k_1
     simp only [SetLike.coe_eq_coe]
     by_contra
@@ -263,14 +263,14 @@ def transform_B_to_A [NeZero n] : (B n) → (A n) := fun ⟨⟨x, k⟩, h⟩ ↦
     simp only [ne_eq]
     rw [Nat.dist_comm] at ⊢ ndiff
     rw [unique_ndiff] at ⊢ ndiff
-    rw [<-ndiff]
+    rw [←ndiff]
     unfold x_k
     simp
     rw [Nat.sub_one_eq_self]
     exact Nat.ne_zero_of_lt ib1
   by_cases c2 : i < k
   · nth_rw 1 [partial_cycle.symm.apply_of_le _ _ _ _ (by simp; grind) (by exact_mod_cast igt)]
-    nth_rw 1 [partial_cycle.symm.apply_of_le _ _ _ _ (by simpa using c2) (by rw [<-Subtype.coe_lt_coe]; exact Nat.lt_add_of_pos_left ib1)]
+    nth_rw 1 [partial_cycle.symm.apply_of_le _ _ _ _ (by simpa using c2) (by rw [←Subtype.coe_lt_coe]; exact Nat.lt_add_of_pos_left ib1)]
     simp only [add_tsub_cancel_right]
     unfold B at h
     simp only [Subtype.forall, Set.mem_ofPred_eq] at h
@@ -297,12 +297,12 @@ def A_equiv_B [NeZero n] : Equiv (A n) (B n) := {
     unfold transform_A_to_B transform_B_to_A
     refine SetCoe.ext ?_
     simp only
-    rw [<-Perm.mul_apply, Perm.mul_def, trans_eq_refl_iff_eq_symm.mpr] <;> simp
+    rw [←Perm.mul_apply, Perm.mul_def, trans_eq_refl_iff_eq_symm.mpr] <;> simp
   right_inv := fun ⟨⟨x, k⟩, h⟩ ↦ by
     unfold transform_A_to_B transform_B_to_A
     simp only [Subtype.mk.injEq, Prod.mk.injEq]
     and_intros
-    · rw [<-Perm.mul_apply, Perm.mul_def, trans_eq_refl_iff_eq_symm.mpr]
+    · rw [←Perm.mul_apply, Perm.mul_def, trans_eq_refl_iff_eq_symm.mpr]
       · simp
       · congr
         simp_rw [partial_cycle.symm.apply_of_eq n _ _ 1 rfl]
@@ -310,7 +310,7 @@ def A_equiv_B [NeZero n] : Equiv (A n) (B n) := {
         simp only [Subtype.forall, Set.mem_ofPred_eq] at h
         replace h := (h k (by grind)).mp rfl
         rw [unique_ndiff] at h
-        simp_rw [<-h]
+        simp_rw [←h]
         simp only [Subtype.coe_eta]
         refine (Nat.eq_sub_of_add_eq ?_)
         let k_add_1 : Finset.Icc 1 (2*n) := ⟨k+1, by grind⟩
@@ -323,9 +323,9 @@ def A_equiv_B [NeZero n] : Equiv (A n) (B n) := {
       simp only [Subtype.forall, Set.mem_ofPred_eq] at h
       replace h := (h k (by grind)).mp rfl
       rw [unique_ndiff] at h
-      simp_rw [<-h]
+      simp_rw [←h]
       simp only [Subtype.coe_eta]
-      rw [<-Subtype.val_inj]
+      rw [←Subtype.val_inj]
       refine Eq.symm (Nat.eq_sub_of_add_eq ?_)
       let k_add_1 : Finset.Icc 1 (2*n) := ⟨k+1, by grind⟩
       simp_rw [show ↑k + 1 = k_add_1.val by grind]
@@ -404,7 +404,7 @@ theorem embed_B.not_Surjective [NeZero n] : ¬ Function.Surjective (embed_B n) :
   split_ifs at this <;> grind
 
 theorem embed_B.card [NeZero n] : (B n).ncard < {x | T n x}.ncard := by
-  rw [<-Set.ncard_coe, <-Set.ncard_image_of_injective Set.univ (embed_B n).injective]
+  rw [←Set.ncard_coe, ←Set.ncard_image_of_injective Set.univ (embed_B n).injective]
   apply Set.ncard_lt_card
   simp only [Set.coe_ofPred, Set.image_univ, ne_eq]
   rw [Set.range_eq_univ]

--- a/Compfiles/Imo1990P3.lean
+++ b/Compfiles/Imo1990P3.lean
@@ -33,7 +33,7 @@ lemma aux_1
     (2 : ℕ) ^ n ≡ (2 : ℕ) [MOD (7 : ℕ)] ∨
     (2 : ℕ) ^ n ≡ (4 : ℕ) [MOD (7 : ℕ)] := by
   have h₀ : n % 3 < 3 := Nat.mod_lt n (Nat.zero_lt_succ 2)
-  rw [←Nat.div_add_mod n 3]
+  rw [← Nat.div_add_mod n 3]
   generalize n % 3 = r at h₀ ⊢
   generalize n / 3 = d
   interval_cases r

--- a/Compfiles/Imo1990P4.lean
+++ b/Compfiles/Imo1990P4.lean
@@ -112,7 +112,7 @@ theorem PRat.prime_induction (P : ℚ+ → Prop) (base : P 1)
         let p' : Nat.Primes := ⟨p, p_prime⟩
         let x : ℚ+ := ⟨a, by {
           simp at ⊢ h2
-          rw [←Nat.cast_mul, ←Rat.natCast_ofNat, Nat.cast_lt] at h2
+          rw [← Nat.cast_mul, ← Rat.natCast_ofNat, Nat.cast_lt] at h2
           exact Nat.pos_of_mul_pos_left h2
         }⟩
         simp_rw [show ((p.cast * a.cast) : ℚ) = x * p' by unfold x p'; ring]
@@ -130,7 +130,7 @@ theorem PRat.prime_induction (P : ℚ+ → Prop) (base : P 1)
             subst b
             simp
           · simp only [zero_mul]
-            rw [←Nat.cast_mul, ←Nat.cast_mul, ←Rat.natCast_ofNat] at h2
+            rw [← Nat.cast_mul, ← Nat.cast_mul, ← Rat.natCast_ofNat] at h2
             refine (Rat.mul_pos_iff_of_pos_left ?_).mpr ?_
             · simp
               exact Nat.Prime.pos p_prime
@@ -143,7 +143,7 @@ theorem PRat.prime_induction (P : ℚ+ → Prop) (base : P 1)
         simp_rw [show ((p*a).cast / (q*b).cast : ℚ) = x/q' by unfold x q'; simp only [Nat.cast_mul]; field]
         apply ind_div
         unfold x
-        simp_rw [←Nat.cast_mul]
+        simp_rw [← Nat.cast_mul]
         apply ih2
   intro x
   have := this ⟨x.val.num.toNat, x.val.den⟩ (by {
@@ -181,9 +181,9 @@ theorem f_mul_hom (f : ℚ+ → ℚ+) (h : ∀ x y : ℚ+, f (x * f y) = f x / y
   let z := 1 / f y
   have : f z = y := by
     unfold z
-    rw [one_div, ←div_eq_one, ←h1]
+    rw [one_div, ← div_eq_one, ← h1]
     exact f_one_eq_one f h
-  nth_rw 1 [←this]
+  nth_rw 1 [← this]
   rw [h]
   unfold z
   simp
@@ -203,9 +203,9 @@ theorem Set.Infinite.exists_union_disjoint_infinite_of_infinite {α : Type} {s :
   let ⟨t,u, ⟨h1,h2,h3⟩⟩ := Set.Infinite.exists_union_disjoint_cardinal_eq_of_infinite h
   use t, u
   simp only [h1, h2, true_and]
-  repeat rw [←Set.infinite_coe_iff, Cardinal.infinite_iff]
+  repeat rw [← Set.infinite_coe_iff, Cardinal.infinite_iff]
   rw [h3, and_self]
-  rw [←Set.infinite_coe_iff, Cardinal.infinite_iff, ←h1, Cardinal.mk_union_of_disjoint h2] at h
+  rw [← Set.infinite_coe_iff, Cardinal.infinite_iff, ← h1, Cardinal.mk_union_of_disjoint h2] at h
   contrapose! h
   rw [h3]
   exact Cardinal.add_lt_aleph0 h h
@@ -256,7 +256,7 @@ theorem PNat.mk_mul_hom_fun.cancel {R : Type} [CommMonoid R]
       unfold mk_mul_hom_fun
       simp only [MulHom.coe_mk]
       suffices ((List.map g c.val.primeFactorsList).prod * (List.map g' c.val.primeFactorsList).prod) = 1 by simp [this]
-      rw [←List.prod_map_mul]
+      rw [← List.prod_map_mul]
       apply List.prod_eq_one
       aesop
 
@@ -288,7 +288,7 @@ def PRat.mk_mul_hom_fun (g : ℕ → ℚ+) : ℚ+ →* ℚ+ := {
     simp_rw [PNat.mk_mul_hom_fun.inv, Positive.coe_inv, ← Rat.div_def, PRat.mk_mul_mk, ← Subtype.coe_inj]
     field_simp
     rw [div_eq_div_iff (by simp [@Subtype.coe_eq_iff]) (by simp [@Subtype.coe_eq_iff])]
-    simp_rw [←Positive.val_mul, ←map_mul]
+    simp_rw [← Positive.val_mul, ← map_mul]
     congr 2
     simp only [Positive.val_mul]
     repeat rw [Nat.toPNat_mul_toPNat]
@@ -396,7 +396,7 @@ theorem exists_f : ∃ f : ℚ+ → ℚ+, ∀ x y : ℚ+, f (x * f y) = f x / y 
       unfold q
       simp
     · have : ¬ p.val ∈ {p | Nat.Prime p} := by
-        rw [←hU]
+        rw [← hU]
         grind only [= Set.mem_union]
       simp at this
       exact absurd p.prop this
@@ -409,14 +409,14 @@ theorem exists_f : ∃ f : ℚ+ → ℚ+, ∀ x y : ℚ+, f (x * f y) = f x / y 
       simp only [map_mul]
       rw [ih]
       simp only [one_div, mul_inv_rev]
-      rw [mul_comm, mul_left_inj, ←one_div]
+      rw [mul_comm, mul_left_inj, ← one_div]
       apply this
     · intro x p ih
       simp only [map_div]
       rw [ih]
       simp only [one_div, inv_div]
       rw [div_eq_inv_mul, div_eq_inv_mul, mul_comm, mul_right_inj]
-      rw [inv_eq_iff_eq_inv, ←one_div]
+      rw [inv_eq_iff_eq_inv, ← one_div]
       apply this
 
   use f

--- a/Compfiles/Imo1990P4.lean
+++ b/Compfiles/Imo1990P4.lean
@@ -54,7 +54,7 @@ theorem PRat.num_toNat (q : ℚ+) : q.val.num.toNat = q.val.num := by
 
 @[simp]
 theorem PRat.cast_num_toNat (q : ℚ+) : (q.val.num.toNat : ℚ) = q.val.num := by
-  nth_rw 2 [<-(@Int.natCast_toNat_eq_self (q.val.num)).mpr]
+  nth_rw 2 [←(@Int.natCast_toNat_eq_self (q.val.num)).mpr]
   · rfl
   · simp only [Rat.num_nonneg]
     apply le_of_lt
@@ -112,7 +112,7 @@ theorem PRat.prime_induction (P : ℚ+ → Prop) (base : P 1)
         let p' : Nat.Primes := ⟨p, p_prime⟩
         let x : ℚ+ := ⟨a, by {
           simp at ⊢ h2
-          rw [<-Nat.cast_mul, <-Rat.natCast_ofNat, Nat.cast_lt] at h2
+          rw [←Nat.cast_mul, ←Rat.natCast_ofNat, Nat.cast_lt] at h2
           exact Nat.pos_of_mul_pos_left h2
         }⟩
         simp_rw [show ((p.cast * a.cast) : ℚ) = x * p' by unfold x p'; ring]
@@ -130,7 +130,7 @@ theorem PRat.prime_induction (P : ℚ+ → Prop) (base : P 1)
             subst b
             simp
           · simp only [zero_mul]
-            rw [<-Nat.cast_mul, <-Nat.cast_mul, <-Rat.natCast_ofNat] at h2
+            rw [←Nat.cast_mul, ←Nat.cast_mul, ←Rat.natCast_ofNat] at h2
             refine (Rat.mul_pos_iff_of_pos_left ?_).mpr ?_
             · simp
               exact Nat.Prime.pos p_prime
@@ -143,7 +143,7 @@ theorem PRat.prime_induction (P : ℚ+ → Prop) (base : P 1)
         simp_rw [show ((p*a).cast / (q*b).cast : ℚ) = x/q' by unfold x q'; simp only [Nat.cast_mul]; field]
         apply ind_div
         unfold x
-        simp_rw [<-Nat.cast_mul]
+        simp_rw [←Nat.cast_mul]
         apply ih2
   intro x
   have := this ⟨x.val.num.toNat, x.val.den⟩ (by {
@@ -181,9 +181,9 @@ theorem f_mul_hom (f : ℚ+ → ℚ+) (h : ∀ x y : ℚ+, f (x * f y) = f x / y
   let z := 1 / f y
   have : f z = y := by
     unfold z
-    rw [one_div, <-div_eq_one, <-h1]
+    rw [one_div, ←div_eq_one, ←h1]
     exact f_one_eq_one f h
-  nth_rw 1 [<-this]
+  nth_rw 1 [←this]
   rw [h]
   unfold z
   simp
@@ -203,9 +203,9 @@ theorem Set.Infinite.exists_union_disjoint_infinite_of_infinite {α : Type} {s :
   let ⟨t,u, ⟨h1,h2,h3⟩⟩ := Set.Infinite.exists_union_disjoint_cardinal_eq_of_infinite h
   use t, u
   simp only [h1, h2, true_and]
-  repeat rw [<-Set.infinite_coe_iff, Cardinal.infinite_iff]
+  repeat rw [←Set.infinite_coe_iff, Cardinal.infinite_iff]
   rw [h3, and_self]
-  rw [<-Set.infinite_coe_iff, Cardinal.infinite_iff, <-h1, Cardinal.mk_union_of_disjoint h2] at h
+  rw [←Set.infinite_coe_iff, Cardinal.infinite_iff, ←h1, Cardinal.mk_union_of_disjoint h2] at h
   contrapose! h
   rw [h3]
   exact Cardinal.add_lt_aleph0 h h
@@ -256,7 +256,7 @@ theorem PNat.mk_mul_hom_fun.cancel {R : Type} [CommMonoid R]
       unfold mk_mul_hom_fun
       simp only [MulHom.coe_mk]
       suffices ((List.map g c.val.primeFactorsList).prod * (List.map g' c.val.primeFactorsList).prod) = 1 by simp [this]
-      rw [<-List.prod_map_mul]
+      rw [←List.prod_map_mul]
       apply List.prod_eq_one
       aesop
 
@@ -288,7 +288,7 @@ def PRat.mk_mul_hom_fun (g : ℕ → ℚ+) : ℚ+ →* ℚ+ := {
     simp_rw [PNat.mk_mul_hom_fun.inv, Positive.coe_inv, ← Rat.div_def, PRat.mk_mul_mk, ← Subtype.coe_inj]
     field_simp
     rw [div_eq_div_iff (by simp [@Subtype.coe_eq_iff]) (by simp [@Subtype.coe_eq_iff])]
-    simp_rw [<-Positive.val_mul, <-map_mul]
+    simp_rw [←Positive.val_mul, ←map_mul]
     congr 2
     simp only [Positive.val_mul]
     repeat rw [Nat.toPNat_mul_toPNat]
@@ -396,7 +396,7 @@ theorem exists_f : ∃ f : ℚ+ → ℚ+, ∀ x y : ℚ+, f (x * f y) = f x / y 
       unfold q
       simp
     · have : ¬ p.val ∈ {p | Nat.Prime p} := by
-        rw [<-hU]
+        rw [←hU]
         grind only [= Set.mem_union]
       simp at this
       exact absurd p.prop this
@@ -409,14 +409,14 @@ theorem exists_f : ∃ f : ℚ+ → ℚ+, ∀ x y : ℚ+, f (x * f y) = f x / y 
       simp only [map_mul]
       rw [ih]
       simp only [one_div, mul_inv_rev]
-      rw [mul_comm, mul_left_inj, <-one_div]
+      rw [mul_comm, mul_left_inj, ←one_div]
       apply this
     · intro x p ih
       simp only [map_div]
       rw [ih]
       simp only [one_div, inv_div]
       rw [div_eq_inv_mul, div_eq_inv_mul, mul_comm, mul_right_inj]
-      rw [inv_eq_iff_eq_inv, <-one_div]
+      rw [inv_eq_iff_eq_inv, ←one_div]
       apply this
 
   use f

--- a/Compfiles/Imo1991P6.lean
+++ b/Compfiles/Imo1991P6.lean
@@ -60,7 +60,7 @@ theorem fract_sqrt_two_mul_gt (k : ℕ) (pk : 0 < k) : Int.fract (√2 * k) > 1 
   have h_diff_pos : 2 * k ^ 2 - y ^ 2 ≥ 1 := by
     apply Int.le_of_sub_one_lt
     rify
-    rw [<-h_diff]
+    rw [←h_diff]
     nlinarith
 
   rify at h_diff_pos
@@ -115,7 +115,7 @@ theorem one_sub_fract_sqrt_two_mul_gt (k : ℕ) (kpos : 0 < k) : 1 - Int.fract (
   have h_diff_pos : (y + 1) ^ 2 - 2 * (k:ℤ) ^ 2 ≥ 1 := by
     apply Int.le_of_sub_one_lt
     rify
-    rw [<-h_diff]
+    rw [←h_diff]
     nlinarith [Int.fract_lt_one x, fract_eq]
 
   rify at h_diff_pos
@@ -130,14 +130,14 @@ theorem abs_fract_sqrt_two_mul_sub_fract_sqrt_two_mul (i j : ℕ) (hji : j < i) 
   and_intros
   · intro h
     simp only [Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.zero_mod, CharP.cast_eq_zero, add_zero] at h
-    rw [<-h, <-mul_sub, <-Nat.cast_sub (le_of_lt hji)]
+    rw [←h, ←mul_sub, ←Nat.cast_sub (le_of_lt hji)]
     apply lt_of_lt_of_le (fract_sqrt_two_mul_gt _ _) (le_abs_self _)
     exact Nat.zero_lt_sub_of_lt hji
   · intro h
     simp only [Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.mod_succ, Nat.cast_one] at h
-    rw [<-sub_eq_iff_eq_add] at h
+    rw [←sub_eq_iff_eq_add] at h
     rw [sub_eq_sub_iff_comm] at h
-    rw [abs_sub_comm, <-h, <-mul_sub, <-Nat.cast_sub (le_of_lt hji), abs_of_nonneg]
+    rw [abs_sub_comm, ←h, ←mul_sub, ←Nat.cast_sub (le_of_lt hji), abs_of_nonneg]
     · apply one_sub_fract_sqrt_two_mul_gt
       exact Nat.zero_lt_sub_of_lt hji
     · simp [le_of_lt (Int.fract_lt_one _)]
@@ -168,10 +168,10 @@ problem imo1991_p6 (a : ℝ) (ha : 1 < a) :
       have := this a ha j i inej.symm w'
       grind
     unfold solution
-    rw [<-mul_sub, abs_mul, abs_of_nonneg, <-div_le_iff₀]
+    rw [←mul_sub, abs_mul, abs_of_nonneg, ←div_le_iff₀]
     · trans 1 / |(i:ℝ) - j|
       · rw [div_le_div_iff_of_pos_left]
-        · nth_rw 1 [<-Real.rpow_one |(i:ℝ) - j|]
+        · nth_rw 1 [←Real.rpow_one |(i:ℝ) - j|]
           apply Real.rpow_le_rpow_of_exponent_le
           · rw [abs_of_nonneg] <;> {norm_cast; lia}
           · exact le_of_lt ha
@@ -182,7 +182,7 @@ problem imo1991_p6 (a : ℝ) (ha : 1 < a) :
           norm_cast
           lia
       · have := abs_fract_sqrt_two_mul_sub_fract_sqrt_two_mul i j w
-        rw [<-div_le_iff₀' (by apply add_pos <;> simp)]
+        rw [←div_le_iff₀' (by apply add_pos <;> simp)]
         apply le_trans _ (le_of_lt this)
         rw [abs_of_nonneg (by norm_cast; lia)]
         rw [div_div, div_le_div_iff_of_pos_left, mul_add]

--- a/Compfiles/Imo1991P6.lean
+++ b/Compfiles/Imo1991P6.lean
@@ -60,7 +60,7 @@ theorem fract_sqrt_two_mul_gt (k : ℕ) (pk : 0 < k) : Int.fract (√2 * k) > 1 
   have h_diff_pos : 2 * k ^ 2 - y ^ 2 ≥ 1 := by
     apply Int.le_of_sub_one_lt
     rify
-    rw [←h_diff]
+    rw [← h_diff]
     nlinarith
 
   rify at h_diff_pos
@@ -115,7 +115,7 @@ theorem one_sub_fract_sqrt_two_mul_gt (k : ℕ) (kpos : 0 < k) : 1 - Int.fract (
   have h_diff_pos : (y + 1) ^ 2 - 2 * (k:ℤ) ^ 2 ≥ 1 := by
     apply Int.le_of_sub_one_lt
     rify
-    rw [←h_diff]
+    rw [← h_diff]
     nlinarith [Int.fract_lt_one x, fract_eq]
 
   rify at h_diff_pos
@@ -130,14 +130,14 @@ theorem abs_fract_sqrt_two_mul_sub_fract_sqrt_two_mul (i j : ℕ) (hji : j < i) 
   and_intros
   · intro h
     simp only [Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.zero_mod, CharP.cast_eq_zero, add_zero] at h
-    rw [←h, ←mul_sub, ←Nat.cast_sub (le_of_lt hji)]
+    rw [← h, ← mul_sub, ← Nat.cast_sub (le_of_lt hji)]
     apply lt_of_lt_of_le (fract_sqrt_two_mul_gt _ _) (le_abs_self _)
     exact Nat.zero_lt_sub_of_lt hji
   · intro h
     simp only [Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.mod_succ, Nat.cast_one] at h
-    rw [←sub_eq_iff_eq_add] at h
+    rw [← sub_eq_iff_eq_add] at h
     rw [sub_eq_sub_iff_comm] at h
-    rw [abs_sub_comm, ←h, ←mul_sub, ←Nat.cast_sub (le_of_lt hji), abs_of_nonneg]
+    rw [abs_sub_comm, ← h, ← mul_sub, ← Nat.cast_sub (le_of_lt hji), abs_of_nonneg]
     · apply one_sub_fract_sqrt_two_mul_gt
       exact Nat.zero_lt_sub_of_lt hji
     · simp [le_of_lt (Int.fract_lt_one _)]
@@ -168,10 +168,10 @@ problem imo1991_p6 (a : ℝ) (ha : 1 < a) :
       have := this a ha j i inej.symm w'
       grind
     unfold solution
-    rw [←mul_sub, abs_mul, abs_of_nonneg, ←div_le_iff₀]
+    rw [← mul_sub, abs_mul, abs_of_nonneg, ← div_le_iff₀]
     · trans 1 / |(i:ℝ) - j|
       · rw [div_le_div_iff_of_pos_left]
-        · nth_rw 1 [←Real.rpow_one |(i:ℝ) - j|]
+        · nth_rw 1 [← Real.rpow_one |(i:ℝ) - j|]
           apply Real.rpow_le_rpow_of_exponent_le
           · rw [abs_of_nonneg] <;> {norm_cast; lia}
           · exact le_of_lt ha
@@ -182,7 +182,7 @@ problem imo1991_p6 (a : ℝ) (ha : 1 < a) :
           norm_cast
           lia
       · have := abs_fract_sqrt_two_mul_sub_fract_sqrt_two_mul i j w
-        rw [←div_le_iff₀' (by apply add_pos <;> simp)]
+        rw [← div_le_iff₀' (by apply add_pos <;> simp)]
         apply le_trans _ (le_of_lt this)
         rw [abs_of_nonneg (by norm_cast; lia)]
         rw [div_div, div_le_div_iff_of_pos_left, mul_add]

--- a/Compfiles/Imo1992P2.lean
+++ b/Compfiles/Imo1992P2.lean
@@ -41,12 +41,12 @@ problem imo1992_p2 (f : ℝ → ℝ) :
     have ht2 : ∀ x, f (x^2 + t) = (f x)^2 := fun x ↦ by
       simp only [hf, zero_add, t]
     have ht3 : ∀ x, f (f x) = x + t^2 := fun x ↦ by
-      simp only [←hf, zero_pow two_ne_zero, zero_add, t]
+      simp only [← hf, zero_pow two_ne_zero, zero_add, t]
     have ht4 :=
       calc 1 + t + 2 * t^2 + t^4
          = t + (1 + t^2)^2 := by ring
        _ = t + (f (f 1))^2 := by rw [ht3 1]
-       _ = f (t^2 + (f 1)^2) := by rw [←ht1, ←hf, add_comm]
+       _ = f (t^2 + (f 1)^2) := by rw [← ht1, ← hf, add_comm]
        _ = f (t^2 + f (1 + t)) := by rw [← ht2 1, one_pow]
        _ = 1 + t + (f t)^2 := hf t (1 + t)
        _ = 1 + t + t^4 := by rw[ht1]; ring

--- a/Compfiles/Imo1992P6.lean
+++ b/Compfiles/Imo1992P6.lean
@@ -56,7 +56,7 @@ lemma S_set_bounded (n) : ∀ k ∈ S_set n, k ≤ n^2 := by
   let kh := kh k
   simp only [le_refl, forall_const] at kh
   let ⟨s,sh1, sh2⟩ := kh
-  rw [←PNat.coe_le_coe]
+  rw [← PNat.coe_le_coe]
   norm_cast at sh1
   rw [sh1]
   calc
@@ -106,7 +106,7 @@ theorem sum_sub {α : Type} [DecidableEq α] [AddCommMonoid α] (s t : Multiset 
   · intro a t ih s h
     simp only [Multiset.sub_cons, Multiset.sum_cons]
     nth_rw 2 [add_comm]
-    rw [←add_assoc, ih]
+    rw [← add_assoc, ih]
     · rw [add_comm, Multiset.sum_erase]
       apply Multiset.mem_of_le h (by simp)
     · rw [Multiset.le_iff_exists_add] at h
@@ -127,7 +127,7 @@ theorem sub_mod {a b c : Nat} (h : b ≤ a) : (a - b) % c = (a - b % c) % c := b
   · exact Nat.div_mul_le_self b c
 
 theorem sub_mod_eq_add_mod {a b c : Nat} (h : b ≤ a) (cnz : c ≠ 0) : (a - b) % c = (a + (c - b % c)) % c := by
-  rw [←Nat.add_sub_assoc, Nat.sub_add_comm, Nat.add_mod_right]
+  rw [← Nat.add_sub_assoc, Nat.sub_add_comm, Nat.add_mod_right]
   · exact sub_mod h
   · trans b
     · exact Nat.mod_le b c
@@ -149,8 +149,8 @@ theorem imo1992_p6_a : ∀ n ≥ 4, S n ≤ n^2-14 := by
   have nge : 14 < n ^ 2 := by
     simp at nge
     suffices 4^2 ≤ n^2 by
-      rw [←PNat.coe_le_coe] at this
-      rw [←PNat.coe_lt_coe]
+      rw [← PNat.coe_le_coe] at this
+      rw [← PNat.coe_lt_coe]
       apply Nat.lt_of_add_one_le
       simp_all
       exact Nat.le_of_add_left_le this
@@ -165,8 +165,8 @@ theorem imo1992_p6_a : ∀ n ≥ 4, S n ≤ n^2-14 := by
       simp [nge']
     rw [this]
     apply (S_spec n).prop (n^2-13)
-    rw [←PNat.coe_lt_coe, PNat.sub_coe] at h
-    rw [←PNat.coe_le_coe, PNat.sub_coe]
+    rw [← PNat.coe_lt_coe, PNat.sub_coe] at h
+    rw [← PNat.coe_le_coe, PNat.sub_coe]
     simp [nge, nge'] at h ⊢
     rw [Nat.sub_lt_iff_lt_add] at h
     · exact Nat.le_of_lt_succ h
@@ -198,9 +198,9 @@ theorem imo1992_p6_a : ∀ n ≥ 4, S n ≤ n^2-14 := by
           apply pow_left_mono 2
           exact h
         _ > _ := by
-          rw [←Nat.sub_add_comm]
+          rw [← Nat.sub_add_comm]
           · simp
-            rw [←PNat.pow_coe, PNat.val]
+            rw [← PNat.pow_coe, PNat.val]
             simp
           · exact nge'
     simp at this
@@ -253,9 +253,9 @@ theorem imo1992_p6_a : ∀ n ≥ 4, S n ≤ n^2-14 := by
           rw [Finset.mem_Ioo] at hx
           lia
       _ = ∑ j ∈ {1,2,3}, Finset.card {i | s i = j} + ∑ j ∈ {1,2,3}, Finset.card {i | s i = j} * (j ^ 2 - 1) := by
-        rw [←Finset.sum_add_distrib]
-        nth_rw 1 [←Finset.sum_attach]
-        nth_rw 2 [←Finset.sum_attach]
+        rw [← Finset.sum_add_distrib]
+        nth_rw 1 [← Finset.sum_attach]
+        nth_rw 2 [← Finset.sum_attach]
         congr
         funext j
         rw [Nat.mul_sub, Nat.mul_one, Nat.add_sub_cancel']
@@ -383,7 +383,7 @@ theorem msos.sq_sum_shift (C:Multiset ℕ+) (i : ℕ+) (a : ℕ) (h4 : 4*a ≤ C
   unfold sq_sum msos.shift
   rw [Multiset.map_add, Multiset.map_replicate, Multiset.map_sub_of_injective, Multiset.sum_add]
   · rw [Multiset.map_replicate, Multiset.sum_replicate]
-    rw [←Multiset.sum_sub (Multiset.map (fun x ↦ x.val ^ 2) C) (Multiset.replicate (4 * a) (i.val ^ 2))]
+    rw [← Multiset.sum_sub (Multiset.map (fun x ↦ x.val ^ 2) C) (Multiset.replicate (4 * a) (i.val ^ 2))]
     · simp only [PNat.mul_coe, PNat.val_ofNat, smul_eq_mul, Multiset.sum_replicate,
         Nat.add_left_cancel_iff]
       grind
@@ -391,7 +391,7 @@ theorem msos.sq_sum_shift (C:Multiset ℕ+) (i : ℕ+) (a : ℕ) (h4 : 4*a ≤ C
       intro x
       rw [Multiset.count_replicate]
       split_ifs with h
-      · rw [←h, Multiset.count_map_eq_count' (fun (y:ℕ+) ↦ y.val ^ 2)]
+      · rw [← h, Multiset.count_map_eq_count' (fun (y:ℕ+) ↦ y.val ^ 2)]
         · exact h4
         · intro x1 x2 e
           simp_all
@@ -411,7 +411,7 @@ def msos.repeat_shift (C:Multiset ℕ+) : Multiset ℕ+ :=
   termination_by C.card
   decreasing_by
     expose_names
-    rw [←Nat.add_lt_add_iff_right (k:=3*a), msos.card_shift]
+    rw [← Nat.add_lt_add_iff_right (k:=3*a), msos.card_shift]
     · unfold a
       simp only [lt_add_iff_pos_right, Nat.ofNat_pos, mul_pos_iff_of_pos_left, Nat.div_pos_iff, true_and]
       suffices i ∈ C'.toFinset by simp_all only [Multiset.toFinset_filter, Finset.mem_filter, Multiset.mem_toFinset, C', i]
@@ -441,9 +441,9 @@ theorem msos.repeat_shift.forall (C:Multiset ℕ+) :
         grind
       have : b - a ≤ ((shift x i a).card - (repeat_shift (shift x i a)).card) / 3 := by
         simp
-        nth_rw 1 [←msos.card_shift _ i a] at bh <;> grind
+        nth_rw 1 [← msos.card_shift _ i a] at bh <;> grind
       obtain ⟨y, yh1, yh2⟩ := ih1 (b-a) this
-      rw [←add_left_inj (3*a), msos.card_shift] at yh2
+      rw [← add_left_inj (3*a), msos.card_shift] at yh2
       · use y
         rw [yh1, sq_sum_shift] <;> and_intros <;> grind
       · grind
@@ -485,7 +485,7 @@ theorem msos.card_repeat_shift_le (C:Multiset ℕ+) : (msos.repeat_shift C).card
             · unfold C'
               simp only [Multiset.toFinset_filter, Finset.mem_filter, Multiset.mem_toFinset, c,
                 and_true]
-              rw [←Multiset.one_le_count_iff_mem]
+              rw [← Multiset.one_le_count_iff_mem]
               exact Nat.one_le_of_lt c
             · simp
           rw [this]
@@ -519,7 +519,7 @@ theorem is_sum_of_pos_squares_by_repeat_shift (C:Multiset ℕ+) :
       · grind
       · exact (Finset.mem_Icc.mp kbs).right
     · lia
-  rw [this, ←h1]
+  rw [this, ← h1]
   apply msos.is_sum_of_pos_squares
 
 
@@ -561,12 +561,12 @@ theorem msos.count_mk (L : List (ℕ × ℕ+)) (a : ℕ+) : Multiset.count a (ms
     rw [List.filter_cons]
     by_cases c : b.2 = a
     · simp only [c, BEq.rfl, ↓reduceIte, List.map_cons, List.sum_cons]
-      rw [←ih]
+      rw [← ih]
       unfold mk
-      rw [←c]
+      rw [← c]
       simp
     · simp only [beq_iff_eq, c, reduceIte]
-      rw [←ih]
+      rw [← ih]
       unfold mk
       simp only [Multiset.empty_eq_zero, List.map_cons, List.foldr_cons, Multiset.count_add,
         Nat.add_eq_right, Multiset.count_eq_zero]
@@ -580,7 +580,7 @@ theorem sos_13_0mod3 : ∀ k:ℕ, k≠0 → k ≤ 13^2-14 → k%3=0 → is_sum_o
   by_cases lb : 9 ≤ k
   · let C := msos.mk [(151,1), (2, 3)]
     have s : msos.sq_sum C = 13^2 := by decide +kernel
-    rw [←s]
+    rw [← s]
     apply is_sum_of_pos_squares_by_repeat_shift
     · rw [Finset.mem_Icc]
       and_intros
@@ -598,16 +598,16 @@ theorem sos_13_0mod3 : ∀ k:ℕ, k≠0 → k ≤ 13^2-14 → k%3=0 → is_sum_o
     · intro keq
       let C := msos.mk [(1,3), (1, 4), (1,12)]
       have : msos.sq_sum C = 13^2 := by decide +kernel
-      rw [←this]
+      rw [← this]
       have : C.card = k := by unfold C; rw [keq]; simp
-      rw [←this]
+      rw [← this]
       apply msos.is_sum_of_pos_squares
     · intro keq
       let C := msos.mk [(4,2), (1, 3), (1,12)]
       have : msos.sq_sum C = 13^2 := by decide +kernel
-      rw [←this]
+      rw [← this]
       have : C.card = k := by unfold C; rw [keq]; simp
-      rw [←this]
+      rw [← this]
       apply msos.is_sum_of_pos_squares
 
 theorem sos_13_1mod3 : ∀ k:ℕ, k ≤ 13^2-14 → k%3=1 → is_sum_of_pos_squares (13^2) k := by
@@ -615,7 +615,7 @@ theorem sos_13_1mod3 : ∀ k:ℕ, k ≤ 13^2-14 → k%3=1 → is_sum_of_pos_squa
   by_cases lb : 7 ≤ k
   · let C := msos.mk [(149,1), (5, 2)]
     have s : msos.sq_sum C = 13^2 := by decide +kernel
-    rw [←s]
+    rw [← s]
     apply is_sum_of_pos_squares_by_repeat_shift
     · rw [Finset.mem_Icc]
       and_intros
@@ -633,16 +633,16 @@ theorem sos_13_1mod3 : ∀ k:ℕ, k ≤ 13^2-14 → k%3=1 → is_sum_of_pos_squa
     · intro keq
       let C := msos.mk [(1,13)]
       have : msos.sq_sum C = 13^2 := by decide +kernel
-      rw [←this]
+      rw [← this]
       have : C.card = k := by unfold C; rw [keq]; simp
-      rw [←this]
+      rw [← this]
       apply msos.is_sum_of_pos_squares
     · intro keq
       let C := msos.mk [(1,1), (1, 2), (1,8), (1,10)]
       have : msos.sq_sum C = 13^2 := by decide +kernel
-      rw [←this]
+      rw [← this]
       have : C.card = k := by unfold C; rw [keq]; simp
-      rw [←this]
+      rw [← this]
       apply msos.is_sum_of_pos_squares
 
 theorem sos_13_2mod3 : ∀ k:ℕ, k ≤ 13^2-14 → k%3=2 → is_sum_of_pos_squares (13^2) k := by
@@ -650,7 +650,7 @@ theorem sos_13_2mod3 : ∀ k:ℕ, k ≤ 13^2-14 → k%3=2 → is_sum_of_pos_squa
   by_cases lb : 5 ≤ k
   · let C := msos.mk [(152, 1), (2, 2), (1,3)]
     have s : msos.sq_sum C = 13^2 := by decide +kernel
-    rw [←s]
+    rw [← s]
     apply is_sum_of_pos_squares_by_repeat_shift
     · rw [Finset.mem_Icc]
       and_intros
@@ -666,9 +666,9 @@ theorem sos_13_2mod3 : ∀ k:ℕ, k ≤ 13^2-14 → k%3=2 → is_sum_of_pos_squa
   · have keq : k=2 := by lia
     let C := msos.mk [(1,5), (1,12)]
     have : msos.sq_sum C = 13^2 := by decide +kernel
-    rw [←this]
+    rw [← this]
     have : C.card = k := by unfold C; rw [keq]; simp
-    rw [←this]
+    rw [← this]
     apply msos.is_sum_of_pos_squares
 
 theorem complete_13 : complete 13 := by
@@ -686,7 +686,7 @@ theorem sos_mul_const (z k m : ℕ) (mpos : 0 < m) (h : is_sum_of_pos_squares z 
   use fun i => m * s i
   and_intros
   · simp_rw [mul_pow]
-    rw [←Finset.mul_sum, ←sh1, mul_comm]
+    rw [← Finset.mul_sum, ← sh1, mul_comm]
   · intro i
     simp [sb i, mpos]
 
@@ -724,7 +724,7 @@ theorem sos_mul (z1 z2 k1 k2: ℕ) (h1 : is_sum_of_pos_squares z1 k1) (h2 : is_s
       unfold f
       simp_rw [mul_pow, implies_true]
     simp_rw [this]
-    rw [←Finset.sum_fiberwise (ι:=Fin (k1*k2)) _ (fun x => (equi x).1)]
+    rw [← Finset.sum_fiberwise (ι:=Fin (k1*k2)) _ (fun x => (equi x).1)]
     congr
     funext i
     rw [Eq.comm]
@@ -760,7 +760,7 @@ theorem sos_split (z k: ℕ) (kb : 1 ≤ k) (h : is_sum_of_pos_squares z k) : �
     · simp
       rw [Nat.sub_eq_iff_eq_add]
       · rw [sh]
-        rw [←Finset.sum_erase_add (a:=⟨k-1, by grind⟩) _ _ (by simp)]
+        rw [← Finset.sum_erase_add (a:=⟨k-1, by grind⟩) _ _ (by simp)]
         rw [Nat.add_right_cancel_iff]
         apply Finset.sum_bij' (fun i _ => ⟨i.val, by grind⟩) (fun i _ => i.castLT (by grind)) <;> simp
         intro i
@@ -790,7 +790,7 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
   by_cases c : k1*k2 ≤ k
   · generalize Ndef : ((n1 * n2).val ^ 2) = N
     have N_lb : (13*13)^2 ≤ N := by
-      rw [←Ndef, PNat.mul_coe]
+      rw [← Ndef, PNat.mul_coe]
       exact Nat.pow_le_pow_left n1n2_lb 2
     have h14 : 3*N ≤ 4 * (n1 ^ 2 - 14).val * (n2 ^ 2 - 14).val := by
       qify
@@ -798,12 +798,12 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
       · simp only [PNat.pow_coe, Nat.cast_pow, PNat.val_ofNat, Nat.cast_ofNat]
         ring_nf
         have : n1.val ^ 2 * n2.val ^ 2 = (N : ℚ) := by
-          rw [←Ndef]
+          rw [← Ndef]
           simp [mul_pow]
         rw [this]
         suffices n1 ^ 2 * 56 + n2 ^ 2 * 56 ≤ 784 + (N : ℚ) by linarith
         suffices N/(n1^2) * 56 + N/(n2^2) * 56 ≤ 784 + (N : ℚ) by
-          rw [←Ndef] at this ⊢
+          rw [← Ndef] at this ⊢
           simp only [PNat.mul_coe, mul_pow, Nat.cast_mul, Nat.cast_pow, ne_eq, OfNat.ofNat_ne_zero,
             not_false_eq_true, pow_eq_zero_iff, Nat.cast_eq_zero, PNat.ne_zero, mul_div_cancel_left₀,
             isUnit_iff_ne_zero, IsUnit.mul_div_cancel_right] at this
@@ -820,12 +820,12 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
                 · simp
                 · simp
                 · apply Nat.ofNat_le_cast.mpr
-                  rw [←PNat.val_ofNat, PNat.coe_le_coe]
+                  rw [← PNat.val_ofNat, PNat.coe_le_coe]
                   simp [lb1, lb2]
             }
           _ ≤ (N : ℚ) := by
             ring_nf
-            rw [←mul_div_assoc, div_le_iff₀]
+            rw [← mul_div_assoc, div_le_iff₀]
             · apply Rat.mul_le_mul_of_nonneg_left rfl
               simp
             · simp
@@ -837,7 +837,7 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
           exact lb2
       · intro h
         contrapose! h
-        rw [←PNat.coe_lt_coe]
+        rw [← PNat.coe_lt_coe]
         apply Nat.lt_of_succ_le
         trans 13^2
         · simp
@@ -849,7 +849,7 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
           exact lb1
       · intro h
         contrapose! h
-        rw [←PNat.coe_lt_coe]
+        rw [← PNat.coe_lt_coe]
         apply Nat.lt_of_succ_le
         trans 13^2
         · simp
@@ -859,7 +859,7 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
     have C1_card : C1.card = N-14 := by
       unfold C1
       simp only [msos.card_mk, List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero, Nat.reduceAdd]
-      rw [←Nat.sub_add_comm]
+      rw [← Nat.sub_add_comm]
       · simp
       · apply le_trans (by simp) N_lb
     have C1_sq_sum : msos.sq_sum C1 = N := by
@@ -872,7 +872,7 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
     have C2_card : C2.card = N-15 := by
       unfold C2
       simp only [msos.card_mk, List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
-      rw [←Nat.sub_add_comm]
+      rw [← Nat.sub_add_comm]
       · simp
       · apply le_trans (by simp) N_lb
     have C2_sq_sum : msos.sq_sum C2 = N := by
@@ -885,7 +885,7 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
     have C3_card : C3.card = N-16 := by
       unfold C3
       simp only [msos.card_mk, List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
-      rw [←Nat.sub_add_comm]
+      rw [← Nat.sub_add_comm]
       · simp
       · apply le_trans (by simp) N_lb
     have C3_sq_sum : msos.sq_sum C3 = N := by
@@ -895,23 +895,23 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
       apply Nat.sub_add_cancel
       · apply le_trans (by simp) N_lb
     have kb' : k ≤ N - 14 := by
-      rw [←PNat.coe_le_coe] at kb
-      rw [←Ndef]
+      rw [← PNat.coe_le_coe] at kb
+      rw [← Ndef]
       rw [PNat.sub_coe, ite_eq_left_iff.mpr] at kb
       · exact kb
       · intro h
         contrapose h
         apply PNat.add_one_le_iff.mp
-        rw [←PNat.coe_le_coe]
+        rw [← PNat.coe_le_coe]
         trans (13*13)^2
         · simp
         · rw [PNat.pow_coe, PNat.mul_coe]
           exact Nat.pow_le_pow_left n1n2_lb 2
     unfold k1 k2 at c
-    rw [←PNat.coe_le_coe, PNat.mul_coe] at c
+    rw [← PNat.coe_le_coe, PNat.mul_coe] at c
     have : k.val%3 = (N-14)%3 ∨ k.val%3 = (N-15)%3 ∨ k.val%3 = (N-16)%3 := by lia
     apply this.elim3
-    · rw [←C1_card, ←C1_sq_sum]
+    · rw [← C1_card, ← C1_sq_sum]
       apply is_sum_of_pos_squares_by_repeat_shift
       rw [Finset.mem_Icc]
       and_intros
@@ -923,15 +923,15 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
           OfNat.ofNat_ne_one, not_false_eq_true, List.filter_cons_of_neg, List.filter_nil,
           List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero, tsub_le_iff_right]
         apply le_of_mul_le_mul_left (a:=4) _ (by simp)
-        rw [mul_add, mul_add, ←mul_assoc]
-        rw [←add_le_add_iff_left N] at h14
+        rw [mul_add, mul_add, ← mul_assoc]
+        rw [← add_le_add_iff_left N] at h14
         trans N+3*N
         · grind
         · apply le_trans h14
           lia
       · rw [C1_card]
         exact kb'
-    · rw [←C2_card, ←C2_sq_sum]
+    · rw [← C2_card, ← C2_sq_sum]
       intro m
       apply is_sum_of_pos_squares_by_repeat_shift _ _ _ m
       rw [Finset.mem_Icc]
@@ -944,15 +944,15 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
           OfNat.ofNat_ne_one, not_false_eq_true, List.filter_cons_of_neg, List.filter_nil,
           List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero, tsub_le_iff_right]
         apply le_of_mul_le_mul_left (a:=4) _ (by simp)
-        rw [mul_add, mul_add, ←mul_assoc]
-        rw [←add_le_add_iff_left N] at h14
+        rw [mul_add, mul_add, ← mul_assoc]
+        rw [← add_le_add_iff_left N] at h14
         trans N+3*N
         · grind
         · apply le_trans h14
           lia
       · rw [C2_card] at m ⊢
         lia
-    · rw [←C3_card, ←C3_sq_sum]
+    · rw [← C3_card, ← C3_sq_sum]
       intro m
       apply is_sum_of_pos_squares_by_repeat_shift _ _ _ m
       rw [Finset.mem_Icc]
@@ -965,8 +965,8 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
           OfNat.ofNat_ne_one, not_false_eq_true, List.filter_cons_of_neg, List.filter_nil,
           List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero, tsub_le_iff_right]
         apply le_of_mul_le_mul_left (a:=4) _ (by simp)
-        rw [mul_add, mul_add, ←mul_assoc]
-        rw [←add_le_add_iff_left N] at h14
+        rw [mul_add, mul_add, ← mul_assoc]
+        rw [← add_le_add_iff_left N] at h14
         trans N+3*N
         · grind
         · apply le_trans h14
@@ -1003,7 +1003,7 @@ theorem complete_mul (n1 n2) (lb1 : 13 ≤ n1) (lb2 : 13 ≤ n2) (n1h : complete
         · show (k:ℕ) - (k.natPred/k2.val)*k2 ≤ (k2 : ℕ)
           simp only [tsub_le_iff_right, PNat.natPred]
           rw [Nat.div_mul_self_eq_mod_sub_self]
-          rw [←Nat.add_sub_assoc, Nat.sub_add_comm, ←Nat.sub_le_iff_le_add, Nat.sub_sub_self, Nat.le_sub_iff_add_le, Nat.one_add_le_iff]
+          rw [← Nat.add_sub_assoc, Nat.sub_add_comm, ← Nat.sub_le_iff_le_add, Nat.sub_sub_self, Nat.le_sub_iff_add_le, Nat.one_add_le_iff]
           · apply Nat.mod_lt
             simp
           · apply le_of_lt
@@ -1053,7 +1053,7 @@ theorem imo1992_p6_c : {n | S n = n^2 - 14}.Infinite := by
   · intro e' e'pos ih
     rw [pow_add]
     apply complete_mul
-    · nth_rw 1 [←pow_one 13]
+    · nth_rw 1 [← pow_one 13]
       apply pow_right_monotone (by simp)
       exact Nat.one_le_of_lt e'pos
     · simp

--- a/Compfiles/Imo1993P1.lean
+++ b/Compfiles/Imo1993P1.lean
@@ -38,7 +38,7 @@ problem imo1993_p1 : ∀ n > 1, ¬∃ p q : ℤ[X], f n = p*q ∧ ¬ isConstant 
   unfold f at fprod
 
   have h1 : (b.eval 0) * (c.eval 0) = 3 := by
-    rw [←eval_mul, ←fprod]
+    rw [← eval_mul, ← fprod]
     simp only [eval_add, eval_pow, eval_X, eval_mul, eval_ofNat, add_eq_right]
     rw [zero_pow, zero_pow]
     · simp
@@ -92,9 +92,9 @@ problem imo1993_p1 : ∀ n > 1, ¬∃ p q : ℤ[X], f n = p*q ∧ ¬ isConstant 
 
   have h2 : ∀ i, 0 < i → i < n-1 → (b*c).coeff i = 0 := by
     intro i ibd1 ibd2
-    rw [←fprod]
+    rw [← fprod]
     simp only [coeff_add, coeff_X_pow, coeff_ofNat_mul, mul_ite, mul_one, mul_zero]
-    rw [←C_ofNat, coeff_C]
+    rw [← C_ofNat, coeff_C]
     repeat rw [ite_eq_right_iff.mpr (by grind)]
     rfl
 
@@ -119,12 +119,12 @@ problem imo1993_p1 : ∀ n > 1, ¬∃ p q : ℤ[X], f n = p*q ∧ ¬ isConstant 
             simp
           _ = - (∑ x ∈ Finset.antidiagonal i, c.coeff (x.1 + 1) * b.coeff x.2) % 3 := by
             rw [add_eq_zero_iff_eq_neg] at h2
-            rw [←h2]
+            rw [← h2]
           _ = (∑ x ∈ Finset.antidiagonal i, (- c.coeff (x.1 + 1)) * b.coeff x.2) % 3 := by
-            rw [←Finset.sum_neg_distrib]
+            rw [← Finset.sum_neg_distrib]
             simp_rw [neg_mul]
           _ = (∑ x ∈ Finset.antidiagonal i, ((- c.coeff (x.1 + 1)) * b.coeff x.2)%3) % 3 := by
-            rw [←Finset.sum_int_mod]
+            rw [← Finset.sum_int_mod]
           _ = (∑ x ∈ Finset.antidiagonal i, (((- c.coeff (x.1 + 1)) % 3) * (b.coeff x.2 % 3))%3) % 3 := by
             simp_rw [Int.mul_emod _ (b.coeff _)]
           _ = 0 % 3 := by
@@ -132,7 +132,7 @@ problem imo1993_p1 : ∀ n > 1, ¬∃ p q : ℤ[X], f n = p*q ∧ ¬ isConstant 
             apply Finset.sum_eq_zero
             intro x xh
             suffices b.coeff x.2 % 3 = 0 by simp [this]
-            rw [←Int.dvd_iff_emod_eq_zero]
+            rw [← Int.dvd_iff_emod_eq_zero]
             rw [Finset.mem_antidiagonal] at xh
             apply ih <;> lia
           _ = _ := by simp
@@ -150,12 +150,12 @@ problem imo1993_p1 : ∀ n > 1, ¬∃ p q : ℤ[X], f n = p*q ∧ ¬ isConstant 
         intro x xh
         rw [Int.mul_emod]
         suffices b.coeff x.2 % 3 = 0 by simp [this]
-        rw [←Int.dvd_iff_emod_eq_zero]
+        rw [← Int.dvd_iff_emod_eq_zero]
         apply h3
         rw [Finset.mem_antidiagonal] at xh
         grind
       _ = _ := by
-        rw [←fprod]
+        rw [← fprod]
         simp only [coeff_add, coeff_X_pow, coeff_ofNat_mul, mul_ite, mul_one, mul_zero,
           coeff_ofNat_succ, add_zero]
         rw [ite_eq_right_iff.mpr (by grind)]
@@ -185,17 +185,17 @@ problem imo1993_p1 : ∀ n > 1, ¬∃ p q : ℤ[X], f n = p*q ∧ ¬ isConstant 
       exact compareOfLessAndEq_eq_lt.mp rfl
 
   have degbc : (b*c).degree = n := by
-    rw [←fprod]
+    rw [← fprod]
     rw [degree_add_eq_left_of_degree_lt, degree_add_eq_left_of_degree_lt]
     · exact degree_X_pow n
     · rw [degree_X_pow, degree_mul_X_pow]
-      rw [←C_ofNat, degree_C (by simp)]
+      rw [← C_ofNat, degree_C (by simp)]
       simp [Nat.zero_lt_of_lt n_gt_1]
-    · rw [←C_ofNat, degree_C (by simp)]
+    · rw [← C_ofNat, degree_C (by simp)]
       rw [degree_add_eq_left_of_degree_lt]
       · simp [Nat.zero_lt_of_lt n_gt_1]
       · rw [degree_X_pow, degree_mul_X_pow]
-        rw [←C_ofNat, degree_C (by simp)]
+        rw [← C_ofNat, degree_C (by simp)]
         simp [Nat.zero_lt_of_lt n_gt_1]
 
   have degbc : (b*c).natDegree = n := by
@@ -216,17 +216,17 @@ problem imo1993_p1 : ∀ n > 1, ¬∃ p q : ℤ[X], f n = p*q ∧ ¬ isConstant 
 
   have mc : IsUnit c.leadingCoeff := by
     have : (b*c).leadingCoeff = 1 := by
-      rw [←fprod]
+      rw [← fprod]
       rw [leadingCoeff_add_of_degree_lt', leadingCoeff_add_of_degree_lt']
       · exact leadingCoeff_X_pow n
       · rw [degree_X_pow, degree_mul_X_pow]
-        rw [←C_ofNat, degree_C (by simp)]
+        rw [← C_ofNat, degree_C (by simp)]
         simp [Nat.zero_lt_of_lt n_gt_1]
-      · rw [←C_ofNat, degree_C (by simp)]
+      · rw [← C_ofNat, degree_C (by simp)]
         rw [degree_add_eq_left_of_degree_lt]
         · simp [Nat.zero_lt_of_lt n_gt_1]
         · rw [degree_X_pow, degree_mul_X_pow]
-          rw [←C_ofNat, degree_C (by simp)]
+          rw [← C_ofNat, degree_C (by simp)]
           simp [Nat.zero_lt_of_lt n_gt_1]
     rw [Int.isUnit_iff]
     rw [leadingCoeff_mul, Int.mul_eq_one_iff_eq_one_or_neg_one] at this
@@ -264,7 +264,7 @@ problem imo1993_p1 : ∀ n > 1, ¬∃ p q : ℤ[X], f n = p*q ∧ ¬ isConstant 
         rw [eval_mul, xr]
         simp
       _ = (x ^ n + 5 * x ^ (n - 1) + 3) % 2 := by
-        rw [←fprod]
+        rw [← fprod]
         simp
       _ = (x * x ^ (n - 2) * (x+5) + 3) % 2 := by
         congr 1

--- a/Compfiles/Imo1995P2.lean
+++ b/Compfiles/Imo1995P2.lean
@@ -78,22 +78,22 @@ problem imo1995_p2 (a b c : ℝ) (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
           _ = √(x * (x * x)) := by rw [naive']
 
       have ha' : √((b + c)⁻¹ * (a ^ 3)⁻¹) * √(a * (b + c)) = 1 / a := by
-        rw [mul_comm, ←mul_inv, Real.sqrt_inv]
+        rw [mul_comm, ← mul_inv, Real.sqrt_inv]
         field_simp
         rw [Real.sqrt_mul (by positivity), Real.sqrt_mul (by positivity),
-            ←mul_assoc, helper a ha]
+            ← mul_assoc, helper a ha]
 
       have hb' : √((c + a)⁻¹ * (b ^ 3)⁻¹) * √(b * (c + a)) = 1 / b := by
-        rw [mul_comm, ←mul_inv, Real.sqrt_inv]
+        rw [mul_comm, ← mul_inv, Real.sqrt_inv]
         field_simp
         rw [Real.sqrt_mul (by positivity), Real.sqrt_mul (by positivity),
-            ←mul_assoc, helper b hb]
+            ← mul_assoc, helper b hb]
 
       have hc' : √((a + b)⁻¹ * (c ^ 3)⁻¹) * √(c * (a + b)) = 1 / c := by
-        rw [mul_comm, ←mul_inv, Real.sqrt_inv]
+        rw [mul_comm, ← mul_inv, Real.sqrt_inv]
         field_simp
         rw [Real.sqrt_mul (by positivity), Real.sqrt_mul (by positivity),
-            ←mul_assoc, helper c hc]
+            ← mul_assoc, helper c hc]
 
       rw [ha', hb', hc']
       ring

--- a/Compfiles/Imo1996P3.lean
+++ b/Compfiles/Imo1996P3.lean
@@ -61,7 +61,7 @@ problem imo1996_p3 (f : ℕ → ℕ) :
     have h3 : ∀ x, k ∣ f x := fun x ↦ by
       rw [hf1]
       dsimp only
-      rw [←Nat.add_mul]
+      rw [← Nat.add_mul]
       exact Nat.dvd_mul_left _ _
 
     -- Then f(f(m)) = f(m)
@@ -84,7 +84,7 @@ problem imo1996_p3 (f : ℕ → ℕ) :
                  dvd_refl, Nat.mod_mod_of_dvd]
       have h7 : k ∣ b * k + n1 s * k := by apply Nat.dvd_add <;> simp
       rw [Nat.add_div_of_dvd_left h7]
-      rw [←Nat.add_mul b]
+      rw [← Nat.add_mul b]
       rw [Nat.mul_div_left (b + n1 s) hkp, Nat.add_mul]
       ring
 
@@ -134,7 +134,7 @@ problem imo1996_p3 (f : ℕ → ℕ) :
     | zero => simp only [hf0, zero_mul]
     | succ q ih =>
       rw [Nat.add_mul, one_mul]
-      nth_rw 2 [←hfk]
+      nth_rw 2 [← hfk]
       rw [hf, ih, hfk]
 
   have h4 : ∀ n, f n = n → k ∣ n := fun n hn ↦ by
@@ -172,10 +172,10 @@ problem imo1996_p3 (f : ℕ → ℕ) :
   constructor
   · simp[hf0]
   ext x
-  nth_rw 1 [←Nat.div_add_mod x k]
+  nth_rw 1 [← Nat.div_add_mod x k]
   have h11 := h3 (x / k)
   nth_rw 2 [mul_comm] at h11
-  rw [←h11, add_comm _ (x % k), hf, h3]
+  rw [← h11, add_comm _ (x % k), hf, h3]
   have h12 : f (x % k) / k * k = f (x % k) := Nat.div_mul_cancel (h10 (x % k))
   rw [h12]
   ring

--- a/Compfiles/Imo1996P6.lean
+++ b/Compfiles/Imo1996P6.lean
@@ -115,11 +115,11 @@ problem imo1996_p6 {p q n : ℕ} (x : ℕ → ℤ)
       intro i hi
       cases' h₇ i hi with hp hq
       · left
-        rwa [hx' i (Nat.le_of_succ_le hi), hx' (i + 1) (Order.add_one_le_iff.mpr hi), hp', ←sub_mul, Nat.cast_mul,
+        rwa [hx' i (Nat.le_of_succ_le hi), hx' (i + 1) (Order.add_one_le_iff.mpr hi), hp', ← sub_mul, Nat.cast_mul,
             mul_right_cancel_iff_of_pos (Int.natCast_pos.mpr h_w_pos)] at hp
       · right
-        rwa [hx' i (Nat.le_of_succ_le hi), hx' (i + 1) (Order.add_one_le_iff.mpr hi), hq', ←sub_mul, Nat.cast_mul,
-            ←neg_mul, mul_right_cancel_iff_of_pos (Int.natCast_pos.mpr h_w_pos)] at hq
+        rwa [hx' i (Nat.le_of_succ_le hi), hx' (i + 1) (Order.add_one_le_iff.mpr hi), hq', ← sub_mul, Nat.cast_mul,
+            ← neg_mul, mul_right_cancel_iff_of_pos (Int.natCast_pos.mpr h_w_pos)] at hq
 
     -- Now use recursion to prove it for the reduced problem
     have h_ind := imo1996_p6 x' h₁' h₂' h₃ h₄' h₅' h₆' h₇'
@@ -174,7 +174,7 @@ problem imo1996_p6 {p q n : ℕ} (x : ℕ → ℤ)
     rw [hk, mul_comm, mul_assoc] at h_rp_eq_sq
     have : r = k * q := Nat.eq_of_mul_eq_mul_left h₁ h_rp_eq_sq
     rw [mul_comm] at this
-    simp [h_eq_add, hk, this, ←add_mul, add_comm]
+    simp [h_eq_add, hk, this, ← add_mul, add_comm]
 
   have h_k_dvd_n : k ∣ n := Dvd.intro_left (p + q) h_p_add_q_mul_k_eq_n
   obtain ⟨h, hh⟩ := h_k_dvd_n
@@ -227,7 +227,7 @@ problem imo1996_p6 {p q n : ℕ} (x : ℕ → ℤ)
       · rw [h_gihp, h_giq]
         simp [h_h_eq_p_add_q]
     · cases' h_gi with h_gip h_giq
-      · rw [h_gihq, h_gip, ←neg_sub]
+      · rw [h_gihq, h_gip, ← neg_sub]
         simp [h_h_eq_p_add_q]
       · rw [h_gihq, h_giq]
         simp
@@ -281,7 +281,7 @@ problem imo1996_p6 {p q n : ℕ} (x : ℕ → ℤ)
     have h_di_delta_t_minus_1 := h_di_delta (t - 1) (Nat.sub_lt_right_of_lt_add h_t_pos h_t_lt_nh)
     simp [Nat.sub_add_cancel h_t_pos] at h_di_delta_t_minus_1
     have : d t - d (t - 1) = (v - w) * ↑h := by
-      rw [hv, hw, ←sub_mul]
+      rw [hv, hw, ← sub_mul]
     repeat rw [this] at h_di_delta_t_minus_1
     have h_h_ne : (h : ℤ) ≠ 0 := Int.natCast_ne_zero_iff_pos.mpr h_pos
     rcases h_di_delta_t_minus_1 with h_zero | h_eq_h | h_eq_neg_h

--- a/Compfiles/Imo1998P3.lean
+++ b/Compfiles/Imo1998P3.lean
@@ -288,7 +288,7 @@ lemma d_of_factorization (t : ℕ) (ps exps : List ℕ)
             exact (Nat.pow_right_inj hp₂prime.two_le).mp heq
           · intro heq
             have hpowdvd : p₁ ∣ p₂ ^ k₂ := by
-              rw [←heq]
+              rw [← heq]
               exact Nat.div_pow_of_pos p₁ k₁ hk₁gt0
             have hdvd : p₁ ∣ p₂ := Nat.Prime.dvd_of_dvd_pow hp₁prime hpowdvd
             have heq2 : p₁ = p₂ := (Nat.prime_dvd_prime_iff_eq hp₁prime hp₂prime).mp hdvd
@@ -409,7 +409,7 @@ theorem odd_k_satisfies (k : ℕ)
             dsimp [C]
             rw [Nat.mul_sub_left_distrib, Nat.mul_one]
             rw [Nat.sub_sub]
-            rw [←hkkeqjt]
+            rw [← hkkeqjt]
             rw [Nat.add_sub_add_right]
             apply Nat.sub_pos_of_lt
             exact hjltkk
@@ -423,7 +423,7 @@ theorem odd_k_satisfies (k : ℕ)
             obtain ⟨p, k, hpk⟩ := hnin
             have hpinps : p ∈ ps := (List.of_mem_zip hpk.left).left
             have hpcoprime : Nat.Coprime p nⱼ := (hps.left p hpinps).right.right
-            rw [←hpk.right]
+            rw [← hpk.right]
             apply Nat.Coprime.pow_left
             exact hpcoprime
           have hxneq0 : x ≠ 0 := by
@@ -459,7 +459,7 @@ theorem odd_k_satisfies (k : ℕ)
             simp
             dsimp [C]
             rw [Nat.mul_sub_right_distrib, Nat.mul_sub_left_distrib, Nat.mul_one]
-            rw [Nat.mul_sub_right_distrib, mul_assoc j, ←pow_add]
+            rw [Nat.mul_sub_right_distrib, mul_assoc j, ← pow_add]
             rw [Nat.mul_add, Nat.mul_one]
             rw [mul_comm (2^i) j]
             grind
@@ -501,7 +501,7 @@ theorem odd_k_satisfies (k : ℕ)
             dsimp [C]
             rw [mul_comm 2, mul_assoc, mul_comm (2 ^ i) 2, (pow_succ' 2 i).symm]
             rw [Nat.mul_sub_right_distrib, Nat.mul_sub_left_distrib, Nat.mul_one]
-            rw [Nat.mul_sub_right_distrib, mul_assoc j, ←pow_add]
+            rw [Nat.mul_sub_right_distrib, mul_assoc j, ← pow_add]
             grind
           have htelescopes : d (x ^ 2) * j = d x * (2 ^ t * j - 1) := by
             have h : d (x ^ 2) * (2 ^ t * j - (j + 1) + 1) =
@@ -520,7 +520,7 @@ theorem odd_k_satisfies (k : ℕ)
                 simp [f, hneqdx]; rw [two_mul]
               rw [h1.symm, h2.symm]
               rw [mul_comm _ (f 0)]
-              rw [←List.prod_cons]
+              rw [← List.prod_cons]
               have hlhs : f 0 :: List.map (f ∘ Nat.succ) (List.range t) =
                         List.map f (List.range (t + 1)) := by
                 rw [List.range_succ_eq_map, List.map_cons, List.map_map]
@@ -546,7 +546,7 @@ theorem odd_k_satisfies (k : ℕ)
               ring
             have hden : 2 ^ t * j - (j + 1) + 1 = j * (2 ^ t - 1) := by grind
             rw [hfactor, hden] at h
-            rw [←mul_assoc, ←mul_assoc] at h
+            rw [← mul_assoc, ← mul_assoc] at h
             apply Nat.eq_of_mul_eq_mul_right _
             · exact h
             · apply Nat.sub_pos_of_lt

--- a/Compfiles/Imo2001P1.lean
+++ b/Compfiles/Imo2001P1.lean
@@ -412,7 +412,7 @@ lemma BOC_non_collinear : ¬Collinear ℝ {cfg.B, cfg.O, cfg.C} := by
   rw [angle_comm] at h₁
   rw [angle_eq_abs_oangle_toReal (A_ne_B cfg).symm (A_ne_C cfg).symm] at h₁
   have h₂ := aux₄ h h₁
-  rw [←angle_eq_abs_oangle_toReal (A_ne_B cfg).symm (A_ne_C cfg).symm] at h₂
+  rw [← angle_eq_abs_oangle_toReal (A_ne_B cfg).symm (A_ne_C cfg).symm] at h₂
   apply angle_in_ABC_pos cfg (1 : Fin 3) 0 2 (by decide)
   exact h₂
 

--- a/Compfiles/Imo2001P3.lean
+++ b/Compfiles/Imo2001P3.lean
@@ -98,7 +98,7 @@ lemma card_not_easy_le_210 {α β : Type} [Fintype α] [Fintype β]
       gcongr with i
       rw [sum_const, smul_eq_mul]
       exact mul_le_mul_left (card_not_easy_le_five hcard_α (hA _) (hB _)) _
-    _ = _ := by simp [←hcard_β]
+    _ = _ := by simp [← hcard_β]
 
 snip end
 
@@ -118,7 +118,7 @@ problem imo2001_p3
   have cG := card_not_easy_le_210 hcard_girl hcard_boy B_le_6 B_inter_G
   rw [← card_map ⟨_, Prod.swap_injective⟩] at cG
   have key := (card_union_le _ _).trans (add_le_add cB cG) |>.trans_lt
-    (show _ < #(@univ (Girl × Boy) _) by simp [←hcard_boy, ←hcard_girl])
+    (show _ < #(@univ (Girl × Boy) _) by simp [← hcard_boy, ← hcard_girl])
   obtain ⟨⟨i, j⟩, -, hij⟩ := exists_mem_notMem_of_card_lt_card key
   simp_rw [mem_union, mem_map, mem_filter, mem_univ, Function.Embedding.coeFn_mk, Prod.exists,
     Prod.swap_prod_mk, Prod.mk.injEq, existsAndEq, true_and, and_true, not_or, not_exists,

--- a/Compfiles/Imo2002P5.lean
+++ b/Compfiles/Imo2002P5.lean
@@ -64,7 +64,7 @@ lemma extend_function_mono
     obtain ⟨z, h_z_lt_x, hxz, zpos⟩ := this
     -- then dist (f z) (f x) < ε.
     have hbzb := hδ z hxz
-    rw [←h z] at hbzb
+    rw [← h z] at hbzb
     have huzuy : u x < u z := by
       have hufp : u x - f x < 0 := by linarith
       have hua : ε = -(u x - f x) := abs_of_neg hufp
@@ -88,7 +88,7 @@ lemma extend_function_mono
     obtain ⟨z, h_x_lt_z, hxz⟩ := this
     -- then dist (f z) (f y) < ε.
     have hbzb := hδ z hxz
-    rw [←h z] at hbzb
+    rw [← h z] at hbzb
     have huzuy : u z < u x := by
       have hufp : 0 < u x - f x := by linarith
       have hua : ε = u x - f x := abs_of_pos hufp
@@ -166,14 +166,14 @@ problem imo2002_p5 (f : ℝ → ℝ) :
       · rw [h7, h1]
     have h8 : |x| = (Real.sqrt |x|)^2 := by
       exact (Real.sq_sqrt (by positivity)).symm
-    rw [h6, h8, sq, h4, ←sq]
+    rw [h6, h8, sq, h4, ← sq]
     positivity
   have h6 : ∀ v u, 0 ≤ v → v ≤ u → f v ≤ f u := by
     intro v u hv0 hvu
     have h7 : ∀ x y, (f x + f y)^2 = f (x^2 + y^2) := fun x y ↦ by
       have h8 := hf x y y x
       have h9 : x * y - y * x = 0 := by ring
-      rw [h9, h3, zero_add, ←sq, ←sq] at h8
+      rw [h9, h3, zero_add, ← sq, ← sq] at h8
       linarith only [h8]
     have h8 := h7 (Real.sqrt v) (Real.sqrt (u - v))
     have h9 : 0 ≤ u - v := sub_nonneg_of_le hvu
@@ -183,23 +183,23 @@ problem imo2002_p5 (f : ℝ → ℝ) :
     have h10 : (f √v) ^2 + (f √(u - v))^2 + 2 * f √v * f √(u - v) =
               (f √v + f √(u - v)) ^ 2 := by ring
     have h11 : (f √v) ^2 ≤ (f √v + f √(u - v)) ^ 2 := by
-      rw[←h10]
+      rw[← h10]
       have h12 := h5 (√v)
       have h13 := h5 (√(u - v))
       nlinarith
-    rw [h8, sq, ←h4, ←sq, Real.sq_sqrt (by positivity)] at h11
+    rw [h8, sq, ← h4, ← sq, Real.sq_sqrt (by positivity)] at h11
     exact h11
   ext x
   wlog h7 : 0 ≤ x generalizing x with H
   · have h8 := H (-x) (by linarith)
-    rw [←h1] at h8
+    rw [← h1] at h8
     rw [h8]
     exact neg_pow_two x
   -- For the rest of the proof we follow John Scholes
   -- https://prase.cz/kalva/imo/isoln/isoln025.html
   have h8 : f 1 = 1 := by
     have h9 := hf 0 1 1 1
-    simp [h3, ←h1] at h9
+    simp [h3, ← h1] at h9
     have h10 : f 1 + f 1 ≠ 0 := by
       intro H
       have h11 : f 1 = 0 := by linarith only [H]
@@ -222,17 +222,17 @@ problem imo2002_p5 (f : ℝ → ℝ) :
   have h10 : ∀ z : ℤ, f z = z^2 := fun z ↦ by
     obtain ⟨m, rfl | hm⟩ := Int.eq_nat_or_neg z
     · norm_cast at h9 ⊢; rw [h9]
-    · rw[hm]; push_cast; rw[←h1, h9]; simp only [even_two, Even.neg_pow]
+    · rw[hm]; push_cast; rw[← h1, h9]; simp only [even_two, Even.neg_pow]
   have h11 : ∀ q : ℚ, f q = q^2 := fun q ↦ by
     have h12 := h4 q q.den
     rw [h9] at h12
     have h13 : q * q.den = q.num := Rat.mul_den_eq_num q
     have h14 : (((q * (q.den : ℚ)):ℚ):ℝ) = (q:ℝ) * (q.den:ℝ) := by norm_cast
-    rw [←h14, h13, Rat.cast_intCast] at h12
+    rw [← h14, h13, Rat.cast_intCast] at h12
     rw [h10] at h12
     have h16 : (q.num:ℝ)^2 / (q.den : ℝ)^2 = q^2 := by
       rw [Rat.cast_def q]; field_simp
-    rw [←h16]
+    rw [← h16]
     have h17 : (q.den : ℝ)^2 ≠ 0 := by positivity
     exact eq_div_of_mul_eq h17 h12.symm
   obtain rfl | h7' :=  h7.eq_or_lt

--- a/Compfiles/Imo2006P4.lean
+++ b/Compfiles/Imo2006P4.lean
@@ -54,7 +54,7 @@ problem imo2006_p4 :
         · rw [Int.cast_pow] at h
           apply sq_lt_sq.mp at h
           norm_cast at h
-        · rw [Int.natAbs_sq, Int.cast_pow, ←h]
+        · rw [Int.natAbs_sq, Int.cast_pow, ← h]
           calc
             _ < (1 : ℝ) + 1 + 1 := by
               apply add_lt_add
@@ -71,7 +71,7 @@ problem imo2006_p4 :
         · rw [Int.cast_pow] at h
           apply sq_lt_sq.mp at h
           norm_cast at h
-        · rw [Int.natAbs_sq, Int.cast_pow, ←h, add_assoc]
+        · rw [Int.natAbs_sq, Int.cast_pow, ← h, add_assoc]
           simp only [one_pow, gt_iff_lt, lt_add_iff_pos_right]
           positivity
       interval_cases k
@@ -85,7 +85,7 @@ problem imo2006_p4 :
       apply H (-y) x this at hy
       simp at hy
       rcases hy with ⟨hx, hy⟩ | ⟨hx, hy⟩ | ⟨hx, hy⟩ | ⟨hx, hy⟩
-      all_goals simp [hx, ←hy]
+      all_goals simp [hx, ← hy]
     · lift y to ℕ using hynonneg
       norm_cast at h
       by_cases hx : x = 0
@@ -93,19 +93,19 @@ problem imo2006_p4 :
         simp [hx] at h
         rw [show 4 = 2 ^ 2 by norm_num] at h
         apply sq_eq_sq₀ (by simp) (by simp) |>.mp at h
-        simp [hx, ←h]
+        simp [hx, ← h]
       · -- Now let $(x, y)$ be a solution with $x&gt;0$;
         -- without loss of generality confine attention to $y&gt;0$.
         have hxpos : x > 0 := by apply Nat.ne_zero_iff_zero_lt.mp hx
         have hypos : y > 0 := by by_contra hy; simp at hy; simp [hy] at h
         -- The equation rewritten as $$ 2^{x}\left(1+2^{x+1}\right)=(y-1)(y+1) $$
         have h : 2 ^ x * (2 ^ (x + 1) + 1) = (y - 1) * (y + 1) := by
-          rw [Nat.sub_mul, Nat.mul_add, Nat.one_mul, Nat.mul_add, Nat.mul_one, Nat.mul_one, Nat.add_comm y 1, Nat.add_sub_add_right, ←sq, ←h]
+          rw [Nat.sub_mul, Nat.mul_add, Nat.one_mul, Nat.mul_add, Nat.mul_one, Nat.mul_one, Nat.add_comm y 1, Nat.add_sub_add_right, ← sq, ← h]
           apply Nat.eq_sub_of_add_eq
           ring_nf
         -- shows that the factors $y-1$ and $y+1$ are even, exactly one of them divisible by 4 .
         have h2dvd : 2 ∣ y - 1 := by
-          have : 2 ^ x ∣ (y - 1) * (y + 1) := by simp [←h]
+          have : 2 ^ x ∣ (y - 1) * (y + 1) := by simp [← h]
           have : 2 ∣ y - 1 ∨ 2 ∣ (y + 1) := by
             refine (Nat.Prime.dvd_mul ?pp).mp ?_
             · norm_num
@@ -138,7 +138,7 @@ problem imo2006_p4 :
             ring
         -- Hence $x \geq 3$ and one of these factors is divisible by $2^{x-1}$ but not by $2^{x}$.
         have hxge3 : x ≥ 3 := by
-          rw [←h] at h8div
+          rw [← h] at h8div
           have hco : (2 ^ 3).Coprime (2 ^ (x + 1) + 1) := by
             refine Nat.Coprime.pow_left 3 ?_
             refine Odd.coprime_two_left ?_
@@ -176,9 +176,9 @@ problem imo2006_p4 :
           · have : y + 1 = 2 * (2 ^ (n₁ - 1) * t + 1) := by
               apply Nat.eq_add_of_sub_eq at ht
               · rw [ht, mul_add]
-                simp [←Nat.mul_assoc]
+                simp [← Nat.mul_assoc]
                 left
-                rw [←Nat.pow_add_one', Nat.sub_add_cancel]
+                rw [← Nat.pow_add_one', Nat.sub_add_cancel]
                 exact Nat.one_le_of_lt h₁
               exact hypos
             have h' : 2 ^ x * (2 ^ (x + 1) + 1) = 2 ^ (n₁ + 1) * (t * (2 ^ (n₁ - 1) * t + 1)) := by
@@ -214,7 +214,7 @@ problem imo2006_p4 :
               contradiction
             · simp at ht
               have : y + 1 = 2 * (t + 1) := by
-                rw [mul_add, ←ht]
+                rw [mul_add, ← ht]
                 simp
                 rw [Nat.sub_add_cancel]
                 exact hypos
@@ -255,7 +255,7 @@ problem imo2006_p4 :
         -- $$ 2^{x}\left(1+2^{x+1}\right)=\left(2^{x-1} m+\epsilon\right)^{2}-1=2^{2 x-2} m^{2}+2^{x} m \epsilon, $$
         have h : 2 ^ x * (1 + 2 ^ (x + 1)) = 2 ^ (2 * x - 2) * m ^ 2 + 2 ^ x * m * ε := by
           trans (((y - 1) * (y + 1) : ℕ) : ℤ)
-          · rw [←h]
+          · rw [← h]
             simp [add_comm]
           · rw [Nat.cast_mul, Nat.cast_sub]
             · simp [hy]
@@ -280,18 +280,18 @@ problem imo2006_p4 :
             _ = (2 ^ x * 2 ^ (x - 2) * m ^ 2 + 2 ^ x * m * ε) / 2 ^ x := by
                 rw [h]
                 congr
-                rw [←pow_add, ←Nat.add_sub_assoc]
+                rw [← pow_add, ← Nat.add_sub_assoc]
                 · simp; ring_nf
                 exact Nat.le_of_succ_le hxge3
-            _ = 2 ^ x * (2 ^ (x - 2) * m ^ 2 + m * ε) / 2 ^ x := by rw [mul_add, ←mul_assoc, ←mul_assoc]
+            _ = 2 ^ x * (2 ^ (x - 2) * m ^ 2 + m * ε) / 2 ^ x := by rw [mul_add, ← mul_assoc, ← mul_assoc]
             _ = _ := by simp
         -- $$ Therefore $$ 1-\epsilon m=2^{x-2}\left(m^{2}-8\right).
         have : 1 - m * ε = 2 ^ (x - 2) * (m ^ 2 - 8) := by
           rw [mul_sub]
           apply sub_eq_of_eq_add'
-          rw [←add_sub_assoc]
+          rw [← add_sub_assoc]
           apply eq_sub_of_add_eq
-          rw [add_comm (m * ε), ←h, show (8 : ℤ) = 2 ^ 3 by simp, ←pow_add]
+          rw [add_comm (m * ε), ← h, show (8 : ℤ) = 2 ^ 3 by simp, ← pow_add]
           congr 2
           simp only [Nat.reduceEqDiff]
           rw [Nat.sub_add_cancel]
@@ -331,7 +331,7 @@ problem imo2006_p4 :
               · exact Nat.le_sub_of_add_le hxge3
             · simp
             · apply nonneg_of_mul_nonneg_right (a := 2 ^ (x - 2))
-              · rw [←this]; exact Int.le.intro_sub (1 + m + 0) rfl
+              · rw [← this]; exact Int.le.intro_sub (1 + m + 0) rfl
               · positivity
             · positivity
           -- $$ implying $2 m^{2}-m-17 \leq 0$. Hence $m \leq 3$;
@@ -353,11 +353,11 @@ problem imo2006_p4 :
             let t := 2 ^ (x - 2)
             have : (1 : ℤ) + 8 * t = t * 9 + (-3) := by
               simp [t]
-              rw [←h]
+              rw [← h]
               simp
-              rw [show (8 : ℤ) = 2 ^ 3 by simp, ←pow_add]
-              rw [←Nat.add_sub_assoc]
-              · rw [show 3 = 1 + 2 by simp, Nat.add_comm, ←Nat.add_assoc]
+              rw [show (8 : ℤ) = 2 ^ 3 by simp, ← pow_add]
+              rw [← Nat.add_sub_assoc]
+              · rw [show 3 = 1 + 2 by simp, Nat.add_comm, ← Nat.add_assoc]
                 simp
               · exact Nat.le_of_succ_le hxge3
             have : (t : ℤ) = 4 := by linarith only [this]

--- a/Compfiles/Imo2007P1.lean
+++ b/Compfiles/Imo2007P1.lean
@@ -38,7 +38,7 @@ problem imo2007_p1a {n : ℕ} (hn : 0 < n) (a x : Fin n → ℝ) (h : Monotone x
     have : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
     apply exists_eq_ciSup_of_finite
   rcases h₁ with ⟨i, hi⟩
-  rw [←hi, d]
+  rw [← hi, d]
   have h₂ : ∃ j : {j // j ≤ i}, a j = ⨆ j : {j // j ≤ i}, a j:= by
     have : Nonempty {j // j ≤ i} := by
       rw [nonempty_subtype]

--- a/Compfiles/Imo2008P4.lean
+++ b/Compfiles/Imo2008P4.lean
@@ -72,7 +72,7 @@ problem imo2008_p4 (f : PosReal → PosReal) :
   · ---- Deduce `f(x^2) = f(x)^2` and `f(x) = x` or `x f(x) = 1`
     have h0 : ∀ x, f (x ^ 2) = f x ^ 2 := fun x ↦ by
       replace h := h x x x x rfl
-      rwa [mul_comm, mul_right_inj, ←PosReal.two_mul, ←PosReal.two_mul,
+      rwa [mul_comm, mul_right_inj, ← PosReal.two_mul, ← PosReal.two_mul,
            mul_right_inj, eq_comm] at h
 
     replace h := λ x y ↦ h (x ^ 2) (y ^ 2) (x * y) (x * y) (by rw [← sq, mul_pow])

--- a/Compfiles/Imo2008P5.lean
+++ b/Compfiles/Imo2008P5.lean
@@ -276,7 +276,7 @@ lemma claim (n k : ℕ) (hn : 0 < n) (hnk : n ≤ k) (_he : Even (k - n))
     rw [Nat.sub_add_cancel hnk]
     have h2 : n = ∑ i : Fin n, 1 := by simp
     simp_rw [h2]
-    rw [←Finset.sum_add_distrib]
+    rw [← Finset.sum_add_distrib]
     have h3 : ∀ x ∈ Finset.univ (α := Fin n), c x - 1 + 1 = c x := by
       intro x hx
       exact Nat.sub_add_cancel (hcp x)
@@ -392,9 +392,9 @@ lemma claim (n k : ℕ) (hn : 0 < n) (hnk : n ≤ k) (_he : Even (k - n))
         simpa [hlow] using hpv
   have h2 : Fintype.card S = Fintype.card {g | ψ n k g = f} :=
     Fintype.card_of_bijective h1
-  nth_rewrite 2 [←Nat.card_eq_fintype_card] at h2
+  nth_rewrite 2 [← Nat.card_eq_fintype_card] at h2
   rw [Nat.card_coe_set_eq] at h2
-  rw [←h2, Scard']
+  rw [← h2, Scard']
 
 lemma lemma1 (α : Type) (A B : Set α) (hA : A.Finite) (hB : B.Finite)
     (f : {x // A x} → {x // B x})
@@ -433,7 +433,7 @@ problem imo2008_p5 (n k : ℕ) (hn : 0 < n)
   have h1 := lemma1 (Sequence n k) (NSequence n k) (MSequence n k) hA hB (ψ n k)
               (2 ^ (k - n))
               (claim n k hn hnk he)
-  rw [←h1]
+  rw [← h1]
   push_cast
   rfl
 

--- a/Compfiles/Imo2009P6.lean
+++ b/Compfiles/Imo2009P6.lean
@@ -669,7 +669,7 @@ theorem imo2009_p6_aux1 (n : ℕ) (hn : 0 < n)
       have hM' : ∑ i : Fin n', a' i ∉ M' := by
         have h14 : ∑ i : Fin n', a' i = x := by
           simpa [a', x, n'] using sum_init a
-        rw [←h14] at h1
+        rw [← h14] at h1
         rw [Finset.mem_filter]
         push Not
         intro h15
@@ -690,7 +690,7 @@ theorem imo2009_p6_aux1 (n : ℕ) (hn : 0 < n)
           simpa [a', p] using (prefix_extendPerm a p' (Nat.sub_le n 1) i h30).symm
         rw [h33] at h31
         have h34 : ∑ j ∈ Finset.filter (· ≤ i) Finset.univ, a (p j) ≤ x := by
-          rw [←h33]
+          rw [← h33]
           have h36 : Finset.filter (· ≤ i') Finset.univ ⊆ Finset.univ := by
             intro j hj
             simp
@@ -993,7 +993,7 @@ problem imo2009_p6 (n : ℕ) (hn : 0 < n)
       intro x
       exact congrArg a (ainj (congrArg a (h3 x)))
     have h1 : Finset.map ⟨ps', h0.1⟩ Finset.univ = Finset.univ := by simp
-    rw [←h1]
+    rw [← h1]
     rw [Finset.sum_map, Function.Embedding.coeFn_mk]
     simp_rw [Function.comp_apply]
     dsimp at h3' ⊢

--- a/Compfiles/Imo2013P5.lean
+++ b/Compfiles/Imo2013P5.lean
@@ -59,7 +59,7 @@ lemma f_pos_of_pos {f : ℚ → ℝ} {q : ℚ} (hq : 0 < q)
     (H1 : ∀ x y, 0 < x → 0 < y → f (x * y) ≤ f x * f y)
     (H4 : ∀ n : ℕ, 0 < n → (n : ℝ) ≤ f n) :
     0 < f q := by
-  have hfqn := calc f q.num = f (q * q.den) := by rw [←Rat.mul_den_eq_num]
+  have hfqn := calc f q.num = f (q * q.den) := by rw [← Rat.mul_den_eq_num]
                     _ ≤ f q * f q.den := H1 q q.den hq (Nat.cast_pos.mpr q.pos)
 
   -- Now we just need to show that `f q.num` and `f q.denom` are positive.
@@ -115,7 +115,7 @@ lemma fixed_point_of_pos_nat_pow {f : ℚ → ℝ} {n : ℕ} (hn : 0 < n)
     mod_cast H5 (a ^ n) (one_lt_pow₀ ha1 hn.ne')
 
   have hh1 := calc f (a^n) ≤ (f a)^n := pow_f_le_f_pow hn ha1 H1 H4
-                   _ = (a : ℝ)^n     := by rw [←hae]
+                   _ = (a : ℝ)^n     := by rw [← hae]
   exact mod_cast hh1.antisymm hh0
 
 lemma fixed_point_of_gt_1 {f : ℚ → ℝ} {x : ℚ} (hx : 1 < x)
@@ -196,7 +196,7 @@ problem imo2013_p5
       · have hfneq : f n = n := by
           have h := fixed_point_of_gt_1 (x := n) (mod_cast hn2) H1 H2 H4 H5 ha1 hae
           rwa [Rat.cast_natCast] at h
-        rw [←hfneq]
+        rw [← hfneq]
         exact H1 n x (Nat.cast_pos.mpr hn) hx
     exact h2.antisymm (H3 x hx n hn)
 

--- a/Compfiles/Imo2016P5.lean
+++ b/Compfiles/Imo2016P5.lean
@@ -472,11 +472,11 @@ problem imo2016_p5 :
       have h2 : Finset.card (L ∪ R) ≤ L.card + R.card := Finset.card_union_le L R
       have h3 : Finset.Icc 1 2016 ⊆ (L ∪ R) := fun a ha ↦ by
         specialize H2 a ha
-        rw [←or_iff_not_imp_left] at H2
+        rw [← or_iff_not_imp_left] at H2
         exact Finset.mem_union.mpr H2
       have h4 : (Finset.Icc 1 2016).card ≤ (L ∪ R).card := Finset.card_le_card h3
       rw [Nat.card_Icc, add_tsub_cancel_right] at h4
-      rw [←hcard] at H
+      rw [← hcard] at H
       exact ((h4.trans h2).trans_lt H).false
     obtain ⟨i, hic, hiL, hiR⟩ := h1
     push Not at hLR
@@ -485,7 +485,7 @@ problem imo2016_p5 :
       rw [Finset.mem_sdiff]; exact ⟨hic, hiL⟩
     have hic2 : i ∈ Finset.Icc 1 2016 \ R := by
       rw [Finset.mem_sdiff]; exact ⟨hic, hiR⟩
-    rw [←Finset.prod_erase_mul _ _ hic1, ←Finset.prod_erase_mul _ _ hic2] at hLR
+    rw [← Finset.prod_erase_mul _ _ hic1, ← Finset.prod_erase_mul _ _ hic2] at hLR
     simp at hLR
 
 

--- a/Compfiles/Imo2021P1.lean
+++ b/Compfiles/Imo2021P1.lean
@@ -126,7 +126,7 @@ problem imo2021_p1 :
   have hBsub : B ⊆ Finset.Icc n (2 * n) := by
     intro c hcB; simpa only [Finset.mem_Icc] using h₂ c hcB
   have hB' : 2 * 1 < (B ∩ (Finset.Icc n (2 * n) \ A) ∪ B ∩ A).card := by
-    rw [←inter_union_distrib_left, sdiff_union_self_eq_union, union_eq_left.2 hA,
+    rw [← inter_union_distrib_left, sdiff_union_self_eq_union, union_eq_left.2 hA,
       inter_eq_left.2 hBsub]
     exact Nat.succ_le_iff.mp hB
   -- Since B has cardinality greater or equal to 3, there must exist a subset C ⊆ B such that

--- a/Compfiles/Imo2022P5.lean
+++ b/Compfiles/Imo2022P5.lean
@@ -93,8 +93,8 @@ lemma mylemma_44
     simp only [add_tsub_cancel_right, Nat.reduceSubDiff] at *
     have hn: n ≠ 0 := Nat.ne_zero_of_lt hn2
     have hn1: 1 ≤ n := Nat.one_le_of_lt hn2
-    rw [←Nat.mul_factorial_pred hn, h₀]
-    rw [←Finset.prod_range_mul_prod_Ico _ hn1]
+    rw [← Nat.mul_factorial_pred hn, h₀]
+    rw [← Finset.prod_range_mul_prod_Ico _ hn1]
     rw [Finset.prod_range_one]
     simp only [tsub_zero, mul_eq_mul_left_iff]
     left

--- a/Compfiles/Imo2023P4.lean
+++ b/Compfiles/Imo2023P4.lean
@@ -63,14 +63,14 @@ lemma cauchy_schwarz {x1 x2 x3 y1 y2 y3 : ℝ}
   rw [Real.sq_sqrt hy1] at h1
   rw [Real.sq_sqrt hy2] at h1
   rw [Real.sq_sqrt hy3] at h1
-  rw [←Real.sqrt_mul (show 0 ≤ x1 + x2 + x3 by positivity)] at h1
-  rw [←Real.sqrt_mul hx1] at h1
-  rw [←Real.sqrt_mul hx2] at h1
-  rw [←Real.sqrt_mul hx3] at h1
+  rw [← Real.sqrt_mul (show 0 ≤ x1 + x2 + x3 by positivity)] at h1
+  rw [← Real.sqrt_mul hx1] at h1
+  rw [← Real.sqrt_mul hx2] at h1
+  rw [← Real.sqrt_mul hx3] at h1
   have h4 : (√((x1 + x2 + x3) * (y1 + y2 + y3)))^2 = (x1 + x2 + x3) * (y1 + y2 + y3) := by
     refine Real.sq_sqrt ?_
     positivity
-  rw [←h4]
+  rw [← h4]
   exact pow_le_pow_left₀ h2 h1 2
 
 lemma lemma1 (u : ℝ) (hu : u ≠ 1) (hp : 0 < u) : 2 < u + 1/u := by
@@ -235,8 +235,8 @@ theorem imo2023_p4_generalized
                Subtype.mk_le_mk, add_le_iff_nonpos_right,
                nonpos_iff_eq_zero, one_ne_zero, and_false, not_false_eq_true,
                Finset.sum_insert] at h1
-    rw [←add_assoc, add_comm (x ⟨n + 2, hn2⟩)] at h1
-    rw [←add_assoc] at h1
+    rw [← add_assoc, add_comm (x ⟨n + 2, hn2⟩)] at h1
+    rw [← add_assoc] at h1
     have hx1 : 0 ≤ x ⟨n + 1, hn1⟩ := le_of_lt (hxp ⟨n + 1, hn1⟩)
     have hx2 : 0 ≤ x ⟨n + 2, hn2⟩ := le_of_lt (hxp ⟨n + 2, hn2⟩)
     have hx3 : 0 ≤ ∑ x_1 ∈ Finset.filter
@@ -256,7 +256,7 @@ theorem imo2023_p4_generalized
 
     have h9 := cauchy_schwarz hx1 hx2 hx3 hy1 hy2 hy3
     clear hx1 hx2 hx3 hy1 hy2 hy3
-    rw [←h1] at h9; clear h1
+    rw [← h1] at h9; clear h1
     let x' : { a // a ∈ Finset.Icc 1 (2 * m + 1) } → ℝ :=
       fun ⟨z, hz⟩ ↦ x ⟨z, by simp only [Finset.mem_Icc] at hz ⊢; lia⟩
     let e : { x // x ∈ Finset.Icc 1 (2 * m + 1) } →
@@ -307,9 +307,9 @@ theorem imo2023_p4_generalized
         exact Nat.le_add_left 1 (2 * m)
       unfold aa
       congr 2
-      · rw [←h20 hn, Finset.sum_map]
+      · rw [← h20 hn, Finset.sum_map]
         rfl
-      · rw [←h20 hn, Finset.sum_map]
+      · rw [← h20 hn, Finset.sum_map]
         apply Finset.sum_congr rfl
         intro ii hii
         simp [x', e]
@@ -336,13 +336,13 @@ theorem imo2023_p4_generalized
       specialize hxa ⟨y, hy'⟩
       obtain ⟨k, hk⟩ := hxa
       use k
-      rw [←hk]
+      rw [← hk]
       clear h5 h7 h9
       unfold aa
       congr 2
-      · rw [←h20 hy, Finset.sum_map]
+      · rw [← h20 hy, Finset.sum_map]
         rfl
-      · rw [←h20 hy, Finset.sum_map]
+      · rw [← h20 hy, Finset.sum_map]
         rfl
     specialize ih x' hxp' hxi' hxa'
     have hup : 0 < u := by
@@ -358,7 +358,7 @@ theorem imo2023_p4_generalized
       unfold u
       have hp1 : 0 < x ⟨n + 1, hn1⟩ := hxp ⟨n + 1, hn1⟩
       have hp2 : 0 < x ⟨n + 2, hn2⟩ := hxp ⟨n + 2, hn2⟩
-      rw [←Real.sqrt_mul (by positivity)]
+      rw [← Real.sqrt_mul (by positivity)]
       field_simp
       norm_num
     rw [h11] at h9; clear h11

--- a/Compfiles/Imo2024P2.lean
+++ b/Compfiles/Imo2024P2.lean
@@ -49,7 +49,7 @@ lemma dvd_pow_iff_of_dvd_sub {a b d n : ℕ} {z : ℤ} (ha : a.Coprime d)
     d ∣ a ^ n + b ↔ (((ZMod.unitOfCoprime _ ha) ^ z : (ZMod d)ˣ) : ZMod d) + b = 0 := by
   obtain ⟨k, hk⟩ := hd
   rw [show z = n + (-k) * φ d by lia]
-  rw [zpow_add, zpow_mul', ←ZMod.natCast_eq_zero_iff]
+  rw [zpow_add, zpow_mul', ← ZMod.natCast_eq_zero_iff]
   simp
 
 namespace Condition

--- a/Compfiles/Imo2024P3.lean
+++ b/Compfiles/Imo2024P3.lean
@@ -209,7 +209,7 @@ lemma empty_consecutive_apply_ge_M : {i | M a N ≤ a i ∧ M a N ≤ a (i + 1)}
   have t_map_eq_t' : t.map ⟨(· + 1), add_left_injective 1⟩ = t' := by
     refine map_add_one_range (a · = a i) i ?_
     intro H
-    rw [←H, M] at hi1
+    rw [← H, M] at hi1
     have a0_le : a 0 ≤ (Finset.range (N + 1)).sup a := Finset.le_sup (by simp)
     lia
   have card_t_eq_card_t' : #t = #t' := by simp [← t_map_eq_t', t]

--- a/Compfiles/Imo2025P1.lean
+++ b/Compfiles/Imo2025P1.lean
@@ -536,7 +536,7 @@ noncomputable def shiftLines (v : Plane) (lines : Finset AffSubOfPlane) : Finset
 /-- `shiftLine (-v)` is the inverse of `shiftLine v`. -/
 lemma shift_line_inv (v : Plane) (L : AffSubOfPlane) : (shiftLine (-v)) ((shiftLine v) L) = L := by
   dsimp only [shiftLine, Function.Embedding.coeFn_mk, shiftLineMap]
-  rw [AffineSubspace.map_map, ←affine_trans, ←AffineEquiv.constVAdd_add]
+  rw [AffineSubspace.map_map, ← affine_trans, ← AffineEquiv.constVAdd_add]
   simp
 
 /-- If `L` is sunny, then so is its shift. -/

--- a/Compfiles/Imo2025P3.lean
+++ b/Compfiles/Imo2025P3.lean
@@ -38,7 +38,7 @@ snip begin
 lemma fermat_little_theorem: ∀p:ℕ+, (Nat.Prime (p:ℕ)) → (∀a:ℕ, (a^(p:ℕ)≡a [MOD p])) := by
   intro p hp a
   by_cases h1:(p:ℕ)∣a
-  · rw [←Nat.modEq_zero_iff_dvd] at h1
+  · rw [← Nat.modEq_zero_iff_dvd] at h1
     have h2: a ^ (p:ℕ) ≡ 0 ^ (p:ℕ) [MOD p] := by
       exact Nat.ModEq.pow (p:ℕ) h1
     simp at h2
@@ -56,10 +56,10 @@ lemma fermat_little_theorem: ∀p:ℕ+, (Nat.Prime (p:ℕ)) → (∀a:ℕ, (a^(p
 lemma fermat_little_theorem2: ∀p:ℕ+, (Nat.Prime (p:ℕ)) → (∀a:ℕ, ∀k:ℕ, (a^((p:ℕ)^k)≡a [MOD p])) := by
   intro p hp a k
   induction k with
-  | zero => 
+  | zero =>
     simp
     rfl
-  | succ d hd => 
+  | succ d hd =>
     rw [Nat.pow_add,Nat.mul_comm,Nat.pow_mul]
     simp
     have g1 := fermat_little_theorem p hp a
@@ -158,8 +158,8 @@ problem imo2025_p3 :
             have r3 := dvd_trans r2 hf
 
             have r4 := r3
-            rw [←Nat.cast_pow,←Nat.cast_pow] at r4
-            rw [←Nat.modEq_iff_dvd] at r4
+            rw [← Nat.cast_pow,← Nat.cast_pow] at r4
+            rw [← Nat.modEq_iff_dvd] at r4
 
             have r5 := fermat_little_theorem p hp2 (b:ℕ)
 
@@ -182,10 +182,10 @@ problem imo2025_p3 :
               exact Nat.le_of_lt hb
             have g2: (f b : ℤ) - (b:ℤ) < (p:ℤ) := by
               simp at hp1
-              rw [←PNat.coe_lt_coe] at hp1
+              rw [← PNat.coe_lt_coe] at hp1
               have t : (b:ℕ) ≤ (f b :ℕ) := by
                 linarith
-              rw [←Nat.cast_sub t]
+              rw [← Nat.cast_sub t]
               simp
               have g2' := PNat.sub_coe (f b) b
               rw [if_pos hb] at g2'
@@ -251,8 +251,8 @@ problem imo2025_p3 :
               apply Nat.cast_dvd_cast
               exact PNat.dvd_iff.mp h4
             have r7 := Int.dvd_trans r6 hf
-            rw [←Nat.cast_pow,←Nat.cast_pow] at r7
-            rw [←Nat.modEq_iff_dvd] at r7
+            rw [← Nat.cast_pow,← Nat.cast_pow] at r7
+            rw [← Nat.modEq_iff_dvd] at r7
             rw [r5] at r7
             simp at r7
             have r8 := fermat_little_theorem p hp1 (q:ℕ)
@@ -336,8 +336,8 @@ problem imo2025_p3 :
             simp
           have g2 : (a:ℕ) ≠ 0 := by
             simp
-          rw [←Nat.multiplicity_eq_factorization (by decide) g1]
-          rw [←Nat.multiplicity_eq_factorization (by decide) g2]
+          rw [← Nat.multiplicity_eq_factorization (by decide) g1]
+          rw [← Nat.multiplicity_eq_factorization (by decide) g2]
           clear g1 g2
           have r1 : emultiplicity 2 (f a:ℕ) = multiplicity 2 (f a:ℕ) := by
             apply FiniteMultiplicity.emultiplicity_eq_multiplicity
@@ -386,10 +386,10 @@ problem imo2025_p3 :
               have y4 : 2 = ((2:ℕ):ENat) := by
                 simp
               rw [y3,y4] at g2
-              rw [←ENat.natCast_add,←ENat.natCast_add,←ENat.natCast_add] at g2
+              rw [← ENat.natCast_add,← ENat.natCast_add,← ENat.natCast_add] at g2
               rw [ENat.natCast_inj] at g2
               rw [y4]
-              rw [←ENat.natCast_add]
+              rw [← ENat.natCast_add]
               rw [ENat.natCast_inj]
               grind
             exact le_of_le_of_eq g1 g5
@@ -440,11 +440,11 @@ problem imo2025_p3 :
             have y3 : 2 = ((2:ℕ):ℤ) :=by
               simp
             rw [y2,y3] at hx
-            rw [←Nat.cast_mul] at hx
+            rw [← Nat.cast_mul] at hx
             grind
           apply Nat.Prime.dvd_of_dvd_pow (by decide) at g4
-          rw [←Nat.not_even_iff_odd] at ha
-          rw [←even_iff_two_dvd] at g4
+          rw [← Nat.not_even_iff_odd] at ha
+          rw [← even_iff_two_dvd] at g4
           exact ha g4
 
         have h13 : ∀ (a : ℕ+), Odd (a:ℕ) → (f a:ℝ) ≤4*(a:ℝ) := by
@@ -505,7 +505,7 @@ problem imo2025_p3 :
                 _ = ((b:ℤ)^2-1)*(y+y) := by rw [hx]
                 _ = ((b:ℤ)^2-1)*((y:ℕ)+y:ℕ) := by grind
                 _ = ((b:ℤ)^2-1)*((b:ℤ)^2+1) := by
-                  rw [←hy]
+                  rw [← hy]
                   simp
                 _ = ((b:ℤ)^4-1) := by ring
             · have g2 : f b = 2 := by grind

--- a/Compfiles/Imo2025P6.lean
+++ b/Compfiles/Imo2025P6.lean
@@ -1894,7 +1894,7 @@ lemma pivot_no_black (cp : CrossingPoints c) :
         rw [h_p_eq_vl1] at h_px_v_lt
         exact (lt_self_iff_false _).mp h_px_v_lt
     · exact c.h_unique_x p hp_blk vl (c.hv_sub mem_vl) h_px_eq.symm
-  have h_eq : uk = vl := by rw [←h_p_eq_uk, h_p_eq_vl]
+  have h_eq : uk = vl := by rw [← h_p_eq_uk, h_p_eq_vl]
   have h_uk_in_v : uk ∈ c.v := by rw [h_eq]; exact mem_vl
   have h_uk_not_in_v : uk ∉ c.v := disjoint_left.mp c.h_disj mem_uk
   contradiction

--- a/Compfiles/India1998P1.lean
+++ b/Compfiles/India1998P1.lean
@@ -59,7 +59,7 @@ problem india1998_p1b (n a b : ℤ) (hn : a^2 + 3 * b^2 = 7 * n) :
     obtain ⟨m2, hm2⟩ := exists_eq_mul_right_of_dvd h16
     use m1; use m2
     have h20 : (7 * m1) ^ 2 + 3 * (7 * m2) ^ 2 = 7 * 7 * n := by
-      rw [←hm1, ←hm2]; linear_combination 7 * hn
+      rw [← hm1, ← hm2]; linear_combination 7 * hn
 
     exact (mul_right_inj' h22).mp (by linear_combination h20)
 
@@ -79,7 +79,7 @@ problem india1998_p1b (n a b : ℤ) (hn : a^2 + 3 * b^2 = 7 * n) :
     obtain ⟨m2, hm2⟩ := exists_eq_mul_right_of_dvd h16
     use m1; use m2
     have h20 : (7 * m1) ^ 2 + 3 * (7 * m2) ^ 2 = 7 * 7 * n := by
-      rw [←hm1, ←hm2]; linear_combination 7 * hn
+      rw [← hm1, ← hm2]; linear_combination 7 * hn
 
     exact (mul_right_inj' h22).mp (by linear_combination h20)
 

--- a/Compfiles/IntegersInACircle.lean
+++ b/Compfiles/IntegersInACircle.lean
@@ -46,7 +46,7 @@ lemma lemma2 {f : ZMod 101 → ℤ} (y : ZMod 101)
     rw [Finset.mem_range] at ha hb
     rwa [Nat.mod_eq_of_lt ha, Nat.mod_eq_of_lt hb] at h8
   replace hg : Set.InjOn g (Finset.range 101) := hg
-  rw [←Finset.sum_image hg]
+  rw [← Finset.sum_image hg]
   have h3 : Finset.image g (Finset.range 101) = Finset.univ := by
      rw [Finset.eq_univ_iff_forall]
      intro a
@@ -106,7 +106,7 @@ problem integers_in_a_circle
       rwa [Nat.mod_eq_of_lt (ha.2.trans y.prop),
            Nat.mod_eq_of_lt (hb.2.trans y.prop)] at h13
     replace h10 : Set.InjOn Nat.cast _ := h10
-    rw [←Finset.sum_image h10, ←ha_sum]
+    rw [← Finset.sum_image h10, ← ha_sum]
     have h9 : (Finset.Ico x.val y.val).image (λ i:ℕ ↦ (i : ZMod 101)) ⊂ Finset.univ := by
       rw [Finset.ssubset_univ_iff]
       intro hn
@@ -155,7 +155,7 @@ problem integers_in_a_circle
     have h18 : Finset.range 101 =
         Finset.range ((y.val - x.val) + (101 - (y.val - x.val))) := by congr
     have h19 := Finset.sum_range_add (λi ↦ a (x + i)) (y.val - x.val) (101 - (y.val - x.val))
-    rw [h100, ←h18, ha_sum] at h19
+    rw [h100, ← h18, ha_sum] at h19
     have h21 : ∀ i ∈ Finset.range (101 - (y.val - x.val)),
           a (x + ↑(y.val - x.val + i)) = a (↑(ZMod.val y) + ↑i) := by
       intro i _
@@ -166,7 +166,7 @@ problem integers_in_a_circle
            norm_cast
       rw [h22]
       norm_cast
-      rw [←Nat.add_assoc, add_comm x.val _, Nat.sub_add_cancel (le_of_lt hxy)]
+      rw [← Nat.add_assoc, add_comm x.val _, Nat.sub_add_cancel (le_of_lt hxy)]
 
     rw [Finset.sum_congr rfl h21] at h19
     lia

--- a/Compfiles/Iran1998P3.lean
+++ b/Compfiles/Iran1998P3.lean
@@ -32,7 +32,7 @@ namespace Iran1998P3
 snip begin
 
 lemma cube_root_cube (x : ℝ) (h : 0 ≤ x) : (x^(3:ℝ)) ^ ((1:ℝ)/3) = x := by
-  rw [←Real.rpow_mul h, mul_div_cancel₀ (1 : ℝ) three_ne_zero]
+  rw [← Real.rpow_mul h, mul_div_cancel₀ (1 : ℝ) three_ne_zero]
   exact Real.rpow_one x
 
 snip end
@@ -58,7 +58,7 @@ problem iran1998_p3
     have xnonneg : ∀ i ∈ Finset.range 4, 0 ≤ x i := by
       intro i _; exact le_of_lt (x_positive i)
     rw [Real.finsetProd_rpow (Finset.range 4) x xnonneg, h, Real.one_rpow] at amgm'
-    rw [←Finset.mul_sum] at amgm'
+    rw [← Finset.mul_sum] at amgm'
 
     let C := 1/4 * ∑ i ∈ Finset.range 4, x i
     have hcp' : 0 ≤ ∑ i ∈ Finset.range 4, x i := Finset.sum_nonneg xnonneg
@@ -82,7 +82,7 @@ problem iran1998_p3
       intro i hi; have := habs i hi; exact congr_fun (congr_arg _ this) 3
     rw [Finset.sum_congr rfl habs3] at holder
     have hccc: (4:ℝ) * C =  ∑ i ∈ Finset.range 4, x i := by simp [C]
-    rw [←hccc] at holder
+    rw [← hccc] at holder
 
     rw [Real.mul_rpow zero_le_four hcp] at holder
 
@@ -94,9 +94,9 @@ problem iran1998_p3
       -- clear_except holder
       have hknn : (0:ℝ) ≤ (4:ℝ) ^ (-3 : ℝ) := by norm_num1
       have hh := mul_le_mul_of_nonneg_left holder hknn
-      rw [←mul_assoc] at hh
+      rw [← mul_assoc] at hh
       have h4mm: (4:ℝ) ^ (-3: ℝ) * (4:ℝ) ^ (3:ℝ) = 1 := by norm_num1
-      rw [h4mm, one_mul, ←mul_assoc] at hh
+      rw [h4mm, one_mul, ← mul_assoc] at hh
       have h4mm': (4:ℝ) ^ (-3: ℝ) * ((4:ℕ):ℝ) ^ (2:ℝ) = 1/4 := by norm_num1
       rw [h4mm'] at hh
       exact hh
@@ -139,11 +139,11 @@ problem iran1998_p3
       have hs : ∀ i ∈ ((Finset.range 4).erase j),
         (fun (ii : ℕ) ↦ (1:ℝ) / 3) i * (fun (ii : ℕ) ↦ x ii ^ (3:ℝ)) i =
          ((1:ℝ)/3) * x i ^ (3:ℝ) := by simp
-      rw [Finset.sum_congr rfl hs, ←Finset.mul_sum] at amgm
+      rw [Finset.sum_congr rfl hs, ← Finset.mul_sum] at amgm
       exact amgm
     have h3 : ∀ j ∈ (Finset.range 4), ∏ i ∈ (Finset.range 4).erase j, x i = 1 / x j := by
       intro j hj
-      rw [←h, ←Finset.prod_erase_mul _ _ hj]
+      rw [← h, ← Finset.prod_erase_mul _ _ hj]
       have : x j ≠ 0 := ne_of_gt (x_positive j)
       field_simp
     have h4 : ∀ j ∈ Finset.range 4, 1 / x j ≤ 1 / 3 * B j := by
@@ -154,7 +154,7 @@ problem iran1998_p3
     have h5 : ∑ i ∈ Finset.range 4, 1 / x i ≤ A := by
       have h5': ∑ i ∈ Finset.range 4, 1 / x i ≤ ∑ i ∈ Finset.range 4, (1 / 3) * B i :=
         Finset.sum_le_sum h4
-      rw [←Finset.mul_sum] at h5'
+      rw [← Finset.mul_sum] at h5'
       rw [hab]
       exact h5'
     exact h5

--- a/Compfiles/Iran1998P9.lean
+++ b/Compfiles/Iran1998P9.lean
@@ -120,9 +120,9 @@ problem iran1998_p9
   have hyyy : y * ((y - 1) / y) = y - 1 := by field_simp
   have hzzz : z * ((z - 1) / z) = z - 1 := by field_simp
 
-  rw [←Real.sqrt_mul hx0 ((x - 1) / x),
-      ←Real.sqrt_mul hy0 ((y - 1) / y),
-      ←Real.sqrt_mul hz0 ((z - 1) / z),
+  rw [← Real.sqrt_mul hx0 ((x - 1) / x),
+      ← Real.sqrt_mul hy0 ((y - 1) / y),
+      ← Real.sqrt_mul hz0 ((z - 1) / z),
       hxxx, hyyy, hzzz] at hinner
 
   rw [hinner] at cauchy_schwarz

--- a/Compfiles/Romania1998P12.lean
+++ b/Compfiles/Romania1998P12.lean
@@ -66,7 +66,7 @@ lemma extend_function_mono
     obtain ⟨z, h_z_lt_y, hyz⟩ := this
     -- then dist (f z) (f y) < ε.
     have hbzb := hδ z hyz
-    rw [←h z] at hbzb
+    rw [← h z] at hbzb
     have huzuy : u y < u z := by
       have hufp : u y - f y < 0 := by linarith
       have hua : ε = -(u y - f y) := abs_of_neg hufp
@@ -92,7 +92,7 @@ lemma extend_function_mono
     obtain ⟨z, h_y_lt_z, hyz⟩ := this
     -- then dist (f z) (f y) < ε.
     have hbzb := hδ z hyz
-    rw [←h z] at hbzb
+    rw [← h z] at hbzb
     have huzuy : u z < u y := by
       have hufp : 0 < u y - f y := by linarith
       have hua : ε = u y - f y := abs_of_pos hufp
@@ -208,7 +208,7 @@ lemma exp_characterization
     intro x
     have := hu x (-x)
     rw [add_neg_cancel] at this
-    rw [←this]
+    rw [← this]
     exact hu0
 
   have hunz : ∀ x, 0 < u x := fun x ↦ by
@@ -232,7 +232,7 @@ lemma exp_characterization
     · have := h1 n x
       norm_cast at this
     · have h10 := h1 n x
-      rw [←hn]
+      rw [← hn]
       have h11: ↑(-((↑n):ℤ)) * x = - (n * x) := by norm_num
       rw [h11, h3 _]
       rw [h10, one_div]
@@ -246,7 +246,7 @@ lemma exp_characterization
   have hnexp : ∀ n : ℕ, u n = Real.exp (k * n) := by
     intro n
     have h10 := h4 n 1
-    rw [←hk, mul_one] at h10
+    rw [← hk, mul_one] at h10
     norm_cast at h10
     rw [h10, mul_comm]
     exact (Real.exp_nat_mul _ _).symm
@@ -261,7 +261,7 @@ lemma exp_characterization
       exact hnexp n
     · have := h4 (-↑n) 1
       rw[mul_one] at this
-      rw[this, ←hk]
+      rw[this, ← hk]
       rw [Real.exp_mul]
       exact (Real.rpow_intCast _ _).symm
 
@@ -287,12 +287,12 @@ lemma exp_characterization
     have h14: u (x / ↑(p.succ)) ^ p.succ = u (x / ↑(p.succ)) ^ (p.succ:ℝ) := by norm_cast
     rw [h14]
     have h15 := le_of_lt (hunz (x / ↑(p.succ)))
-    rw [←Real.rpow_mul h15 _]
+    rw [← Real.rpow_mul h15 _]
     field_simp
     simp
 
   have hq : ∀ q : ℚ, u q = Real.exp (k * q) := fun q ↦ by
-    rw [Rat.cast_def q, hp q.den q.pos q.num, hzexp q.num, ←Real.exp_mul]
+    rw [Rat.cast_def q, hp q.den q.pos q.num, hzexp q.num, ← Real.exp_mul]
     ring_nf
 
   use k
@@ -360,10 +360,10 @@ lemma romania1998_p12_mp (u : ℝ → ℝ) :
     intro x hx
     obtain hm1 | hm2 := hm
     · obtain h1 | h2 | h3 := lt_trichotomy x 0
-      · rw [←hf0];
+      · rw [← hf0];
         exact ne_of_lt (hm1 h1)
       · exfalso; exact hx h2
-      · rw [←hf0]
+      · rw [← hf0]
         exact (ne_of_lt (hm1 h3)).symm
     · obtain h1 | h2 | h3 := lt_trichotomy x 0
       · have := hm2 h1
@@ -378,7 +378,7 @@ lemma romania1998_p12_mp (u : ℝ → ℝ) :
   -- f(x)u(y) + f(y) = f (x + y) = f(x) + f(y)u(x)
   have h1 : ∀ x y : ℝ, f x * u y + f y = f x + f y * u x := by
     intro x y
-    rw [←hf, add_comm]
+    rw [← hf, add_comm]
     linarith[hf y x]
 
   -- so f(x)(u(y) - 1) = f(y)(u(x) - 1) for all x,y ∈ ℝ.

--- a/Compfiles/UK2024R1P1.lean
+++ b/Compfiles/UK2024R1P1.lean
@@ -56,7 +56,7 @@ def S' (k : ℕ) (m : Fin (k + 2)) := {f | f ∈ S (k + 2) ∧ f 0 = m}
 lemma g_nonzero_ne_m {g : Equiv.Perm (Fin (k + 2))}
     (hg : g ∈ (S' k m)) (n : Fin (k + 2)) (hn : n ≠ 0) : g n ≠ m := by
   contrapose! hn
-  rwa [←Equiv.apply_eq_iff_eq g, hg.2]
+  rwa [← Equiv.apply_eq_iff_eq g, hg.2]
 
 def f_toFun (g : Equiv.Perm (Fin (k + 2))) (hg : g ∈ (S' k m)) (n : Fin (k + 1)) : Fin (k + 1) :=
   if hg' : g n.succ ≤ m then
@@ -76,13 +76,13 @@ def f_invFun (g : Equiv.Perm (Fin (k + 2))) (hg : g ∈ (S' k m)) (n : Fin (k + 
       contrapose! hg'
       rw [le_iff_lt_or_eq]
       right
-      rw [←hg.2, ←hg', Equiv.apply_symm_apply]
+      rw [← hg.2, ← hg', Equiv.apply_symm_apply]
     )
   else
     (g.symm n.succ).pred (by
       contrapose! hg'
       rw [Equiv.symm_apply_eq, hg.2] at hg'
-      simp only [←hg', Fin.castSucc_lt_succ_iff, le_refl]
+      simp only [← hg', Fin.castSucc_lt_succ_iff, le_refl]
     )
 
 lemma f_left_inv (g : Equiv.Perm (Fin (k + 2))) (hg : g ∈ (S' k m)) :
@@ -98,7 +98,7 @@ lemma f_left_inv (g : Equiv.Perm (Fin (k + 2))) (hg : g ∈ (S' k m)) :
     intro hg''
     apply hg'
     push Not at hg'
-    rwa [←Fin.lt_castPred_iff (Fin.ne_last_of_lt hg'), Fin.pred_lt_castPred_iff] at hg''
+    rwa [← Fin.lt_castPred_iff (Fin.ne_last_of_lt hg'), Fin.pred_lt_castPred_iff] at hg''
 
 lemma f_right_inv (g : Equiv.Perm (Fin (k + 2))) (hg : g ∈ (S' k m)) :
     Function.RightInverse (f_invFun g hg) (f_toFun g hg) := by
@@ -177,7 +177,7 @@ lemma f'_in_S'_k (hm : m ≤ 1) {g : Equiv.Perm (Fin (k + 1))} (hg : g ∈ S (k 
       · apply le_trans (Fin.castSucc_le_castSucc_iff.2 (hg (n.pred hn)))
         rw [Fin.succ_pred]
         exact le_of_lt Fin.castSucc_lt_succ
-      · rw [←Fin.succ_castSucc]
+      · rw [← Fin.succ_castSucc]
         apply le_trans (Fin.succ_le_succ_iff.2 (hg (n.pred hn)))
         rw [Fin.succ_pred]
   · simp [f', f'_toFun]
@@ -223,7 +223,7 @@ lemma S'_k_card_eq_S_succ_k_card (hm : m ≤ 1) : (S' k m).ncard = (S (k + 1)).n
         rw [Fin.pred_succ]
         exact n.succ.succ_ne_zero
     · intro a b ha hb hab
-      rw [←f_f'_left_inv ha, ←f_f'_left_inv hb, hab]
+      rw [← f_f'_left_inv ha, ← f_f'_left_inv hb, hab]
     · intro b hb
       exact ⟨f' m b, ⟨f'_in_S'_k hm hb, f_f'_right_inv hm hb⟩⟩
 
@@ -245,7 +245,7 @@ lemma S_succ_succ_k_card_eq_two_mul_S_succ_k_card : (S (k + 2)).ncard = (S (k + 
       intro x
       constructor <;> intro hx
       · have hx' : (x 0) ≤ 1 := by
-          rw [←Fin.val_fin_le, Fin.val_one]
+          rw [← Fin.val_fin_le, Fin.val_one]
           exact hx 0
         obtain hx' | hx' := le_iff_lt_or_eq.mp hx'
         · left
@@ -271,7 +271,7 @@ lemma S_succ_k_card_eq_two_pow_k {k : ℕ} :
       · intro h
         simp [h, f, Fin.eq_zero]
   | succ n hn =>
-      rw [Nat.pow_succ, ←hn, S_succ_succ_k_card_eq_two_mul_S_succ_k_card]
+      rw [Nat.pow_succ, ← hn, S_succ_succ_k_card_eq_two_mul_S_succ_k_card]
 snip end
 
 determine solution_value : ℕ := 256

--- a/Compfiles/UK2024R1P2.lean
+++ b/Compfiles/UK2024R1P2.lean
@@ -37,10 +37,10 @@ problem uk2024_r1_p2 (a : ℕ → ℤ)
     specialize ha (i + 1 + 1) (by norm_num)
     simp only [add_tsub_cancel_right, Nat.reduceSubDiff] at ha
     obtain ha | ha := ha <;> rw [ha] at hP
-    · rwa [two_mul, ←sub_add, sub_add_cancel_right, neg_add_eq_sub] at hP
+    · rwa [two_mul, ← sub_add, sub_add_cancel_right, neg_add_eq_sub] at hP
     -- This branch is invalid because the difference between the terms we know are
     -- consecutive is both 1 and a multiple of 2, which is a contradiction
-    · rw [←sub_add, sub_add_eq_add_sub, ←two_mul, ←mul_sub_left_distrib, abs_mul,
+    · rw [← sub_add, sub_add_eq_add_sub, ← two_mul, ← mul_sub_left_distrib, abs_mul,
           Int.mul_eq_one_iff_eq_one_or_neg_one] at hP
       obtain hP | hP := hP <;> replace hP := hP.1 <;> norm_num at hP
 

--- a/Compfiles/UpperLowerContinuous.lean
+++ b/Compfiles/UpperLowerContinuous.lean
@@ -232,7 +232,7 @@ lemma continuous_of_upper_lower_continuous
        upper_intervals upper_basis).mp h3 c h4
     obtain ⟨t, ⟨a', c', hac'⟩, htc, ht⟩ := h5
     use a'
-    rw [←hac'] at htc
+    rw [← hac'] at htc
     constructor
     · intro x hx
       have h7 : x ∈ Set.Ioc a' c' := ⟨hx.1, hx.2.trans htc.2⟩
@@ -252,7 +252,7 @@ lemma continuous_of_upper_lower_continuous
        lower_intervals lower_basis).mp h3 c h4
     obtain ⟨t, ⟨c', b', hcb'⟩, htc, ht⟩ := h5
     use b'
-    rw [←hcb'] at htc
+    rw [← hcb'] at htc
     constructor
     · intro x hx
       have h7 : x ∈ Set.Ico c' b' := by
@@ -278,7 +278,7 @@ lemma continuous_of_upper_lower_continuous
         have subeq :
           Set.Ioc a' c ∪ Set.Ico c b' ⊆ f ⁻¹' Set.Ioc a (f c) ∪ f ⁻¹' Set.Ico (f c) b
           := Set.union_subset_union ha' hb'
-        rw [ilem1, ←Set.preimage_union, ilem2, hab] at subeq
+        rw [ilem1, ← Set.preimage_union, ilem2, hab] at subeq
         exact subeq
   exact
      (@TopologicalSpace.IsTopologicalBasis.isOpen_iff ℝ tₛ (f ⁻¹' ab)
@@ -343,12 +343,12 @@ theorem monotone_of_upper_lower_continuous
     obtain ⟨t , ⟨ta, tb, htb⟩, xint, tsub⟩ := h2
     use tb
     constructor
-    · rw [←htb] at xint
+    · rw [← htb] at xint
       exact xint.2
     · have auxsub : Set.Ico x tb ⊆ t := by
         intro xx hxx
-        rw[←htb]
-        rw[←htb] at xint
+        rw[← htb]
+        rw[← htb] at xint
         constructor
         · exact xint.1.trans hxx.1
         · exact hxx.2
@@ -383,7 +383,7 @@ theorem monotone_of_upper_lower_continuous
           intro w hw
           constructor
           · exact hw.1
-          · rw [←hiiu'] at hyii
+          · rw [← hiiu'] at hyii
             exact hw.2.trans hyii.2
       rw [hiiu'] at h999
       exact h999.trans hiis

--- a/Compfiles/Usa1974P2.lean
+++ b/Compfiles/Usa1974P2.lean
@@ -36,10 +36,10 @@ lemma usa1974_p2_wlog :
     simp (discharger := positivity) only [Real.rpow_add, Real.mul_rpow]
     ring
   apply le_of_pow_le_pow_left₀ (by decide : 3 ≠ 0) (by positivity)
-  rw [←Real.rpow_natCast]
+  rw [← Real.rpow_natCast]
   rw [←(Real.rpow_mul (le_of_lt habc))]
   norm_num
-  rw [←h]
+  rw [← h]
   rw [pow_three']
   have hab' := Real.log_le_log hb hab
   have hbc' := Real.log_le_log hc hbc
@@ -61,10 +61,10 @@ problem usa1974_p2 :
   -- https://artofproblemsolving.com/wiki/index.php/1974_USAMO_Problems/Problem_2
   intro a b c ha hb hc
   wlog hab : a ≥ b with Hab
-  · move_add [←b]; move_mul [←b^b, ←b]
+  · move_add [← b]; move_mul [← b^b, ← b]
     refine Hab b a c hb ha hc (le_of_lt <| not_le.mp hab)
   · wlog hac : a ≥ c with Hac
-    · move_add [←c]; move_mul [←c^c, ←c]
+    · move_add [← c]; move_mul [← c^c, ← c]
       have hca : c ≥ a := le_of_lt <| not_le.mp hac
       apply Hac c a b <;> try assumption
       trans a <;> assumption

--- a/Compfiles/Usa1978P1.lean
+++ b/Compfiles/Usa1978P1.lean
@@ -50,13 +50,13 @@ problem usa1978_p1 :
     intro he a b c d h1 h2
     apply not_le_of_gt he
     have h11 : (a + b + c + d) ^ 2 = (8 - e) ^ 2 := by
-      rw [(by rw [←h1]; simp only [add_sub_cancel_right] : a + b + c + d = 8 - e)]
+      rw [(by rw [← h1]; simp only [add_sub_cancel_right] : a + b + c + d = 8 - e)]
     have h12 :  a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 = 16 - e ^ 2 := by
-      rw [←h2]; simp only [add_sub_cancel_right]
+      rw [← h2]; simp only [add_sub_cancel_right]
     have h3 : (a - b)^2 + (a - c)^2 + (a - d)^2 +
               (b - c)^2 + (b - d)^2 + (c - d)^2 = 4 * (16 - e^2) - (8 - e)^2 := by
       linear_combination 4 * h12 - h11
-    have h4 : 4 * (16 - e ^ 2) - (8 - e) ^ 2 ≥ 0 := by rw [←h3]; positivity
+    have h4 : 4 * (16 - e ^ 2) - (8 - e) ^ 2 ≥ 0 := by rw [← h3]; positivity
     revert h4
     rw [(by ring_nf : 4 * (16 - e ^ 2) - (8 - e) ^ 2 = e * (16 - 5 * e))]
     contrapose!

--- a/Compfiles/Usa1981P5.lean
+++ b/Compfiles/Usa1981P5.lean
@@ -32,7 +32,7 @@ problem usa1981_p5 (x : ℝ) (n : ℕ) :
   -- We follow the solution from
   -- https://artofproblemsolving.com/wiki/index.php/1981_USAMO_Problems/Problem_5
 
-  simp_rw [←Int.self_sub_fract, sub_div, mul_div_right_comm]
+  simp_rw [← Int.self_sub_fract, sub_div, mul_div_right_comm]
   rw [Finset.sum_sub_distrib]
   have h1 : ∀ x1 ∈ Finset.Icc 1 n, (x1 : ℝ) / (x1 : ℝ) * x = x := fun x1 hx ↦ by
     rw [Finset.mem_Icc] at hx
@@ -79,7 +79,7 @@ problem usa1981_p5 (x : ℝ) (n : ℕ) :
     exact Nat.sub_le n m
   rw [show Finset.Icc 1 n = Finset.Ico 1 (n + 1) by rfl]
   rw [show Finset.Icc 1 (n - m) = Finset.Ico 1 (n - m + 1) by rfl] at h9
-  rw [←Finset.sum_Ico_consecutive _ h12 h13]
+  rw [← Finset.sum_Ico_consecutive _ h12 h13]
   have h14 : a m ≤ ∑ i ∈ Finset.Ico (n - m + 1) (n + 1), a i / ↑i := by
     have h15 : m ≠ 0 := Nat.pos_iff_ne_zero.mp hm3
     have h16 : (m:ℝ) ≠ 0 := Nat.cast_ne_zero.mpr h15
@@ -100,7 +100,7 @@ problem usa1981_p5 (x : ℝ) (n : ℕ) :
     have h20 : n + 1 - (n - m + 1) = m := by
       rw [Nat.add_sub_add_right]
       exact Nat.sub_sub_self hm4
-    rw [h20, ←mul_div_assoc] at h19
+    rw [h20, ← mul_div_assoc] at h19
     exact h19
   calc _ ≤ a (n - m) + a m := h11
        _ ≤ _ := add_le_add h9 h14

--- a/Compfiles/Usa1982P4.lean
+++ b/Compfiles/Usa1982P4.lean
@@ -52,9 +52,9 @@ lemma some_useful_mod_lemma : ∀ (n a b c d : ℕ),
     unfold Nat.ModEq
     unfold Nat.ModEq at h2
     rw [←(Nat.div_add_mod' (a - n) b)]
-    rw [←h1]
+    rw [← h1]
     simp only [Nat.zero_mod, add_zero]
-    rw [mul_comm, pow_mul, Nat.pow_mod, h2, ←Nat.pow_mod, one_pow]
+    rw [mul_comm, pow_mul, Nat.pow_mod, h2, ← Nat.pow_mod, one_pow]
 
 lemma usa1982_p4_lemma (e a b)
     (he :
@@ -87,7 +87,7 @@ lemma usa1982_p4_lemma (e a b)
       gcongr
       focus rfl
       trans 2 ^ a; swap; focus rw [ha]; rfl
-      rw [←he]
+      rw [← he]
       apply some_useful_mod_lemma n a b e 2 hn
       rw [hb, he]; rfl
   }
@@ -97,7 +97,7 @@ lemma usa1982_mod_lemma {n r r' q : ℕ}
     (hm : n % 64 = r') (p : ℕ) (hpq : p * q = 64) (hrr : r' ≡ r [MOD q]) : n ≡ r [MOD q] := by
   trans r'; swap
   · exact hrr
-  rw [Nat.ModEq, ←hm, ←hpq, Nat.mod_mul_left_mod]
+  rw [Nat.ModEq, ← hm, ← hpq, Nat.mod_mul_left_mod]
 
 snip end
 

--- a/Compfiles/Usa1987P1.lean
+++ b/Compfiles/Usa1987P1.lean
@@ -85,17 +85,17 @@ problem usa1987_p1 (m n : ℤ) :
     have hk' : k^2 = k'^2 := (sq_abs _).symm
     have hk0' : 0 ≤ k' := abs_nonneg _
 
-    rw [ ←sq] at h13
+    rw [ ← sq] at h13
     have h20 : k' < 8 := by
       by_contra! H
       rw [hm', hk'] at h13
       have h14 : k' < m' := by
         have h14' : k'^2 < m'^2 := by
-          rw [←h13]; exact Int.lt_add_of_pos_left _ (by norm_num)
+          rw [← h13]; exact Int.lt_add_of_pos_left _ (by norm_num)
         exact lt_of_pow_lt_pow_left₀ 2 hm0' h14'
       have h15 : k' + 1 ≤ m' := h14
       have h16 : (k' + 1)^2 ≤ m'^2 := by gcongr
-      rw [←h13] at h16
+      rw [← h13] at h16
       have h17 : 2 * k' + 1 ≤ 16 := by linarith only [h16]
       have h18 : 2 * 8 + 1 ≤ 2 * k' + 1 := by gcongr
       have h19 := h18.trans h17
@@ -110,15 +110,15 @@ problem usa1987_p1 (m n : ℤ) :
         simp only [Set.mem_insert_iff, true_or, or_true]
       · exact (h1 (sub_eq_neg_self.mp h25)).elim
     · rw [hm'] at h13
-      have h21 : 4^2 < m'^2 := by rw [←h13]; norm_num
+      have h21 : 4^2 < m'^2 := by rw [← h13]; norm_num
       have h23 : 4 < m' := lt_of_pow_lt_pow_left₀ 2 hm0' h21
-      have h22 : m'^2 < 5^2 := by rw [←h13]; norm_num
+      have h22 : m'^2 < 5^2 := by rw [← h13]; norm_num
       have h24 : m' < 5 := lt_of_pow_lt_pow_left₀ 2 (by norm_num) h22
       exact (Int.not_le.mpr h24 h23).elim
     · rw [hm'] at h13
-      have h21 : 4^2 < m'^2 := by rw [←h13]; norm_num
+      have h21 : 4^2 < m'^2 := by rw [← h13]; norm_num
       have h23 : 4 < m' := lt_of_pow_lt_pow_left₀ 2 hm0' h21
-      have h22 : m'^2 < 5^2 := by rw [←h13]; norm_num
+      have h22 : m'^2 < 5^2 := by rw [← h13]; norm_num
       have h24 : m' < 5 := lt_of_pow_lt_pow_left₀ 2 (by norm_num) h22
       exact (Int.not_le.mpr h24 h23).elim
     · rw [hm'] at h13
@@ -135,27 +135,27 @@ problem usa1987_p1 (m n : ℤ) :
           simp only [Set.mem_insert_iff, Set.mem_singleton_iff, or_true]
       · lia
     · rw [hm'] at h13
-      have h21 : 5^2 < m'^2 := by rw [←h13]; norm_num
+      have h21 : 5^2 < m'^2 := by rw [← h13]; norm_num
       have h23 : 5 < m' := lt_of_pow_lt_pow_left₀ 2 hm0' h21
-      have h22 : m'^2 < 6^2 := by rw [←h13]; norm_num
+      have h22 : m'^2 < 6^2 := by rw [← h13]; norm_num
       have h24 : m' < 6 := lt_of_pow_lt_pow_left₀ 2 (by norm_num) h22
       exact (Int.not_le.mpr h24 h23).elim
     · rw [hm'] at h13
-      have h21 : 6^2 < m'^2 := by rw [←h13]; norm_num
+      have h21 : 6^2 < m'^2 := by rw [← h13]; norm_num
       have h23 : 6 < m' := lt_of_pow_lt_pow_left₀ 2 hm0' h21
-      have h22 : m'^2 < 7^2 := by rw [←h13]; norm_num
+      have h22 : m'^2 < 7^2 := by rw [← h13]; norm_num
       have h24 : m' < 7 := lt_of_pow_lt_pow_left₀ 2 (by norm_num) h22
       exact (Int.not_le.mpr h24 h23).elim
     · rw [hm'] at h13
-      have h21 : 7^2 < m'^2 := by rw [←h13]; norm_num
+      have h21 : 7^2 < m'^2 := by rw [← h13]; norm_num
       have h23 : 7 < m' := lt_of_pow_lt_pow_left₀ 2 hm0' h21
-      have h22 : m'^2 < 8^2 := by rw [←h13]; norm_num
+      have h22 : m'^2 < 8^2 := by rw [← h13]; norm_num
       have h24 : m' < 8 := lt_of_pow_lt_pow_left₀ 2 (by norm_num) h22
       exact (Int.not_le.mpr h24 h23).elim
     · rw [hm'] at h13
-      have h21 : 8^2 < m'^2 := by rw [←h13]; norm_num
+      have h21 : 8^2 < m'^2 := by rw [← h13]; norm_num
       have h23 : 8 < m' := lt_of_pow_lt_pow_left₀ 2 hm0' h21
-      have h22 : m'^2 < 9^2 := by rw [←h13]; norm_num
+      have h22 : m'^2 < 9^2 := by rw [← h13]; norm_num
       have h24 : m' < 9 := lt_of_pow_lt_pow_left₀ 2 (by norm_num) h22
       exact (Int.not_le.mpr h24 h23).elim
 

--- a/Compfiles/Usa1989P5.lean
+++ b/Compfiles/Usa1989P5.lean
@@ -46,7 +46,7 @@ problem usa1989_p5
   have hU : ∀ x, x ≠ 1 → U x = (x^10 - x) / (x - 1) + 9 * x^9 := fun x hx ↦ by
     convert_to U x = x * ((x^9 - 1) / (x - 1)) + 9 * x^9
     · ring
-    rw [←geom_sum_eq hx 9, Finset.mul_sum]
+    rw [← geom_sum_eq hx 9, Finset.mul_sum]
     have h1 : ∀ i, i ∈ Finset.range 9 → x * x^i = x ^(i + 1) := fun i _ ↦ (pow_succ' x i).symm
     rw [Finset.sum_congr rfl h1, Finset.sum_range_succ]
     ring
@@ -54,7 +54,7 @@ problem usa1989_p5
   have hV : ∀ x, x ≠ 1 → V x = (x^12 - x) / (x - 1) + 9 * x^11 := fun x hx ↦ by
     convert_to V x = x * ((x^11 - 1) / (x - 1)) + 9 * x^11
     · ring
-    rw [←geom_sum_eq hx 11, Finset.mul_sum]
+    rw [← geom_sum_eq hx 11, Finset.mul_sum]
     have h1 : ∀ i, i ∈ Finset.range 11 → x * x^i = x ^(i + 1) := fun i _ ↦ (pow_succ' x i).symm
     rw [Finset.sum_congr rfl h1, Finset.sum_range_succ]
     ring
@@ -78,7 +78,7 @@ problem usa1989_p5
       rw [hV x h6]
       have h8 : (x ^ 12 - x) / (x - 1) ≤ 0 := by
         obtain h7 | h7 : 0 = x^12 - x ∨ 0 < x^12 - x := h3.eq_or_lt
-        · rw [←h7]; simp
+        · rw [← h7]; simp
         · exact (div_neg_of_pos_of_neg h7 h4).le
       have h5 : 9 * x^11 ≤ 0 := by
         suffices H : 0 ≤ (-x)^11 by linarith

--- a/Compfiles/Usa1992P1.lean
+++ b/Compfiles/Usa1992P1.lean
@@ -67,9 +67,9 @@ lemma digits_sum (m x y : ℕ)
     exact Nat.le_of_lt_succ h4
   have ⟨k, hk⟩ : ∃ k, (Nat.digits 10 y).length + k = m := Nat.le.dest h3
   nth_rewrite 1 [add_comm, mul_comm]
-  nth_rewrite 1 [←hk]
+  nth_rewrite 1 [← hk]
   have one_lt_ten : 1 < 10 := by norm_num
-  rw [←Nat.digits_append_zeroes_append_digits one_lt_ten (Nat.zero_lt_succ x)]
+  rw [← Nat.digits_append_zeroes_append_digits one_lt_ten (Nat.zero_lt_succ x)]
   simp only [List.sum_append, List.sum_replicate, smul_eq_mul, mul_zero, add_zero]
   rw [digits_sum_mul_pow]
   ring
@@ -274,7 +274,7 @@ lemma lemma5 {m n : ℕ} (hm : m < 10^n) :
       rw [h_length]
     rw [h2] at h1
     unfold complement_digits
-    rw [←h1, ←lemma8, h_sub2]
+    rw [← h1, ← lemma8, h_sub2]
   rw [h_sub]
   have h12 : ∀ l ∈ complement_digits, l < 10 := by
     intro x hx
@@ -313,7 +313,7 @@ lemma List.sum_map_sub (l1 l2 : List ℕ) (h2 : List.Forall₂ (· ≥ ·) l1 l2
 
 lemma lemma4 {m n : ℕ} (hm : m < 10^n) :
     (Nat.digits 10 (10^n - 1 - m)).sum = 9 * n - (Nat.digits 10 m).sum := by
-  rw [←digitsPadded_sum, lemma5 hm]
+  rw [← digitsPadded_sum, lemma5 hm]
   have h2 := List.map_eq_zip 9 (digitsPadded 10 m n) (fun x y ↦ x - y)
   rw [h2]
   have h5 : List.Forall₂ (· ≥ ·)
@@ -366,7 +366,7 @@ problem usa1992_p1 (n : ℕ) :
   -- So, for all m, `b m < 10^(1 + 2 + 2^2 + ... + 2^m)`.
   have h2 : ∀ m, b m < 10^(∑ i ∈ Finset.range (m + 1), 2^i) := fun m ↦ by
     dsimp [b]
-    rw [←Finset.prod_pow_eq_pow_sum]
+    rw [← Finset.prod_pow_eq_pow_sum]
     refine Finset.prod_lt_prod_of_nonempty ?_ ?_ Finset.nonempty_range_add_one
     · intro i hi
       exact ha1 i
@@ -390,8 +390,8 @@ problem usa1992_p1 (n : ℕ) :
 
   -- Now b (n + 1) = (b n) * 10^N - b n, where N = 2^(n + 1).
   have h4 : b (n + 1) = b n * 10^(2^(n+1)) - b n := by
-    nth_rewrite 2 [←mul_one (b n)]
-    rw [←Nat.mul_sub_left_distrib]
+    nth_rewrite 2 [← mul_one (b n)]
+    rw [← Nat.mul_sub_left_distrib]
     dsimp [b]
     rw [Finset.prod_range_succ]
 
@@ -411,7 +411,7 @@ problem usa1992_p1 (n : ℕ) :
     have h5' := h5.le
     have h8 : 10 ^ 2 ^ (n + 1) ≤ b n * 10 ^ 2 ^ (n + 1) :=
       Nat.le_mul_of_pos_left (10 ^ 2 ^ (n + 1)) h7
-    rw [←Nat.add_sub_assoc h5']
+    rw [← Nat.add_sub_assoc h5']
     nth_rewrite 2 [add_comm]
     rw [Nat.mul_sub_right_distrib, one_mul, Nat.add_sub_of_le h8]
 
@@ -423,7 +423,7 @@ problem usa1992_p1 (n : ℕ) :
    have h9 : 0 < b n := h7
    have h10 := digits_sum (2^(n+1)) (b n - 1) (10^2^(n+1) - b n)
              (Nat.sub_lt_self h9 h5.le) -- ..
-   rw [←h10, h4]
+   rw [← h10, h4]
    congr 2
    lia
 
@@ -438,8 +438,8 @@ problem usa1992_p1 (n : ℕ) :
       rw [show 10 = 5 * 2 by rfl]
       rw [mul_pow, Nat.mul_mod, Nat.pow_mod]
       simp
-    rw [←Nat.even_iff] at h32
-    rw [←Nat.odd_iff]
+    rw [← Nat.even_iff] at h32
+    rw [← Nat.odd_iff]
     have h33 : Odd 1 := Nat.odd_iff.mpr rfl
     have h34 : 1 ≤ 10 ^ 2 ^ i := Nat.one_le_pow' (2 ^ i) 9
     exact Nat.Even.sub_odd h34 h32 h33
@@ -494,17 +494,17 @@ problem usa1992_p1 (n : ℕ) :
       change _ ≡ _ [MOD 10] at H
       rw [show 10 = 2 * 5 by rfl] at H
       have h40 : Nat.Coprime 2 5 := by norm_num
-      rw [←Nat.modEq_and_modEq_iff_modEq_mul h40] at H
+      rw [← Nat.modEq_and_modEq_iff_modEq_mul h40] at H
       obtain ⟨H1, -⟩ := H
       change _ % _ = _ % _ at H1
       simp only [Nat.reduceMod, Nat.reduceMul] at H1
       symm at H1
-      rw [←Nat.odd_iff] at H1
+      rw [← Nat.odd_iff] at H1
       have h42 : (10 ^ 2 ^ (n+1)) % 2 = 0 := by
         rw [show 10 = 5 * 2 by rfl]
         rw [mul_pow, Nat.mul_mod, Nat.pow_mod]
         simp
-      rw [←Nat.even_iff] at h42
+      rw [← Nat.even_iff] at h42
       have h43 : Odd 1 := Nat.odd_iff.mpr rfl
       have h44 : 1 ≤ 10 ^ 2 ^ (n+1) := Nat.one_le_pow' _ _
       have h45 : Odd (10 ^ 2 ^ (n + 1) - 1) := Nat.Even.sub_odd h44 h42 h43
@@ -513,9 +513,9 @@ problem usa1992_p1 (n : ℕ) :
       rw [Nat.odd_iff] at H1
       simp [H1] at h47
     apply_fun (· + 1) at h12
-    rw [←lemma3 h15] at h12
+    rw [← lemma3 h15] at h12
     have h17 : 10 ^ 2 ^ (n + 1) - 1 - b n + 1 = 10 ^ 2 ^ (n + 1) - b n := by lia
-    rw [←h17]
+    rw [← h17]
     exact h12
 
   rw [h13] at h8

--- a/Compfiles/Usa1993P1.lean
+++ b/Compfiles/Usa1993P1.lean
@@ -53,7 +53,7 @@ problem usa1993_p1 (n : ℕ) (hn : 2 ≤ n) (a b : ℝ) (ha : 0 < a) (hb : 0 < b
     rw[pow_succ] at han
     have h9 : a < a * a^n := by linarith only [han, ha]
     have h10 : 1 < a^n := (lt_mul_iff_one_lt_right ha).mp h9
-    rw [←one_pow n] at h10
+    rw [← one_pow n] at h10
     exact lt_of_pow_lt_pow_left₀ n h11 h10
   obtain h12 | rfl | h14 := lt_trichotomy a b
   · exfalso

--- a/Compfiles/Usa1996P1.lean
+++ b/Compfiles/Usa1996P1.lean
@@ -60,7 +60,7 @@ problem usa1996_p1 :
         have h3 : 2 * ((x:ℝ) + 1) + 1 = 2 * (↑x + 1 + 1) - 1 := by ring
         rw [h3]
       rw [h1]; clear h1
-      rw [sub_add_eq_sub_sub, ←Finset.sum_sub_distrib]
+      rw [sub_add_eq_sub_sub, ← Finset.sum_sub_distrib]
       have h4 : ∀ x ∈ Finset.range 90,
          ((↑x + 1) * Real.cos ((2 * (↑x + 1) - 1) * Real.pi / 180) -
            ↑x * Real.cos ((2 * (↑x + 1) - 1) * Real.pi / 180)) =
@@ -74,7 +74,7 @@ problem usa1996_p1 :
         simp only [Finset.range_eq_Ico]
         have h6 : 0 ≤ 45 := by norm_num
         have h7 : 45 ≤ 90 := by norm_num
-        rw [←Finset.sum_Ico_consecutive
+        rw [← Finset.sum_Ico_consecutive
              (f := (fun x ↦ Real.cos ((2 * (↑x + 1) - 1) * Real.pi / 180))) h6 h7]
         have h8 : ∀ i ∈ Finset.Ico (0:ℕ) 45,
              Real.cos ((2 * (↑i + 1) - 1) * Real.pi / 180) =
@@ -89,7 +89,7 @@ problem usa1996_p1 :
           have h15 : 45 = 89 + 1 - 45 := by norm_num
           have h16 : 90 = 89 + 1 - 0 := by norm_num
           nth_rewrite 1 [h15, h16]
-          rw [←Finset.sum_Ico_reflect _ 0 h7]
+          rw [← Finset.sum_Ico_reflect _ 0 h7]
           apply Finset.sum_congr rfl
           intro x hx
           apply congrArg
@@ -101,13 +101,13 @@ problem usa1996_p1 :
           ring
         rw [h9]; clear h9
         exact add_comm _ _
-      rw [←h5]
+      rw [← h5]
       norm_num1
       ring
     · rw [mul_comm]
       rw [Finset.sum_eq_zero]
       · simp only [zero_sub]
-        rw [←neg_mul, ←Real.cos_sub_pi]
+        rw [← neg_mul, ← Real.cos_sub_pi]
         ring_nf
       intro n _
       rw [cos_add]

--- a/Compfiles/Usa1998P1.lean
+++ b/Compfiles/Usa1998P1.lean
@@ -43,7 +43,7 @@ lemma mod2_abs (a : ℤ) : |a| % 2 = a % 2 := by
 
 -- For integers M,N we have |M-N| ≡ M-N ≡ M+N MOD 2.
 lemma mod2_diff (a b : ℤ) : |a - b| % 2 = (a + b) % 2 := by
-  rw [mod2_abs, Int.sub_eq_add_neg, Int.add_emod, Int.neg_emod_two, ←Int.add_emod]
+  rw [mod2_abs, Int.sub_eq_add_neg, Int.add_emod, Int.neg_emod_two, ← Int.add_emod]
 
 lemma lemma0 (n : ℕ) : (∑ x ∈ Finset.Icc 1 (4 * n + 2), (x:ℤ) % 2) % 2 = 1 := by
   norm_cast
@@ -98,7 +98,7 @@ problem usa1998_p1
       intro i
       rw [mod2_diff, Int.add_emod]
 
-    rw [Fintype.sum_congr _ _ h4, ←Finset.sum_int_mod, Finset.sum_add_distrib]
+    rw [Fintype.sum_congr _ _ h4, ← Finset.sum_int_mod, Finset.sum_add_distrib]
 
     have h9 : ∑ x : Fin 999, ((ab 0 x : ℤ) % 2) + ∑ x : Fin 999, ((ab 1 x : ℤ) % 2) =
          ∑ x : Fin 2 × Fin 999, (↑↑(ab.uncurry x) % 2) := by
@@ -121,7 +121,7 @@ problem usa1998_p1
       ← zmod_eq,
       show (10:ℤ) = 2 * 5 by norm_num]
 
-  rw [←Int.modEq_and_modEq_iff_modEq_mul hmn, zmod_eq, zmod_eq, h3, h2]
+  rw [← Int.modEq_and_modEq_iff_modEq_mul hmn, zmod_eq, zmod_eq, h3, h2]
   decide
 
 end Usa1998P1

--- a/Compfiles/Usa1998P3.lean
+++ b/Compfiles/Usa1998P3.lean
@@ -71,7 +71,7 @@ lemma lemma1 (x : ℝ) (hx : x ∈ Set.Ioo 0 (Real.pi / 2)) :
   · exact hx.2
 
 lemma lemma2' (n : ℕ) : Finset.erase (Finset.range (n + 1)) n = Finset.range n :=
-by rw [←Nat.succ_eq_add_one, Finset.range_add_one]; simp
+by rw [← Nat.succ_eq_add_one, Finset.range_add_one]; simp
 
 lemma lemma2 (n : ℕ) (f : ℕ → ℝ) :
     ∏ i ∈ Finset.range (n + 1), ∏ j ∈ Finset.erase (Finset.range (n + 1)) i, f j =
@@ -219,7 +219,7 @@ problem usa1998_p3
       have h30 : 0 ≤ 1 - y x := sub_nonneg.mpr (le_of_lt (lemma1 (a x) (ha x hx)))
       have h31 : (1:ℝ) / n * n = n / n := by field_simp
       have h32 : (n:ℝ) / n = 1 := by field_simp
-      rw [←Real.rpow_mul h30, h31, h32, Real.rpow_one]
+      rw [← Real.rpow_mul h30, h31, h32, Real.rpow_one]
     rw [h23] at h21; clear h23
     have h24 : ∏ i ∈ Finset.range (n + 1), (1 + y i) / ↑n =
                  (∏ i ∈ Finset.range (n + 1), (1 + y i)) / (↑n)^((n:ℝ) + 1) := by
@@ -245,7 +245,7 @@ problem usa1998_p3
       apply Finset.prod_pos
       intro x hx
       exact sub_pos.mpr (lemma1 (a x) (ha x hx))
-    rw [le_div_iff₀ h26, ←le_div_iff₀' h25]
+    rw [le_div_iff₀ h26, ← le_div_iff₀' h25]
     exact h21
 
   -- by the addition formula for tangents,
@@ -279,7 +279,7 @@ problem usa1998_p3
         · have hk2 : k ≤ -1 := Iff.mp Int.lt_add_one_iff hk'
           have : kk ≤ -1 := by rw [← hkk']; norm_cast
           nlinarith only [Real.pi_pos, ha1, hk2, this, hk]
-        · have hk0 : kk = 0 := by rw [←hkk']; norm_cast
+        · have hk0 : kk = 0 := by rw [← hkk']; norm_cast
           rw [hk0] at hk
           norm_num at hk
         · have hk2 : 1 ≤ k := hk'
@@ -297,7 +297,7 @@ problem usa1998_p3
               ∏ j ∈ Finset.range (n + 1), (1 + y j) / (1 - y j) :=
      Finset.prod_congr rfl (fun x hx ↦ h7 x hx)
   have h9 : (n:ℝ) ^ ((n:ℝ) + 1) = n ^ (n + 1) := by norm_cast
-  rw [h8, ←h9]
+  rw [h8, ← h9]
   exact h6
 
 

--- a/Compfiles/Usa1998P5.lean
+++ b/Compfiles/Usa1998P5.lean
@@ -89,7 +89,7 @@ problem usa1998_p5 (n : ℕ) (_hn : 2 ≤ n) :
                       ∏ t ∈ Sp.erase a, (a-t)^2 :=
                Finset.mul_prod_erase (Sp.erase a) (fun x ↦ (a-x)^2) hbb
             have Lmod : L % (a - b)^2 = 0 := by
-                 rw [h5, ←h6, mul_assoc, Int.mul_emod, Int.emod_self]
+                 rw [h5, ← h6, mul_assoc, Int.mul_emod, Int.emod_self]
                  norm_num
             have Lmod' : (L + a) * (L + b) % (a-b)^2 = 0 := by
                have h7 : (L + a) * (L + b) = L * (L + a + b) + a * b := by ring

--- a/Compfiles/Usa2000P1.lean
+++ b/Compfiles/Usa2000P1.lean
@@ -61,10 +61,10 @@ problem usa2000_p1 :
       have h4 : -((n : ℝ) + 1) = - (n : ℝ) - 1 := by ring
       rw [h4, div_eq_mul_one_div]
       have h5 : (1:ℝ) / 2 = 2 ^ (-(1:ℝ)) := by norm_num
-      rw [h5, ←Real.rpow_add h2p]
+      rw [h5, ← Real.rpow_add h2p]
       congr
     rw [h3] at h2
-    rw [←neg_eq_zero_sub, abs_neg] at h2
+    rw [← neg_eq_zero_sub, abs_neg] at h2
     have h6 : 0 < (2:ℝ) ^ (-(n:ℝ)) := Real.rpow_pos_of_pos h2p _
     rw [abs_of_pos h6] at h2
     have h7 : (2:ℝ) ^ (- (n : ℝ)) = 1 / 2^(n:ℝ) := by
@@ -84,10 +84,10 @@ problem usa2000_p1 :
       have h4 : -((n : ℝ) + 1) = - (n : ℝ) - 1 := by ring
       rw [h4, div_eq_mul_one_div]
       have h5 : (1:ℝ) / 2 = 2 ^ (-(1:ℝ)) := by norm_num
-      rw [h5, neg_mul, ←Real.rpow_add h2p]
+      rw [h5, neg_mul, ← Real.rpow_add h2p]
       congr
     rw [h3] at h2; clear h3
-    rw [←neg_eq_zero_sub, abs_neg] at h2
+    rw [← neg_eq_zero_sub, abs_neg] at h2
     have h6 : -(2:ℝ) ^ (-(n:ℝ)) < 0 := neg_lt_zero.mpr (Real.rpow_pos_of_pos h2p _)
     rw [abs_of_neg h6, neg_neg] at h2
     have h7 : (2:ℝ) ^ (- (n : ℝ)) = 1 / 2^(n:ℝ) := by
@@ -121,7 +121,7 @@ problem usa2000_p1 :
       calc _ ≤ _ := le_sub_iff_add_le.mpr (h1 n)
            _ = _ := by rw [hf0, zero_add]
            _ ≤ (A - 2 * (n:ℝ)) / 2 ^ (n.succ:ℝ) - 1 / 2 ^ (n:ℝ) := sub_le_sub_right hpn _
-           _ ≤ _ := by rw [h7, ←sub_div, h8]
+           _ ≤ _ := by rw [h7, ← sub_div, h8]
 
   -- Using a similar line of reasoning as above, f(-2⁻ⁿ) ≤ (B - 2n)/2ⁿ.
 
@@ -147,7 +147,7 @@ problem usa2000_p1 :
       calc _ ≤ _ := le_sub_iff_add_le.mpr (h1' n)
            _ = _ := by rw [hf0, zero_add]
            _ ≤ (B - 2 * (n:ℝ)) / 2 ^ (n.succ:ℝ) - 1 / 2 ^ (n:ℝ) := sub_le_sub_right hpn _
-           _ ≤ _ := by rw [h7, ←sub_div, h8]
+           _ ≤ _ := by rw [h7, ← sub_div, h8]
 
   -- Therefore, for every nonnegative integer n, f(2⁻ⁿ) + f(-2⁻ⁿ) ≤ (A+B-4n)/2ⁿ.
   have h4 : ∀ n : ℕ,
@@ -155,7 +155,7 @@ problem usa2000_p1 :
     intro n
     have h5 := add_le_add (h2 n) (h3 n)
     have h6 : A - 2 * ↑n + (B - 2 * ↑n) = A + B - 4 * ↑n := by ring
-    rwa [←add_div, h6] at h5
+    rwa [← add_div, h6] at h5
 
   -- Now, we choose n large enough such that n > (A+B)/4 - 1.
   let N := Nat.ceil ((A + B) / 4)
@@ -174,14 +174,14 @@ problem usa2000_p1 :
   have h20 := hc (2 ^(-(N:ℝ))) (-2 ^(-(N:ℝ)))
 
   -- This is a contradiction.
-  rw [add_neg_cancel, zero_div, hf0, zero_add, sub_neg_eq_add, ←two_mul] at h20
+  rw [add_neg_cancel, zero_div, hf0, zero_add, sub_neg_eq_add, ← two_mul] at h20
   nth_rewrite 1 [show (2:ℝ) = (2:ℝ) ^ (1:ℝ) by norm_num] at h20
-  rw [←Real.rpow_add (by norm_num)] at h20
+  rw [← Real.rpow_add (by norm_num)] at h20
   have h21 := calc _ ≤ _ := le_abs_self ((2 : ℝ) ^ (1 + -(N : ℝ)))
                _ ≤ _ := h20
   replace h20 : (2:ℝ) * 2^(1 + -(N:ℝ)) ≤ f ((2:ℝ)^(-(N:ℝ))) + f (-(2:ℝ) ^ (-(N:ℝ))) := by linarith
   nth_rewrite 1 [show (2:ℝ) = (2:ℝ) ^ (1:ℝ) by norm_num] at h20
-  rw [←Real.rpow_add (by norm_num)] at h20
+  rw [← Real.rpow_add (by norm_num)] at h20
   have h22 : (1 + (1 + -(N:ℝ))) = -((N : ℝ) - 2) := by ring
   have h23 : (0 :ℝ) ≤ 2 := by norm_num
   rw [h22, Real.rpow_neg h23, inv_eq_one_div] at h20

--- a/Compfiles/Usa2001P1.lean
+++ b/Compfiles/Usa2001P1.lean
@@ -65,7 +65,7 @@ lemma usa2001_p1_lemma {α} (s : Finset α) (sz : s.card = 6) (gen : α -> ℕ)
   set aa := (∑ x ∈ s, (gen x : ℝ)) with haa
   set bb := (∑ x ∈ s, (1 / (gen x : ℝ))) with hbb
   rify at sum
-  rw [←haa] at sum
+  rw [← haa] at sum
   norm_num1 at h
   have : aa ≥ 0 := by positivity
   have : bb ≥ 0 := by positivity
@@ -105,7 +105,7 @@ problem usa2001_p1 : IsLeast possible_num_colors min_colors := by
           simp only [Finset.mem_insert, Finset.mem_singleton] at hz
           obtain rfl | rfl := hz <;> assumption
         have h₆ : Finset.card {x, y} = 2 := by grind
-        have h₇ : 2 ≤ (f i ∩ f j).card := by rw [←h₆]; exact Finset.card_le_card h₅
+        have h₇ : 2 ≤ (f i ∩ f j).card := by rw [← h₆]; exact Finset.card_le_card h₅
         lia
       rintro x y i j hij
       fin_cases i <;> fin_cases j <;> dsimp only at hij ⊢ <;> (try contradiction) <;> decide

--- a/Compfiles/Usa2001P3.lean
+++ b/Compfiles/Usa2001P3.lean
@@ -63,15 +63,15 @@ problem usa2001_p3 (a b c : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c)
     (h : a^2 + b^2 + c^2 + a * b * c = 4) :
     0 ≤ a * b + b * c + c * a - a * b * c ∧
     a * b + b * c + c * a - a * b * c ≤ 2 := by
-  rw [←feq] at h
-  rw [←geq]
+  rw [← feq] at h
+  rw [← geq]
   wlog ha1 : a≤1 generalizing a b c with Ha
   · by_cases hb1 : b ≤ 1
     · rw [(by ring_nf : g a b c = g b a c)]
-      exact Ha b a c hb ha hc (by rw [←h]; unfold f; ring_nf) hb1
+      exact Ha b a c hb ha hc (by rw [← h]; unfold f; ring_nf) hb1
     by_cases hc1 : c ≤ 1
     · rw [(by ring_nf : g a b c = g c b a)]
-      exact Ha c b a hc hb ha (by rw [←h]; unfold f; ring_nf) hc1
+      exact Ha c b a hc hb ha (by rw [← h]; unfold f; ring_nf) hc1
     apply False.elim (ne_of_not_le _ h)
     unfold f
     rw [not_le]
@@ -87,13 +87,13 @@ problem usa2001_p3 (a b c : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c)
   · wlog hb1 : b ≤ 1 generalizing b c with Hb
     · by_cases hc1 : c ≤ 1
       · rw [(by ring_nf : g a b c = g a c b)]
-        exact Hb c b hc hb (by rw [←h]; unfold f; ring_nf) hc1
+        exact Hb c b hc hb (by rw [← h]; unfold f; ring_nf) hc1
       · apply usa2001_p3_lemma a b c ha h
         have : (b - 1 > 0) := by linarith
         have : (c - 1 > 0) := by linarith
         positivity
     · rw [(by ring_nf : g a b c = g c a b)]
-      apply usa2001_p3_lemma c a b hc (by rw [←h]; unfold f; ring_nf)
+      apply usa2001_p3_lemma c a b hc (by rw [← h]; unfold f; ring_nf)
       rw [(by ring_nf : (a - 1) * (b - 1) = (1 - a) * (1 - b))]
       positivity
 

--- a/Compfiles/Usa2001P4.lean
+++ b/Compfiles/Usa2001P4.lean
@@ -65,11 +65,11 @@ problem usa2001_p4
       have h4 : 0 < ∠ X Z Y - Real.pi / 2 := sub_pos.mpr hObtuse
       have h10 : ({X, Y, Z} : Set _) = {X, Z, Y} :=
         congrArg (Set.insert _) (Set.pair_comm _ _)
-      have h8 : ¬ Collinear ℝ {X, Z, Y} := by rwa [←h10]
+      have h8 : ¬ Collinear ℝ {X, Z, Y} := by rwa [← h10]
       have h7 : ∠ X Z Y < Real.pi := EuclideanGeometry.angle_lt_pi_of_not_collinear h8
       have h5 : ∠ X Z Y < Real.pi + Real.pi / 2 := by linarith only [h4, h7]
       exact Real.cos_neg_of_pi_div_two_lt_of_lt hObtuse h5
-    simp only [←sq] at h2
+    simp only [← sq] at h2
     have h13 : 2 * dist X Z * dist Y Z * Real.cos (∠ X Z Y) < 0 := by
       have h14 : 0 < 2 * dist X Z * dist Y Z := by positivity
       exact mul_neg_iff.mpr (Or.inl ⟨h14, h3⟩)
@@ -101,7 +101,7 @@ problem usa2001_p4
     pow_lt_pow_left₀ h23 dist_nonneg (by norm_num)
   rw [Real.sq_sqrt (by positivity)] at h23
   have h30 := EuclideanGeometry.law_cos B A C
-  simp only [←sq] at h30
+  simp only [← sq] at h30
   rw [h30] at h23; clear h30
   rw [dist_comm C A] at h23
   have h31 : 0 < 2 * dist B A * dist A C * Real.cos (∠ B A C) := by linarith only [h23]

--- a/Compfiles/Usa2002P1.lean
+++ b/Compfiles/Usa2002P1.lean
@@ -129,7 +129,7 @@ lemma usa2002_p1_generalized
         · obtain ⟨h6, h7⟩ := h4 hfs1
           have hfs2 : f s2 = Color.red := by rwa [hs12] at hfs1
           obtain ⟨h6', h7'⟩ := h4' hfs2
-          rw [←h7] at h7'
+          rw [← h7] at h7'
           have h8 := hf1' _ _ h7'
           simp [hs12, h6, h6', f]
           rw [Finset.subtype_union, Finset.union_comm]
@@ -196,7 +196,7 @@ lemma usa2002_p1_generalized
         · obtain ⟨h6, h7⟩ := h4 hfs1
           have hfs2 : f s2 = Color.blue := by rwa [hs12] at hfs1
           obtain ⟨h6', h7'⟩ := h4' hfs2
-          rw [←h7] at h7'
+          rw [← h7] at h7'
           have h8 := hf1' _ _ h7'
           simp (config := {decide := true}) only [hs12, Finset.mem_union, h6, h6', f]
           rw [Finset.subtype_union, Finset.union_comm]
@@ -271,7 +271,7 @@ lemma usa2002_p1_generalized
                 rw [has] at ha
                 contradiction
               exact Finset.filter_eq_self.mpr h7
-          rw [←Fintype.card_of_bijective hb]
+          rw [← Fintype.card_of_bijective hb]
           exact h5
 
         simp only [Fintype.card_sum, h4, hf2']

--- a/Compfiles/Usa2003P1.lean
+++ b/Compfiles/Usa2003P1.lean
@@ -37,7 +37,7 @@ lemma lemma2 (a b c : ℕ) (hb : 0 < b) (h : Nat.Coprime a b) : ∃ k, k < b ∧
   · exact Nat.mod_lt _ hb
   · change N % b = c % b at HN2
     change (a * (x % b)) % b = c % b
-    rw [← HN2, hx, Nat.mul_mod, Nat.mod_mod, ←Nat.mul_mod]
+    rw [← HN2, hx, Nat.mul_mod, Nat.mod_mod, ← Nat.mul_mod]
 
 snip end
 
@@ -73,7 +73,7 @@ problem usa2003_p1 (n : ℕ) :
     suffices h : ∃ k, Odd k ∧ k < 10 ∧ 5 ∣ (2^n * k + a) by
       obtain ⟨k, hk1, hk2, kk, hkk⟩ := h
       refine ⟨k, hk1, hk2, kk, ?_⟩
-      rw [Nat.pow_succ, Nat.mul_assoc, ←hkk, Nat.mul_pow 5 2 n]
+      rw [Nat.pow_succ, Nat.mul_assoc, ← hkk, Nat.mul_pow 5 2 n]
       ring
 
     -- ...which is true when k ≡ -3ⁿ⬝a MOD 5.

--- a/Compfiles/Usa2005P2.lean
+++ b/Compfiles/Usa2005P2.lean
@@ -51,7 +51,7 @@ problem usa2005_p2 :
   generalize (y' : ZMod 13) = y at *
   generalize (z' : ZMod 13) = z at *
   clear! x' y' z'
-  rw [←hM] at h1; rw [←hN] at h2
+  rw [← hM] at h1; rw [← hN] at h2
   have h3 : (x^3 + y + 1)^2 + z^9 = 147^157 + 157^147 + 1 := by
     linear_combination h1 + h2
   have h4 : (x^3 + 1) * (x^3 + y) = 147^157 := by linear_combination h1

--- a/Compfiles/Usa2011P4.lean
+++ b/Compfiles/Usa2011P4.lean
@@ -43,7 +43,7 @@ problem usa2011_p4 :
   refine ⟨by norm_num, ?_⟩
   rw [not_exists]
   intro x hx
-  rw [show 4 = 2^2 by rfl, ←Nat.pow_mul] at hx
+  rw [show 4 = 2^2 by rfl, ← Nat.pow_mul] at hx
 
   -- 2^(2^25) is small enough that we can just normalize it.
   set_option exponentiation.threshold 100000000 in

--- a/Compfiles/Usa2015P1.lean
+++ b/Compfiles/Usa2015P1.lean
@@ -49,9 +49,9 @@ problem usa2015_p1 (x y : ℤ) :
   apply iff_comm (c := ∃ t, x + y = 3 * t)
   · simp; intro h; obtain h | h := h
     all_goals obtain ⟨h, hx, hy⟩ := h; rw [hx, hy]; ring_nf; use (h + h ^ 2); ring_nf
-  · intro h; apply_fun (· * 3 ^ 3) at h; rw [←mul_pow, (add_mul _ 1)] at h; simp at h
+  · intro h; apply_fun (· * 3 ^ 3) at h; rw [← mul_pow, (add_mul _ 1)] at h; simp at h
     norm_num at h; norm_cast at h
-    suffices (x + y) % 3 = 0 by rw [←dvd_def]; exact Int.dvd_of_emod_eq_zero this
+    suffices (x + y) % 3 = 0 by rw [← dvd_def]; exact Int.dvd_of_emod_eq_zero this
     have h1 : (x ^ (2 : ℕ) + x * y + y ^ (2 : ℕ)) * (27 : ℤ) % 3 =
               (x + y + (3 : ℤ)) ^ (3 : ℕ) % 3 := by rw [h]
     clear h
@@ -71,14 +71,14 @@ problem usa2015_p1 (x y : ℤ) :
   rw [← Rat.intCast_add, ht]
   rw [(by cancel_denoms : ((3 * t) : ℤ) / (3 : ℚ) = t)]
   norm_cast
-  rw [(by rw [←ht]; linarith only : (x ^ 2 + x * y + y ^ 2) = (3 * t) ^ 2 + x * (x - 3 * t))]
+  rw [(by rw [← ht]; linarith only : (x ^ 2 + x * y + y ^ 2) = (3 * t) ^ 2 + x * (x - 3 * t))]
   trans (2 * x - 3 * t) ^ 2 = (t - 2) ^ 2 * (4 * t + 1)
   swap; constructor <;> intro h <;> linarith only [h]
   constructor
   · intro h
     simp at h
     obtain ⟨n, h1, h2⟩ | ⟨n, h1, h2⟩ := h
-    all_goals have ht : t = n ^ 2 + n := by rw [ht2, h1, h2]; ring_nf; rw [←add_mul]; simp
+    all_goals have ht : t = n ^ 2 + n := by rw [ht2, h1, h2]; ring_nf; rw [← add_mul]; simp
     all_goals rw [ht]; (first | rw [h1] | rw [h2]); ring_nf
   · intro ht3
     by_cases ht4 : (t = 2)
@@ -89,7 +89,7 @@ problem usa2015_p1 (x y : ℤ) :
       simp [*]; use 1; simp
     · obtain ⟨d, hd⟩ := abc (sub_ne_zero_of_ne ht4) ht3
       have Odd_dd : Odd (d ^ 2) := by
-        rw [←hd]; apply Even.add_one; apply Even.mul_right; exact Int.even_iff.mpr rfl
+        rw [← hd]; apply Even.add_one; apply Even.mul_right; exact Int.even_iff.mpr rfl
       have Odd_d  : Odd d := (Int.odd_pow' (by positivity)).mp Odd_dd
       set n := d / 2 with hn
       have nd : d = 2 * n + 1 := by rw [hn]; symm; exact Int.two_mul_ediv_two_add_one_of_odd Odd_d

--- a/Compfiles/Usa2018P1.lean
+++ b/Compfiles/Usa2018P1.lean
@@ -59,7 +59,7 @@ problem usa2018_p1 (a b c : ℝ) :
       · move_add [(b^2)]
         convert (H3 a c b ha hc hb ?_ h2 h1 ?_) using 3
         · linarith
-        · rw [min_comm, ←min_assoc, min_comm (a*a)]
+        · rw [min_comm, ← min_assoc, min_comm (a*a)]
         · linear_combination (norm := (field_simp; ring_nf)) 1 * heq
         · linarith
       · have aabb : a * a ≤ b * b := mul_self_le_mul_self (le_of_lt ha) h1
@@ -72,15 +72,15 @@ problem usa2018_p1 (a b c : ℝ) :
         rw [heq]
         have amgm := am_gm (a * ((4 : ℝ) * (a * b * c) ^ ((1 : ℝ) / 3))) (b * c)
                            (by positivity) (by positivity)
-        rw [←mul_le_mul_iff_right₀ zero_lt_four] at amgm
+        rw [← mul_le_mul_iff_right₀ zero_lt_four] at amgm
         convert! amgm
         ring_nf
         nth_rw 2 [(by simp : a * b * c = (a * b * c) ^ (1 : ℕ))]
-        rw [←Real.rpow_two, ←Real.rpow_mul (by positivity)]
-        rw [mul_comm ((a * b * c) ^ (1 : ℕ)), ←Real.rpow_add_natCast (by positivity)]
+        rw [← Real.rpow_two, ← Real.rpow_mul (by positivity)]
+        rw [mul_comm ((a * b * c) ^ (1 : ℕ)), ← Real.rpow_add_natCast (by positivity)]
         norm_num
         nth_rw 2 [Real.mul_rpow (by positivity) (by positivity)]
-        rw [←Real.rpow_mul (by positivity)]
+        rw [← Real.rpow_mul (by positivity)]
         norm_num
         rw [(mul_assoc _ _ 8)]
         simp only [mul_eq_mul_left_iff]

--- a/Compfiles/Usa2019P1.lean
+++ b/Compfiles/Usa2019P1.lean
@@ -138,7 +138,7 @@ lemma pnat_odd_mul {a b c : ℕ+} (h : a * b = c * c) (hc : Odd c.val) :
   apply_fun (fun x ↦ x.val) at h
   replace h : a * b = c * c := h
   have h1 : Odd (c * c) := Odd.mul hc hc
-  rw [←h] at h1
+  rw [← h] at h1
   exact Nat.odd_mul.mp h1
 
 lemma lemma_3
@@ -176,11 +176,11 @@ lemma lemma_3
          obtain h9 | h9 := H
          · replace h2 : m2 < f (f m2) := Ne.lt_of_le' h9 h2
            have h10 : m2 * m2 < f^[↑(f m2)] m2 * f (f m2) := mul_lt_mul_of_le_of_lt h4 h2
-           rw [←h1] at h10
+           rw [← h1] at h10
            exact LT.lt.false h10
          · replace h4 : m2 < f^[f m2] m2 := Ne.lt_of_le' h9 h4
            have h10 : m2 * m2 < f^[↑(f m2)] m2 * f (f m2) := mul_lt_mul_of_lt_of_le h4 h2
-           rw [←h1] at h10
+           rw [← h1] at h10
            exact LT.lt.false h10
       obtain ⟨h6, h7⟩ := h5
       have h8 : f^[2] m2 = f^[↑(f m2)] m2 := by rw[h7]; exact h6
@@ -218,9 +218,9 @@ problem usa2019_p1 (m : ℕ+) :
     constructor
     · intro n
       obtain heq | hne := eq_or_ne n 1000
-      · rw [heq, ←hmeq, hmeq1]
+      · rw [heq, ← hmeq, hmeq1]
         obtain ⟨m', hm'⟩ := hm
-        rw [←Nat.two_mul] at hm'
+        rw [← Nat.two_mul] at hm'
         rw [hm', Function.iterate_mul, Function.iterate_fixed hmsq']
         decide
       · obtain heq' | hne' := eq_or_ne n m

--- a/Compfiles/Usa2022P4.lean
+++ b/Compfiles/Usa2022P4.lean
@@ -59,7 +59,7 @@ problem usa2022_p4 (p q : ℕ) :
 
   -- Subtracting our equations gives (b - a)(b + a) = b² - a² = p(q - 1),
   have h1 : (b + a) * (b - a) = p * (q - 1) := by
-    rw [←Nat.sq_sub_sq, Nat.mul_sub_left_distrib, mul_one]
+    rw [← Nat.sq_sub_sq, Nat.mul_sub_left_distrib, mul_one]
     have h2 : (b^2 + q) - (a^2 + q) = p * q - p := by rw [ha, hb]
     rw [Nat.add_sub_add_right] at h2
     exact h2
@@ -79,7 +79,7 @@ problem usa2022_p4 (p q : ℕ) :
   have h3 : ¬ p ∣ b - a := Nat.not_dvd_of_pos_of_lt hba' h2
 
   have h4 : p ∣ p * (q - 1) := Nat.dvd_mul_right p (q - 1)
-  rw [←h1, mul_comm] at h4
+  rw [← h1, mul_comm] at h4
   have h5 : p ∣ b + a := Or.resolve_left ((Nat.Prime.dvd_mul hpp).mp h4) h3
 
   -- Since and b + a < 2p, we have that a + b must in fact equal p.
@@ -102,11 +102,11 @@ problem usa2022_p4 (p q : ℕ) :
   have h9 : q = 2 := by
     have h10 : (b + a) % 2 = (b - a) % 2 := by
       have h11 : b + a = b - a + 2 * a := by
-        rw [Nat.two_mul, ←add_assoc, add_left_inj]
+        rw [Nat.two_mul, ← add_assoc, add_left_inj]
         exact Nat.eq_add_of_sub_eq (Nat.le_of_lt hba) rfl
       rw [h11, Nat.add_mod]
       simp only [Nat.mul_mod_right, add_zero, Nat.mod_mod]
-    rw [h7, ←h8] at h10
+    rw [h7, ← h8] at h10
     cases h : p % 2 with
     | zero =>
       have h14 : p = 2 := by
@@ -121,7 +121,7 @@ problem usa2022_p4 (p q : ℕ) :
         norm_num at h
         rw [h] at h10
         apply_fun (fun x ↦ (x + (1%2))%2) at h10
-        rw [←Nat.add_mod, Nat.sub_add_cancel hq_pos] at h10
+        rw [← Nat.add_mod, Nat.sub_add_cancel hq_pos] at h10
         norm_num at h10
         have h15 : 2 ∣ q := Nat.modEq_zero_iff_dvd.mp h10.symm
         obtain h16 | h16 := Nat.Prime.eq_one_or_self_of_dvd hpq _ h15
@@ -133,7 +133,7 @@ problem usa2022_p4 (p q : ℕ) :
     have h22 : a ≤ b := Nat.le_of_lt hba
     have h21 : b = 1 + a := Nat.eq_add_of_sub_eq h22 h20
     have h23 : p = 2 * a + 1 := by
-      rw [h21, add_assoc, ←Nat.two_mul, add_comm] at h7
+      rw [h21, add_assoc, ← Nat.two_mul, add_comm] at h7
       exact h7.symm
     rw [h23, h9, Nat.succ_inj] at ha
     have h30 : a = 1 := by

--- a/Compfiles/Usa2023P2.lean
+++ b/Compfiles/Usa2023P2.lean
@@ -39,10 +39,10 @@ snip begin
 lemma val_div (a b : ℝ+) : (a / b).val = a.val / b.val := by rfl
 
 lemma lemma_1 (a b c : ℝ+) : (a + b)/c = a/c + b/c := by
-  rw [division_def, add_mul, ←division_def, ←division_def]
+  rw [division_def, add_mul, ← division_def, ← division_def]
 
 lemma lemma_3 {a b c : ℝ+} (h : a = b + c) : c < a := by
-  rw [h, ←Subtype.coe_lt_coe, Positive.coe_add]
+  rw [h, ← Subtype.coe_lt_coe, Positive.coe_add]
   exact lt_add_of_pos_left _ b.2
 
 snip end
@@ -58,7 +58,7 @@ problem usa2023_p2 (f : ℝ+ → ℝ+) :
     intro x y
     rw [hf]
     dsimp only
-    rw [mul_add, ←add_assoc (x*y), mul_one, add_assoc (x * y + x)]
+    rw [mul_add, ← add_assoc (x*y), mul_one, add_assoc (x * y + x)]
     congr
     rw [Subtype.mk_eq_mk]
     norm_num
@@ -71,14 +71,14 @@ problem usa2023_p2 (f : ℝ+ → ℝ+) :
       rw [solution_set, Set.mem_singleton_iff]
       obtain ⟨a, b, ha, hab⟩ := h
       funext x
-      rw [←Subtype.coe_inj]
+      rw [← Subtype.coe_inj]
 
       suffices h : a = 1 ∧ b = 1 by simp [hab, h]
 
       have P1 : ∀ x : ℝ+, a^2 * x.val + a * b + b = b * x.val + 2 := by
         intro x
         have P2 := P x 1
-        rw [←Subtype.coe_inj] at P2
+        rw [← Subtype.coe_inj] at P2
         simp only [mul_one, Positive.coe_add, Positive.val_mul, hab, Positive.val_one] at P2
         linarith
 
@@ -92,7 +92,7 @@ problem usa2023_p2 (f : ℝ+ → ℝ+) :
 
       have h0 : a^2 = b := by linear_combination hp2 - hp1
 
-      rw [←h0] at hp1 hp2
+      rw [← h0] at hp1 hp2
       have h1 : a = 1 := by nlinarith
       rw [h1, sq, mul_one] at h0
       exact ⟨h1, h0.symm⟩
@@ -141,7 +141,7 @@ problem usa2023_p2 (f : ℝ+ → ℝ+) :
       have h12 := P 1 ⟨1 - (f 1).val, h11⟩
       rw [one_mul, one_mul] at h12
       have h13 : ⟨1 - (f 1).val, h11⟩ + f 1 = 1 := by
-        rw [←Subtype.coe_inj]; simp only [Positive.coe_add, sub_add_cancel, Positive.val_one]
+        rw [← Subtype.coe_inj]; simp only [Positive.coe_add, sub_add_cancel, Positive.val_one]
       rw [h13] at h12; clear h13
       have h14 : ⟨2, two_pos⟩ < f 1 := lemma_3 h12
       have h15 : (1:ℝ+) < ⟨2, two_pos⟩ := by rw [Subtype.mk_lt_mk]; exact one_lt_two
@@ -163,7 +163,7 @@ problem usa2023_p2 (f : ℝ+ → ℝ+) :
       have h21 : (⟨(x + c).val - 1, h11 _⟩ : ℝ+) + 1 = x + c := by
         obtain ⟨x, hx⟩ := x
         obtain ⟨cc, hcc⟩ := c
-        rw [←Subtype.coe_inj]
+        rw [← Subtype.coe_inj]
         simp
       rw [h21] at h20
       exact h20
@@ -172,7 +172,7 @@ problem usa2023_p2 (f : ℝ+ → ℝ+) :
     intro x
 
     have h15 := h12 x
-    rw [←Subtype.coe_inj] at h15
+    rw [← Subtype.coe_inj] at h15
     rw [Positive.coe_add] at h15
     rw [val_div, Positive.val_mul, @Subtype.coe_mk _ _ 2] at h15
     rw [Subtype.coe_mk]

--- a/Compfiles/Usa2023P4.lean
+++ b/Compfiles/Usa2023P4.lean
@@ -155,7 +155,7 @@ lemma lemma5' {a x : ℕ} (hx : 0 < x)
   have h10 : x + a = 2 ^ padicValNat 2 x * (xx + 2 ^ (1 + c) * aa) := by
     nth_rw 1 [hxx]
     nth_rw 1 [haa]
-    rw [mul_assoc, ←mul_add]
+    rw [mul_assoc, ← mul_add]
 
   have h12 : 2 ^ padicValNat 2 x ∣ x + a := Dvd.intro _ h10.symm
   replace h12 := (Nat.pow_dvd_iff_le_padicValNat (by omega) (by lia)).mp h12
@@ -166,7 +166,7 @@ lemma lemma5' {a x : ℕ} (hx : 0 < x)
 
   have h16 : ¬ 2 ∣ xx := by
     rintro ⟨z, rfl⟩
-    rw [←mul_assoc, ←pow_succ] at hxx
+    rw [← mul_assoc, ← pow_succ] at hxx
     have h17 : 2 ^ (padicValNat 2 x + 1) ∣ x := Dvd.intro z hxx.symm
     replace h17 := (Nat.pow_dvd_iff_le_padicValNat (by omega) (Nat.ne_zero_of_lt hx)).mp h17
     lia
@@ -303,7 +303,7 @@ lemma lemma2' (a : ℕ+) (N : ℕ) (hN : 1 < N) (s0 : State N)
         push_cast at hie
         rw [Nat.not_even_iff_odd] at h3
         have h4 := Even.odd_add h2 h3
-        rw [←Nat.not_even_iff_odd] at h4
+        rw [← Nat.not_even_iff_odd] at h4
         exact h4 hie
       · rw [Function.update_of_ne hij] at hie
         have h3 := h1 i

--- a/Compfiles/ZeroesOnesAndTwos.lean
+++ b/Compfiles/ZeroesOnesAndTwos.lean
@@ -82,7 +82,7 @@ problem zeroes_and_ones
 
   obtain ⟨k, hk⟩ := lemma_3 h8 hab'
   use k
-  rw [←hk]
+  rw [← hk]
   have h4 : ∀ (l : ℕ), l ∈ List.replicate a 0 ++ List.replicate (b - a) 1 → l < 10 := by
     intro l hl
     rw [List.mem_append, List.mem_replicate, List.mem_replicate] at hl
@@ -141,7 +141,7 @@ lemma prepend_one_eq_append (n : ℕ) :
     rw [prepend_one_div _ (Nat.succ_pos n')]
     have hns : n'.succ / 10 < n'.succ := Nat.div_lt_self' n' 8
     rw [ih _ hns]
-    rw [←List.cons_append]
+    rw [← List.cons_append]
     rw [prepend_one_mod _ (Nat.succ_pos _), Nat.digits_def' two_le_ten (Nat.succ_pos n')]
 
 lemma prepend_one_all_one_or_two (n : ℕ) (hn : all_one_or_two (Nat.digits 10 n)) :
@@ -185,8 +185,8 @@ lemma prepend_two_eq_append (n : ℕ) :
     rw [prepend_two_div _ (Nat.succ_pos n')]
     have hns : n'.succ / 10 < n'.succ := Nat.div_lt_self' n' 8
     rw [ih _ hns]
-    rw [←List.cons_append]
-    rw [prepend_two_mod _ (Nat.succ_pos _), ←Nat.digits_def' two_le_ten (Nat.succ_pos n')]
+    rw [← List.cons_append]
+    rw [prepend_two_mod _ (Nat.succ_pos _), ← Nat.digits_def' two_le_ten (Nat.succ_pos n')]
 
 lemma prepend_two_all_one_or_two (n : ℕ) (hn : all_one_or_two (Nat.digits 10 n)) :
     all_one_or_two (Nat.digits 10 (prepend_two n)) := by
@@ -242,7 +242,7 @@ lemma ones_and_twos_aux (n : ℕ) :
         lia
       · exact Nat.succ_pos _
     use ⟨k', hkp'⟩
-    rw [PNat.mk_coe, ←hk']
+    rw [PNat.mk_coe, ← hk']
     constructor
     · rw [prepend_two_eq_append]
       rw [List.length_append, List.length_singleton, hpk1]
@@ -268,7 +268,7 @@ lemma ones_and_twos_aux (n : ℕ) :
         lia
       · exact Nat.succ_pos _
     use ⟨k', hkp'⟩
-    rw [PNat.mk_coe,←hk']
+    rw [PNat.mk_coe,← hk']
     constructor
     · rw [prepend_one_eq_append]
       rw [List.length_append, List.length_singleton, hpk1]


### PR DESCRIPTION
replaces:
- `<-` as `←`
- `←(\w)` as `← $1`
