### PR TITLE
Prune `from by exact`

### DIFF
--- a/Compfiles/Bulgaria1998P6.lean
+++ b/Compfiles/Bulgaria1998P6.lean
@@ -429,7 +429,7 @@ lemma lemma_1
   replace hs : 0 < s := Int.natCast_pos.mp hs
   replace ht : 0 < t := Int.natCast_pos.mp ht
   replace hy : 0 < u := Int.natCast_pos.mp hu
-  have h' : s ^ 4 = t ^ 4 + u ^ 2 := by exact Int.ofNat_inj.mp h
+  have h' : s ^ 4 = t ^ 4 + u ^ 2 := Int.ofNat_inj.mp h
   exact lemma_1' s t u hs ht hy h'
 
 snip end

--- a/Compfiles/Imo1961P1.lean
+++ b/Compfiles/Imo1961P1.lean
@@ -113,7 +113,7 @@ lemma aux_1
   let s : ℝ := ((3 * a ^ 2 - b ^ 2) * (3 * b ^ 2 - a ^ 2)) / (4 * a ^ 2)
   have hs : s = ((3 * a ^ 2 - b ^ 2) * (3 * b ^ 2 - a ^ 2)) / (4 * a ^ 2) := by rfl
   have h₁₄: discrim aq bq cq = s := by
-    have g₀: aq ≠ 0 := by exact Ne.symm (zero_ne_one' ℝ)
+    have g₀: aq ≠ 0 := Ne.symm (zero_ne_one' ℝ)
     apply (quadratic_eq_zero_iff_discrim_eq_sq g₀ y).mp at h₁₂
     rw [h₁₂, h₁₃]
     rw [haq, hbq, hcq, hs]
@@ -139,12 +139,12 @@ lemma aux_1
       · exact hc₂
       · positivity
     rw [← h₁₄] at hc₃
-    have h₁₅: aq ≠ 0 := by exact Ne.symm (zero_ne_one' ℝ)
+    have h₁₅: aq ≠ 0 := Ne.symm (zero_ne_one' ℝ)
     by_cases hc₄: s < 0
     · have hc₅: ∀ d:ℝ , discrim aq bq cq ≠ d ^ 2 := by
         intro d
         rw [h₁₄]
-        have hc₆: 0 ≤ d ^ 2 := by exact sq_nonneg d
+        have hc₆: 0 ≤ d ^ 2 := sq_nonneg d
         linarith
       exfalso
       exact hc₅ ((2 : ℝ) * (1 : ℝ) * y + -(a ^ (2 : ℕ) + b ^ (2 : ℕ)) / ((2 : ℝ) * a)) h₁₁
@@ -201,7 +201,7 @@ problem imo1961_p1b (a b x y z : ℝ) (h₀ : IsSolution a b x y z) :
     have h₆: 0 < x * y + (x + y) * z := by linarith
     have h₇: x * y + (x + y) * z < (x ^ 2 + y ^ 2 + z ^ 2) := by linarith
     rw [add_comm (x * y), h₂, pow_two, ← add_mul, h₀] at h₆
-    have hz₀: 0 < z := by exact (pos_iff_pos_of_mul_pos h₆).mp h₃
+    have hz₀: 0 < z := (pos_iff_pos_of_mul_pos h₆).mp h₃
     have h₈: 0 < x ∧ 0 < y := by
       have hx₀: 0 < x * y := by rw [h₂]; exact sq_pos_of_pos hz₀
       by_cases hx₁: 0 < x
@@ -212,7 +212,7 @@ problem imo1961_p1b (a b x y z : ℝ) (h₀ : IsSolution a b x y z) :
         have h₈₀: (x + y) ^ 2 - z ^ 2 = b ^ 2 := by
           rw [add_sq, mul_assoc 2, h₂, ← h₁]
           ring
-        have hy₀: y < 0 := by exact neg_of_mul_pos_right hx₀ hx₁
+        have hy₀: y < 0 := neg_of_mul_pos_right hx₀ hx₁
         have h₈₁: z ^ 2 < (x + y) ^ 2 := by
           refine lt_of_sub_pos ?_
           rw [h₈₀, ← h₁]
@@ -221,7 +221,7 @@ problem imo1961_p1b (a b x y z : ℝ) (h₀ : IsSolution a b x y z) :
           refine add_lt_of_lt_sub_left ?_
           apply sq_lt_sq.mp at h₈₁
           rw [zero_sub]
-          have hx₂ : x + y < 0 := by exact Right.add_neg_of_nonpos_of_neg hx₁ hy₀
+          have hx₂ : x + y < 0 := Right.add_neg_of_nonpos_of_neg hx₁ hy₀
           rw [abs_of_pos hz₀, abs_of_neg hx₂] at h₈₁
           exact h₈₁
         order

--- a/Compfiles/Imo1967P3.lean
+++ b/Compfiles/Imo1967P3.lean
@@ -69,7 +69,7 @@ lemma aux_3
   have h₃: ∀ (n m : ℕ), 0 < n → n.factorial ∣ ∏ i ∈ Finset.Icc 1 n, (m + i) := by
     exact fun (n m : ℕ) (a : 0 < n) ↦ aux_2 n m a
   have h₄: (n + (1 : ℕ)).factorial ∣ (k + m + 1) * (∏ i ∈ Finset.Icc (1 : ℕ) n, (m + i + k + (1 : ℕ))) := by
-    have hn₀ : 0 < n + 1 := by exact Nat.zero_lt_succ n
+    have hn₀ : 0 < n + 1 := Nat.zero_lt_succ n
     have h₈₁: ∀ i, m + i + k + (1 : ℕ) = m + k + (1 : ℕ) + i := by bound
     have h₈₂: (k + m + 1) * (∏ i ∈ Finset.Icc (1 : ℕ) n, (m + i + k + (1 : ℕ))) = ∏ i ∈ Finset.Ico (0 : ℕ) (n + 1), (m + i + k + (1 : ℕ)) := by
       simp_rw [h₈₁]
@@ -83,7 +83,7 @@ lemma aux_3
       group
     have h₈₄: ∏ i ∈ Finset.Ico (1 : ℕ) (n + (2 : ℕ)), (m + i + k) = ∏ i ∈ Finset.Icc (1 : ℕ) (n + (1 : ℕ)), (m + i + k) := by rfl
     rw [h₈₃, h₈₄]
-    have h₈₅: ∀ i, m + i + k = m + k + i := by exact fun (i : ℕ) ↦ Nat.add_right_comm m i k
+    have h₈₅: ∀ i, m + i + k = m + k + i := fun (i : ℕ) ↦ Nat.add_right_comm m i k
     simp_rw [h₈₅]
     exact h₃ (n + 1) (m + k) hn₀
   refine Nat.Coprime.dvd_of_dvd_mul_left ?_ h₄

--- a/Compfiles/Imo1967P5.lean
+++ b/Compfiles/Imo1967P5.lean
@@ -173,7 +173,7 @@ lemma aux_recursive (I : Finset (Fin 8)) (a : Fin 8 → ℝ)
           _ = |∑ k ∈ K, a k^N| := by simp [h_sum_I_pow_N_zero]
           _ ≤ ∑ k ∈ K, |a k^N| := Finset.abs_sum_le_sum_abs (fun i ↦ a i ^ N) K
           _ = ∑ k ∈ K, |a k|^N := by simp
-          _ ≤ ∑ k ∈ K, q^N := by exact Finset.sum_le_sum h_pow_ak_le_q
+          _ ≤ ∑ k ∈ K, q^N := Finset.sum_le_sum h_pow_ak_le_q
           _ = K.card * q^N := by simp
           _ ≤ 8 * q^N := by
             gcongr

--- a/Compfiles/Imo1973P3.lean
+++ b/Compfiles/Imo1973P3.lean
@@ -51,7 +51,7 @@ lemma aux_1
     have h₂₀: (x ^ 4 + a * x ^ 3 + b * x ^ 2 + a * x + 1) / (x ^ 2) = 0 / (x ^ 2) := by
       exact congr(HDiv.hDiv $h₁ (x ^ 2))
     ring_nf at h₂₀
-    have hx₁: x ^ 2 ≠ 0 := by exact pow_ne_zero 2 hx
+    have hx₁: x ^ 2 ≠ 0 := pow_ne_zero 2 hx
     rw [mul_comm (x ^ 2), mul_assoc b, inv_pow, mul_inv_cancel₀ hx₁, mul_one] at h₂₀
     rw [mul_comm x a, mul_assoc a, pow_two, mul_inv,
         ← mul_assoc x, mul_inv_cancel₀ hx, one_mul] at h₂₀
@@ -63,7 +63,7 @@ lemma aux_1
       ring_nf
       rw [mul_inv_cancel₀ hx]
       exact sub_eq_zero_of_eq rfl
-    have g₁: discrim 1 (-t) 1 = (-t) ^ 2 - 4 * 1 * 1 := by exact rfl
+    have g₁: discrim 1 (-t) 1 = (-t) ^ 2 - 4 * 1 * 1 := rfl
     simp at g₁
     by_contra hc₀
     push Not at hc₀
@@ -74,7 +74,7 @@ lemma aux_1
     apply sub_neg_of_lt at hc₁
     have hc₂: ∀ (s : ℝ), discrim 1 (-t) 1 ≠ s ^ 2 := by
       intro s
-      have hs: 0 ≤ s ^ 2 := by exact sq_nonneg s
+      have hs: 0 ≤ s ^ 2 := sq_nonneg s
       linarith
     have hc₃: 1 * (x * x) + -t * x + 1 ≠ 0 := by
       exact quadratic_ne_zero_of_discrim_ne_sq hc₂ x

--- a/Compfiles/Imo1973P6.lean
+++ b/Compfiles/Imo1973P6.lean
@@ -221,7 +221,7 @@ problem imo1973_p6 (npos : 0 < n) (hq : q ∈ Set.Ioo 0 1) (apos : ∀ i, 0 < a 
           · intro a _ b _ e
             exact Fin.eq_of_val_eq e
           · intro a h
-            use ⟨a, by exact Finset.mem_range.mp h⟩
+            use ⟨a, Finset.mem_range.mp h⟩
             simp
           · simp
         _ = ∑ j ≤ i.val, q ^ (j - i.val : ℤ).natAbs + ∑ j ∈ Finset.Ioo i.val n, q ^ (j - i.val : ℤ).natAbs := by

--- a/Compfiles/Imo1974P4.lean
+++ b/Compfiles/Imo1974P4.lean
@@ -118,7 +118,7 @@ lemma Rect.one_le_whiteCount (R : Rect) (hh : 1 ≤ R.h) (hw : 1 ≤ R.w)
     (hbal : R.whiteCount = R.blackCount) : 1 ≤ R.whiteCount := by
   have hcard := R.card_cells hh hw
   have hsum := R.whiteCount_add_blackCount
-  have hm : 1 ≤ R.h * R.w := by exact Nat.mul_le_mul hh hw
+  have hm : 1 ≤ R.h * R.w := Nat.mul_le_mul hh hw
   omega
 
 /-- A finite set of `k` distinct positive integers has sum at least

--- a/Compfiles/Imo1975P6.lean
+++ b/Compfiles/Imo1975P6.lean
@@ -109,8 +109,7 @@ problem imo1975_p6 {P : ℝ[X][Y]} : P ∈ solution_set ↔
   · rintro ⟨m, hp⟩
     refine ⟨⟨⟨m + 1, by omega⟩, ?_⟩, ?_, ?_⟩
     · intro t x y
-      simp [hp, eval_X, evalEval]
-      rw [show t * x + t * y = t * (x + y) from by ring, mul_pow]
+      simp [hp, eval_X, evalEval, ← mul_add, mul_pow]
       ring
     · intro a b c
       simp [hp, eval_X, evalEval]

--- a/Compfiles/Imo1976P4.lean
+++ b/Compfiles/Imo1976P4.lean
@@ -55,7 +55,7 @@ lemma prod_le_sum_pow_sum (s : Multiset ℕ) : s.prod ≤ s.sum ^ s.sum := by
         _ ≤ (i + s'.sum) * s'.sum ^ s'.sum := mul_le_mul_left (Nat.le_add_right _ _) _
         _ ≤ (i + s'.sum) * (i + s'.sum) ^ s'.sum :=
             mul_le_mul_right (pow_le_pow_left' (Nat.le_add_left _ _) _) _
-        _ = (i + s'.sum) ^ (s'.sum + 1) := by exact Nat.pow_add_one'.symm
+        _ = (i + s'.sum) ^ (s'.sum + 1) := Nat.pow_add_one'.symm
         _ ≤ (i + s'.sum) ^ (i + s'.sum) := by
           apply pow_le_pow_right'
           · exact Nat.le_add_right_of_le hi

--- a/Compfiles/Imo1977P5.lean
+++ b/Compfiles/Imo1977P5.lean
@@ -72,7 +72,7 @@ lemma aux_2
     (h₁ : q = (a ^ 2 + b ^ 2) / (a + b)) :
     q ^ 2 + r = 1977 → (a, b) ∈ solution_set := by
   intro h₂
-  have hr₀: r = 1977 - q ^ 2 := by exact Nat.eq_sub_of_add_eq' h₂
+  have hr₀: r = 1977 - q ^ 2 := Nat.eq_sub_of_add_eq' h₂
   have h₅₁: 0 < a + b := by linarith
   have h₅₂: a ^ 2 + b ^ 2 = q * (a + b) + r := by
     rw [h₀, h₁,]

--- a/Compfiles/Imo1978P6.lean
+++ b/Compfiles/Imo1978P6.lean
@@ -119,7 +119,7 @@ theorem induction_step [NeZero N] (h : ∀ (j i k), C i = C j → C j = C k → 
         have := Nat.mul_div_le (Δ'.card + (N - Cdone.card) - 1) (N - Cdone.card)
         rw [Nat.le_sub_iff_add_le, ← Nat.sub_le_iff_le_add, Nat.sub_add_comm] at this
         · exact this
-        · suffices 1 ≤ (Δ'.card + (N - Cdone.card) - 1) / (N - Cdone.card) by exact Nat.le_mul_of_pos_right _ this
+        · suffices 1 ≤ (Δ'.card + (N - Cdone.card) - 1) / (N - Cdone.card) from Nat.le_mul_of_pos_right _ this
           rw [← Nat.div_self NsCdpos]
           apply Nat.div_le_div_right
           rw [Nat.div_self NsCdpos]
@@ -247,7 +247,7 @@ theorem compute_finite_induction [NeZero N] (hC : ∀ (j i k), C i = C j → C j
       rw [h]
       simp
     apply induction_end C (compute_k N) hcom
-    suffices ∀ n ≤ N, motive' C n (compute_k n) by exact this N le_rfl
+    suffices ∀ n ≤ N, motive' C n (compute_k n) from this N le_rfl
     intro n
     induction n with
     | zero =>

--- a/Compfiles/Imo1979P6.lean
+++ b/Compfiles/Imo1979P6.lean
@@ -278,9 +278,9 @@ theorem a_even (n : ℕ) (npos : 0 < n) : a (2*n) = ((2+√2)^(n-1) - (2-√2)^(
   · unfold a b
     simp only [Set.ncard_eq_toFinset_card', Set.toFinset_card,
       show Fintype.card ↑{w : Octagon.Walk A E | isTerminalWalk w ∧ w.length = 2 * Nat.succ 0} = 0
-        from by decide,
+        by decide,
       show Fintype.card ↑{w : Octagon.Walk C E | isTerminalWalk w ∧ w.length = 2 * Nat.succ 0} = 1
-        from by decide]
+        by decide]
     norm_num
   · intro n npos ih
     rw [mul_add, mul_one]

--- a/Compfiles/Imo1979P6.lean
+++ b/Compfiles/Imo1979P6.lean
@@ -272,7 +272,7 @@ theorem a_b_recurrence_2 (n : ℕ) (npos : 0 < n) : b (n+2) = a n + 2 * b n := b
 
 
 theorem a_even (n : ℕ) (npos : 0 < n) : a (2*n) = ((2+√2)^(n-1) - (2-√2)^(n-1)) / √2 := by
-  suffices a (2*n) = ((2+√2)^(n-1) - (2-√2)^(n-1)) / √2 ∧ b (2*n) = ((2+√2)^(n-1) + (2-√2)^(n-1)) / 2 by exact this.left
+  suffices a (2*n) = ((2+√2)^(n-1) - (2-√2)^(n-1)) / √2 ∧ b (2*n) = ((2+√2)^(n-1) + (2-√2)^(n-1)) / 2 from this.left
   revert n
   apply Nat.le_induction
   · unfold a b

--- a/Compfiles/Imo1985P4.lean
+++ b/Compfiles/Imo1985P4.lean
@@ -203,7 +203,7 @@ lemma square_of_pow_of_first_k_prime_mod_two_eq {k m n : ℕ}
     · rw [funext_iff] at hmn
       have hmn'' := hmn k'
       rw [funext_iff] at hmn''
-      have h'k' : k' ∈ Finset.range (k + 1) := by exact Finset.mem_range_succ_iff.mpr hk'
+      have h'k' : k' ∈ Finset.range (k + 1) := Finset.mem_range_succ_iff.mpr hk'
       have hmn''' := hmn'' h'k'
       simp only [pow_of_first_k_prime_mod_two] at hmn'''
       exact hmn'''

--- a/Compfiles/Imo1985P6.lean
+++ b/Compfiles/Imo1985P6.lean
@@ -124,7 +124,7 @@ lemma aux_5
   rw [← hn₁, hf₃]
   have hmo₃: ∀ n, 0 < n → Function.Injective (f₀ n) := by
     exact fun n a => StrictMono.injective (hmo₂ n a)
-  have hn₂: (Function.invFun (f₀ n)) ∘ (f₀ n) = id := by exact Function.invFun_comp (hmo₃ n hn₀)
+  have hn₂: (Function.invFun (f₀ n)) ∘ (f₀ n) = id := Function.invFun_comp (hmo₃ n hn₀)
   rw [Function.comp_def (Function.invFun (f₀ n)) (f₀ n)] at hn₂
   have hn₃ : (fun x => Function.invFun (f₀ n) (f₀ n x)) x = id x :=
     (NNReal.eq (congrArg NNReal.toReal (congrFun hn₂.symm x))).symm
@@ -199,7 +199,7 @@ lemma aux_7
         exact Real.toNNReal_coe
       · intro d hd₀ hd₁
         rw [hf₂ (d + 1) 0 (by lia), h₁ d 0 (by lia)]
-        have hd₂: 0 ≤ f d 0 := by exact h₃ d 0 hd₀
+        have hd₂: 0 ≤ f d 0 := h₃ d 0 hd₀
         have hd₃: f d 0 = 0 := by
           rw [hf₂ d 0 (by lia)] at hd₁
           apply Real.toNNReal_eq_zero.mp at hd₁
@@ -223,7 +223,7 @@ lemma aux_8
   (hfb₁ : ∀ (n : ↑sn), f₀ (↑n) (fb n) = 1 - 1 / ↑↑n) :
   ∀ (n : ↑sn), fb n < 1 := by
   intro n
-  have hn₀: 0 < (n:ℕ) := by exact (hsn₁ n).2
+  have hn₀: 0 < (n:ℕ) := (hsn₁ n).2
   let z := fb n
   have hz₀: z = fb n := by rfl
   rw [← hz₀]
@@ -288,7 +288,7 @@ lemma aux_9
   intro m hm₀
   rw [hfb₀]
   refine Nat.le_induction ?_ ?_ m hm₀
-  · have g₁: fi 1 0 = 0 := by exact hf₅ 0
+  · have g₁: fi 1 0 = 0 := hf₅ 0
     have g₂: (2:NNReal).HolderConjugate (2:NNReal) := NNReal.HolderConjugate.two_two
     simp
     norm_cast
@@ -297,11 +297,11 @@ lemma aux_9
     have hx₀: x = fi 2 2⁻¹ := by rfl
     have hx₁: f₀ 2 x = 2⁻¹ := by
       rw [hx₀]
-      have g₃: Function.RightInverse (fi 2) (f₀ 2) := by exact hmo₇ 2 (by lia)
+      have g₃: Function.RightInverse (fi 2) (f₀ 2) := hmo₇ 2 (by lia)
       exact g₃ 2⁻¹
     rw [← hx₀]
     contrapose! hx₁
-    have hc₁: x = 0 := by exact nonpos_iff_eq_zero.mp hx₁
+    have hc₁: x = 0 := nonpos_iff_eq_zero.mp hx₁
     have hc₃: f₀ 2 x = 0 := by
       rw [hc₁, hf₂ 2 0 (by lia), h₁ 1 0 (by lia), h₀ 0]
       norm_cast
@@ -328,7 +328,7 @@ lemma aux_9
         refine inv_lt_one_of_one_lt₀ ?_
         norm_cast
         exact Nat.lt_add_right 1 hn₀
-      · have g₀: (↑n:NNReal)⁻¹ ≤ 1 := by exact Nat.cast_inv_le_one n
+      · have g₀: (↑n:NNReal)⁻¹ ≤ 1 := Nat.cast_inv_le_one n
         rw [NNReal.coe_sub g₀, NNReal.coe_inv]
         simp
         refine inv_strictAnti₀ ?_ ?_
@@ -368,7 +368,7 @@ lemma aux_10
     have g₁: (2:NNReal).HolderConjugate (2:NNReal) := NNReal.HolderConjugate.two_two
     rw [hfb₀]
     simp
-    have hnb₁: nb.val = 2 := by exact rfl
+    have hnb₁: nb.val = 2 := rfl
     rw [hnb₁]
     norm_cast
     rw [NNReal.HolderConjugate.one_sub_inv g₁]
@@ -376,11 +376,11 @@ lemma aux_10
     have hx₀: x = fi 2 2⁻¹ := by rfl
     have hx₁: f₀ 2 x = 2⁻¹ := by
       rw [hx₀]
-      have g₃: Function.RightInverse (fi 2) (f₀ 2) := by exact hmo₇ 2 (by lia)
+      have g₃: Function.RightInverse (fi 2) (f₀ 2) := hmo₇ 2 (by lia)
       exact g₃ 2⁻¹
     rw [← hx₀]
     contrapose! hx₁
-    have hc₁: x = 0 := by exact nonpos_iff_eq_zero.mp hx₁
+    have hc₁: x = 0 := nonpos_iff_eq_zero.mp hx₁
     have hc₃: f₀ 2 x = 0 := by
       rw [hc₁, hf₂ 2 0 (by lia), h₁ 1 0 (by lia), h₀ 0]
       norm_cast
@@ -434,9 +434,9 @@ lemma aux_11
     · rw [hn₁]
       exact hfc₂ nb
   by_contra! hc₀
-  have hc₁: ∃ x ∈ sbr, cr < x ∧ x ≤ br := by exact IsLUB.exists_between hbr₀ hc₀
+  have hc₁: ∃ x ∈ sbr, cr < x ∧ x ≤ br := IsLUB.exists_between hbr₀ hc₀
   let ⟨x, hx₀, hx₁, _⟩ := hc₁
-  have hc₂: ∃ y ∈ scr, cr ≤ y ∧ y < x := by exact IsGLB.exists_between hcr₀ hx₁
+  have hc₂: ∃ y ∈ scr, cr ≤ y ∧ y < x := IsGLB.exists_between hcr₀ hx₁
   let ⟨y, hy₀, _, hy₂⟩ := hc₂
   have hc₃: x < y := by
     have hx₃: x.toNNReal ∈ sb := by
@@ -459,7 +459,7 @@ lemma aux_11
     let ⟨ny, hny₀⟩ := hy₃
     have hy₄: 0 < y := by
       contrapose! hy₃
-      have hy₅: y.toNNReal = 0 := by exact Real.toNNReal_of_nonpos hy₃
+      have hy₅: y.toNNReal = 0 := Real.toNNReal_of_nonpos hy₃
       intro z
       rw [hy₅]
       exact ne_zero_of_lt (hfc₂ z)
@@ -501,8 +501,8 @@ lemma aux_exists
   obtain hu₆ | hu₆ := lt_or_eq_of_le hu₅
   · apply exists_between at hu₆
     let ⟨a, ha₀, ha₁⟩ := hu₆
-    have ha₂: 0 < a := by exact gt_trans ha₀ hbr₁
-    have ha₃: 0 < a.toNNReal := by exact Real.toNNReal_pos.mpr ha₂
+    have ha₂: 0 < a := gt_trans ha₀ hbr₁
+    have ha₃: 0 < a.toNNReal := Real.toNNReal_pos.mpr ha₂
     use a.toNNReal
     intro n hn₀
     have hn₁: n ∈ sn := by
@@ -679,9 +679,9 @@ lemma aux_unique_top_ind
       exact hn₀
     let nn : ↑sd := ⟨n, hn₃⟩
     have hn₄: nn.1 + 1 ∈ sd := hd₃ nn
-    have hn₅: fd a b nn * (2 - 1 / ↑n) ≤ fd a b ⟨nn.1 + 1, hn₄⟩ := by exact hd₂ nn
+    have hn₅: fd a b nn * (2 - 1 / ↑n) ≤ fd a b ⟨nn.1 + 1, hn₄⟩ := hd₂ nn
     rw [hfd₁ a b ⟨nn.1 + 1, hn₄⟩] at hn₅
-    have hn₆: f (↑nn + 1) b - f (↑nn + 1) a = f (n + 1) b - f (n + 1) a := by exact rfl
+    have hn₆: f (↑nn + 1) b - f (↑nn + 1) a = f (n + 1) b - f (n + 1) a := rfl
     rw [hn₆] at hn₅
     refine le_trans ?_ hn₅
     rw [hn₂, pow_succ (3/2) (n - 2), ← mul_assoc (fd a b i)]
@@ -766,7 +766,7 @@ lemma aux_unique_top
     · refine one_le_pow₀ ?_
       norm_num
   · push Not at hz₀
-    have hz₁: 0 < fd a b i := by exact hd₁ i a b ha₀
+    have hz₁: 0 < fd a b i := hd₁ i a b ha₀
     have hz₂: 0 < Real.log (z / fd a b i) := by
       refine Real.log_pos ?_
       exact (one_lt_div hz₁).mpr hz₀
@@ -817,10 +817,10 @@ lemma aux_unique_nhds
     exact Set.nonempty_Ici_subtype
   refine tendsto_atTop_nhds.mpr ?_
   intro U hU₀ hU₁
-  have hU₂: U ∈ nhds 0 := by exact IsOpen.mem_nhds hU₁ hU₀
+  have hU₂: U ∈ nhds 0 := IsOpen.mem_nhds hU₁ hU₀
   apply mem_nhds_iff_exists_Ioo_subset.mp at hU₂
   obtain ⟨l, u, hl₀, hl₁⟩ := hU₂
-  have hl₂: 0 < u := by exact (Set.mem_Ioo.mpr hl₀).2
+  have hl₂: 0 < u := (Set.mem_Ioo.mpr hl₀).2
   let nd := 2 + Nat.ceil (1/u)
   have hnd₀: nd ∈ sd := by
     rw [hsd]
@@ -837,8 +837,8 @@ lemma aux_unique_nhds
     exact (Set.mem_Ioo.mp hl₀).1
   · have hn₁: fd a b n < 1 / n := by
       rw [hfd₁]
-      have ha₂: 1 - 1 / n < f n a := by exact (ha₁ n).1.1
-      have hb₁: f n b < 1 := by exact (ha₁ n).2.2
+      have ha₂: 1 - 1 / n < f n a := (ha₁ n).1.1
+      have hb₁: f n b < 1 := (ha₁ n).2.2
       refine sub_lt_iff_lt_add.mpr ?_
       refine lt_trans hb₁ ?_
       exact sub_lt_iff_lt_add'.mp ha₂
@@ -874,7 +874,7 @@ lemma aux_unique
   intro x y hx₀ hy₀
   let sd : Set ℕ := Set.Ici 2
   let fd : NNReal → NNReal → ↑sd → ℝ := fun y₁ y₂ n => (f n.1 y₂ - f n.1 y₁)
-  have hfd₁: ∀ y₁ y₂ n, fd y₁ y₂ n = f n.1 y₂ - f n.1 y₁ := by exact fun y₁ y₂ n => rfl
+  have hfd₁: ∀ y₁ y₂ n, fd y₁ y₂ n = f n.1 y₂ - f n.1 y₁ := fun y₁ y₂ n => rfl
   have hd₁: ∀ n a b, a < b → 0 < fd a b n := by
     intro nd a b hnd₀
     rw [hfd₁]
@@ -895,7 +895,7 @@ lemma aux_unique
   · have hy₂: Filter.Tendsto (fd x y) Filter.atTop Filter.atTop := by
       refine hfd₂ x y hy₁ ?_
       intro nd
-      have hnd₀: 0 < nd.1 := by exact lt_of_lt_of_le (two_pos) nd.2
+      have hnd₀: 0 < nd.1 := lt_of_lt_of_le (two_pos) nd.2
       constructor
       · exact (hx₀ nd.1 hnd₀).2.1
       · exact (hy₀ nd.1 hnd₀).2.1
@@ -905,7 +905,7 @@ lemma aux_unique
       have hnd₀: 0 < nd.1 := by
         refine lt_of_lt_of_le ?_ nd.2
         exact Nat.zero_lt_two
-      have hnd₁: nd.1 - 1 + 1 = nd.1 := by exact Nat.sub_add_cancel hnd₀
+      have hnd₁: nd.1 - 1 + 1 = nd.1 := Nat.sub_add_cancel hnd₀
       have hnd₂: 0 < nd.1 - 1 := by
         refine Nat.sub_pos_of_lt ?_
         refine lt_of_lt_of_le ?_ nd.2
@@ -933,7 +933,7 @@ lemma aux_unique
     constructor
     · exact isOpen_Ioo
     · intro N
-      have hy₅: ∃ i, ∀ (a : ↑sd), i ≤ a → N + 3 ≤ fd x y a := by exact hy₂ (N + 3)
+      have hy₅: ∃ i, ∀ (a : ↑sd), i ≤ a → N + 3 ≤ fd x y a := hy₂ (N + 3)
       obtain ⟨i, hi₀⟩ := hy₅
       have hi₁: (N.1 + i.1) ∈ sd := by
         refine Set.mem_Ici.mpr ?_
@@ -958,15 +958,15 @@ lemma aux_unique
     have hy₃: Filter.Tendsto (fd y x) Filter.atTop Filter.atTop := by
       refine hfd₂ y x hy₂ ?_
       intro nd
-      have hnd₀: 0 < nd.1 := by exact lt_of_lt_of_le (two_pos) nd.2
+      have hnd₀: 0 < nd.1 := lt_of_lt_of_le (two_pos) nd.2
       constructor
       · exact (hy₀ nd.1 hnd₀).2.1
       · exact (hx₀ nd.1 hnd₀).2.1
     have hy₄: Filter.Tendsto (fd y x) Filter.atTop (nhds 0) := by
       refine hfd₃ y x hy₂ ?_
       intro nd
-      have hnd₀: 0 < nd.1 := by exact lt_of_lt_of_le (Nat.zero_lt_two) nd.2
-      have hnd₁: nd.1 - 1 + 1 = nd.1 := by exact Nat.sub_add_cancel hnd₀
+      have hnd₀: 0 < nd.1 := lt_of_lt_of_le (Nat.zero_lt_two) nd.2
+      have hnd₁: nd.1 - 1 + 1 = nd.1 := Nat.sub_add_cancel hnd₀
       have hnd₂: 0 < nd.1 - 1 := by
         refine Nat.sub_pos_of_lt ?_
         exact lt_of_lt_of_le (Nat.one_lt_two) nd.2
@@ -993,7 +993,7 @@ lemma aux_unique
     constructor
     · exact isOpen_Ioo
     · intro N
-      have hy₅: ∃ i, ∀ (a : ↑sd), i ≤ a → N + 3 ≤ fd y x a := by exact hy₃ (N + 3)
+      have hy₅: ∃ i, ∀ (a : ↑sd), i ≤ a → N + 3 ≤ fd y x a := hy₃ (N + 3)
       obtain ⟨i, hi₀⟩ := hy₅
       have hi₁: (N.1 + i.1) ∈ sd := by
         refine Set.mem_Ici.mpr ?_
@@ -1083,7 +1083,7 @@ lemma imo_1985_p6_nnreal
   let fc : ↑sn → NNReal := sn.domRestrict (fun (n:ℕ) => fi n 1)
   have hsn₁: ∀ n:↑sn, ↑n ∈ sn ∧ 0 < (↑n:ℕ) := by
     intro n
-    have hn₀: ↑n ∈ sn := by exact Subtype.coe_prop n
+    have hn₀: ↑n ∈ sn := Subtype.coe_prop n
     constructor
     · exact Subtype.coe_prop n
     · exact hn₀
@@ -1091,19 +1091,19 @@ lemma imo_1985_p6_nnreal
   have hfc₀: fc = fun (n:↑sn) => fi n 1 := by rfl
   have hfb₁: ∀ n:↑sn, f₀ n (fb n) = 1 - 1 / (n:NNReal) := by
     intro n
-    have hn₀: 0 < (n:ℕ) := by exact (hsn₁ n).2
+    have hn₀: 0 < (n:ℕ) := (hsn₁ n).2
     rw [hfb₀]
     exact hmo₁ n hn₀ (congrArg (f n) (hmo₇ n hn₀ (1 - 1 / (n:NNReal))))
   have hfc₁: ∀ n:↑sn, f₀ n (fc n) = 1 := by
     intro n
-    have hn₀: 0 < (n:ℕ) := by exact (hsn₁ n).2
+    have hn₀: 0 < (n:ℕ) := (hsn₁ n).2
     rw [hfc₀]
     exact hmo₁ n hn₀ (congrArg (f n) (hmo₇ n hn₀ 1))
   have hu₁: ∀ n:↑sn, fb n < 1 := by
     exact aux_8 f h₀ h₁ hmo₀ hmo₁ f₀ hf₂ sn fb hsn₁ hfb₁
   have hfc₂: ∀ n:↑sn, fb n < fc n := by
     intro n
-    have hn₀: 0 < (n:ℕ) := by exact (hsn₁ n).2
+    have hn₀: 0 < (n:ℕ) := (hsn₁ n).2
     have g₀: f₀ n (fb n) < f₀ n (fc n) := by
       rw [hfb₁ n, hfc₁ n]
       simp
@@ -1120,21 +1120,21 @@ lemma imo_1985_p6_nnreal
     have g₀: StrictAntiOn (fun n => fi n 1) sn := by
       refine strictAntiOn_Ici_of_lt_pred ?_
       intro m hm₀
-      have hm₁: 0 < m - 1 := by exact Nat.zero_lt_sub_of_lt hm₀
+      have hm₁: 0 < m - 1 := Nat.zero_lt_sub_of_lt hm₀
       have hm₂: m = m - 1 + 1 := by rw [Nat.sub_add_cancel (le_of_lt hm₀)]
-      have hm₃: 0 < m := by exact Nat.zero_lt_of_lt hm₀
+      have hm₃: 0 < m := Nat.zero_lt_of_lt hm₀
       simp
       let x := fi m 1
       let y := fi (m - 1) 1
       have hx₀: x = fi m 1 := by rfl
       have hy₀: y = fi (m - 1) 1 := by rfl
-      have hx₁: f₀ m x = 1 := by exact (hf₇ m x 1 (by lia)).mpr hx₀.symm
+      have hx₁: f₀ m x = 1 := (hf₇ m x 1 (by lia)).mpr hx₀.symm
       have hy₁: f₀ (m - 1) y = 1 := by
         exact (hf₇ (m - 1) y 1 hm₁).mpr hy₀.symm
       have hy₂: f (m - 1) y = 1 := by
         rw [hf₁ (m - 1) y hm₁, hy₁]
         exact rfl
-      have hf: StrictMono (f m) := by exact hmo₀ m hm₃
+      have hf: StrictMono (f m) := hmo₀ m hm₃
       refine (StrictMono.lt_iff_lt hf).mp ?_
       rw [← hx₀, ← hy₀]
       rw [hf₁ m x hm₃, hf₁ m y hm₃]
@@ -1147,8 +1147,8 @@ lemma imo_1985_p6_nnreal
     simp
     let mn : ℕ := ↑m
     let nn : ℕ := ↑n
-    have hm₀: mn ∈ sn := by exact Subtype.coe_prop m
-    have hn₀: nn ∈ sn := by exact Subtype.coe_prop n
+    have hm₀: mn ∈ sn := Subtype.coe_prop m
+    have hn₀: nn ∈ sn := Subtype.coe_prop n
     exact g₀ hm₀ hn₀ hmn
   let sb := Set.range fb
   let sc := Set.range fc

--- a/Compfiles/Imo1989P6.lean
+++ b/Compfiles/Imo1989P6.lean
@@ -172,7 +172,7 @@ def transform_A_to_B [NeZero n] : (A n) → (B n) := fun x ↦ by
       grind
     and_intros
     · contrapose! ndiff
-      replace ndiff : k = 1 := by exact SetLike.coe_eq_coe.mp ndiff
+      replace ndiff : k = 1 := SetLike.coe_eq_coe.mp ndiff
       rw [show x_1 = (x.val 1) by rfl]
       rw [show x_k = (x.val 1) by rw [← ndiff]; unfold k; simp]
       simp

--- a/Compfiles/Imo1990P3.lean
+++ b/Compfiles/Imo1990P3.lean
@@ -112,7 +112,7 @@ lemma imo_1990_p3_forward
       refine lt_trans ?_ hn₀
       exact Nat.one_lt_two
     let p : ℕ := Finset.min' sp hsp₁
-    have hp₀: p ∈ sp := by exact Finset.min'_mem sp hsp₁
+    have hp₀: p ∈ sp := Finset.min'_mem sp hsp₁
     have hp₁: Nat.Prime p := Nat.prime_of_mem_primeFactors hp₀
     have hp₂: ∀ x ∈ sp, x ≠ p → p < x := by
       intro x hx₀ hx₁
@@ -154,7 +154,7 @@ lemma imo_1990_p3_forward
         · exact Nat.zero_lt_two
         · refine le_of_eq ?_
           have hh₀: Nat.gcd n (p - 1) = 1 := by
-            have g₀: n ≠ (0 : ℕ) := by exact Nat.ne_zero_of_lt h₀
+            have g₀: n ≠ (0 : ℕ) := Nat.ne_zero_of_lt h₀
             have g₁: p - (1 : ℕ) ≠ (0 : ℕ) := by
               have g₁₀: 2 ≤ p := Nat.Prime.two_le hp₁
               lia
@@ -170,13 +170,13 @@ lemma imo_1990_p3_forward
                 · exact Nat.le_of_mem_primeFactors hx₀
               refine Finset.disjoint_left.mpr ?_
               intro x hx₀
-              have hx₁: p ≤ x := by exact g₂ x hx₀
+              have hx₁: p ≤ x := g₂ x hx₀
               contrapose! hx₁
               exact g₃ x hx₁
             apply Nat.primeFactors_eq_empty.mp at hh₀₀
             obtain hh₀₀ | hh₀₀ := hh₀₀
             · exfalso
-              have hh₀₁: n.gcd (p - (1 : ℕ)) ≠ (0 : ℕ) := by exact Nat.gcd_ne_zero_left g₀
+              have hh₀₁: n.gcd (p - (1 : ℕ)) ≠ (0 : ℕ) := Nat.gcd_ne_zero_left g₀
               exact hh₀₁ hh₀₀
             · exact hh₀₀
           rw [Nat.gcd_comm]
@@ -197,7 +197,7 @@ lemma imo_1990_p3_forward
     have hp₆: ∃ d:ℕ, n = d * p ^ k ∧ ¬ 3 ∣ d := by
       rw [hp₃]
       use n / 3 ^ k
-      have hp₆₀: (3 : ℕ) ^ k ∣ n := by exact pow_multiplicity_dvd (3 : ℕ) n
+      have hp₆₀: (3 : ℕ) ^ k ∣ n := pow_multiplicity_dvd (3 : ℕ) n
       constructor
       · exact (Nat.div_mul_cancel hp₆₀).symm
       · by_contra! hh₀
@@ -262,7 +262,7 @@ lemma imo_1990_p3_forward
       · let sq : Finset ℕ := d.primeFactors
         have hsq₁: sq.Nonempty := Nat.nonempty_primeFactors.mpr hd₂
         let q : ℕ := Finset.min' sq hsq₁
-        have hq₀: q ∈ sq := by exact Finset.min'_mem sq hsq₁
+        have hq₀: q ∈ sq := Finset.min'_mem sq hsq₁
         have hq₁: Nat.Prime q := Nat.prime_of_mem_primeFactors hq₀
         have hq₂: q ∣ d := Nat.dvd_of_mem_primeFactors hq₀
         have hq₃: q ∣ n := by
@@ -283,13 +283,13 @@ lemma imo_1990_p3_forward
               exact Finset.min'_le sq x hx₀
             have hh₀₃: Nat.gcd (q - 1) d = 1 := by
               have hh₀₃₀: q - (1 : ℕ) ≠ (0 : ℕ) := by lia
-              have hh₀₃₁: d ≠ 0 := by exact Nat.ne_zero_of_lt hd₂
+              have hh₀₃₁: d ≠ 0 := Nat.ne_zero_of_lt hd₂
               have hh₀₃₂: ((q - 1).gcd d).primeFactors = ∅ := by
                 rw [Nat.primeFactors_gcd hh₀₃₀ hh₀₃₁]
                 refine Finset.disjoint_iff_inter_eq_empty.mp ?_
                 refine Finset.disjoint_left.mpr ?_
                 intro x hx₀
-                have hx₁: x ≤ q - (1 : ℕ) := by exact hh₀₁ x hx₀
+                have hx₁: x ≤ q - (1 : ℕ) := hh₀₁ x hx₀
                 contrapose! hx₁
                 refine Nat.lt_of_succ_le ?_
                 rw [Nat.succ_eq_add_one, Nat.sub_add_cancel (by bound)]
@@ -297,7 +297,7 @@ lemma imo_1990_p3_forward
               apply Nat.primeFactors_eq_empty.mp at hh₀₃₂
               obtain hh₀₃₂ | hh₀₃₂ := hh₀₃₂
               · exfalso
-                have hh₀₁: (q - 1).gcd d ≠ (0 : ℕ) := by exact Nat.gcd_ne_zero_left hh₀₃₀
+                have hh₀₁: (q - 1).gcd d ≠ (0 : ℕ) := Nat.gcd_ne_zero_left hh₀₃₀
                 exact hh₀₁ hh₀₃₂
               · exact hh₀₃₂
             have hh₀₄: Nat.Coprime d (p ^ k) := by
@@ -369,7 +369,7 @@ lemma imo_1990_p3_forward
             refine Nat.not_dvd_of_pos_of_lt ?_ ?_
             · exact Nat.zero_lt_succ (2 : ℕ)
             · exact Nat.lt_of_add_left_lt hq₅
-          have hh₇: q ≤ 7 := by exact Nat.le_of_dvd (by lia) hh₆
+          have hh₇: q ≤ 7 := Nat.le_of_dvd (by lia) hh₆
           interval_cases q
           · exfalso
             lia

--- a/Compfiles/Imo1991P6.lean
+++ b/Compfiles/Imo1991P6.lean
@@ -109,7 +109,7 @@ theorem one_sub_fract_sqrt_two_mul_gt (k : ℕ) (kpos : 0 < k) : 1 - Int.fract (
   have : 0 ≤ (y:ℝ) := by positivity
 
   have h_diff : ((y:ℝ) + 1 - x) * ((y:ℝ) + 1 + x) = (y + 1) ^ 2 - 2 * k ^ 2 := by
-    rw [show 2 * k ^ 2 = x ^ 2 from by unfold x; simp [mul_pow]]
+    rw [show 2 * k ^ 2 = x ^ 2 by unfold x; simp [mul_pow]]
     rw [mul_comm, sq_sub_sq]
 
   have h_diff_pos : (y + 1) ^ 2 - 2 * (k:ℤ) ^ 2 ≥ 1 := by

--- a/Compfiles/Imo1992P5.lean
+++ b/Compfiles/Imo1992P5.lean
@@ -140,8 +140,7 @@ private theorem main (S : Finset (ℝ × ℝ × ℝ)) :
       _ ≤ ∑ r ∈ R, (sz * ar r * br r).sqrt := Finset.sum_le_sum hslice
       _ = ∑ r ∈ R, sz.sqrt * (ar r * br r).sqrt := by
             congr 1; ext r
-            rw [show sz * ar r * br r = sz * (ar r * br r) from by ring,
-                Real.sqrt_mul (Nat.cast_nonneg _)]
+            rw [mul_assoc, Real.sqrt_mul (Nat.cast_nonneg _)]
       _ = sz.sqrt * ∑ r ∈ R, (ar r * br r).sqrt := (Finset.mul_sum ..).symm
   -- Step 3: Square both sides: |S|² ≤ sz · (Σ √(ar · br))²
   have hS2 : (S.card : ℝ) ^ 2 ≤ sz * (∑ r ∈ R, (ar r * br r).sqrt) ^ 2 := by

--- a/Compfiles/Imo1993P5.lean
+++ b/Compfiles/Imo1993P5.lean
@@ -64,7 +64,7 @@ lemma imo_1993_p5_N:
     exact h₁ n
   have hg₀: 2 < √5 := by
     have g₀: 0 ≤ (2:ℝ) := zero_le_two
-    have g₁: 0 ≤ √5 := by exact Real.sqrt_nonneg 5
+    have g₁: 0 ≤ √5 := Real.sqrt_nonneg 5
     rw [← abs_of_nonneg g₀, ← abs_of_nonneg g₁]
     refine sq_lt_sq.mp ?_
     rw [Real.sq_sqrt (by positivity)]
@@ -110,7 +110,7 @@ lemma imo_1993_p5_N:
       have h₂₁: |(fz (fz ↑n) - G * fz ↑n) + (G - 1) * (fz ↑n - G * ↑n)| < 1 := by
         refine lt_of_le_of_lt (abs_add_le ((fz (fz ↑n) - G * fz ↑n)) ((G - 1) * (fz ↑n - G * ↑n))) ?_
         rw [abs_mul]
-        have g₀: |↑(fz (fz ↑n)) - G * ↑(fz ↑n)| ≤ 1 / 2 := by exact h₂₀ (fz ↑n)
+        have g₀: |↑(fz (fz ↑n)) - G * ↑(fz ↑n)| ≤ 1 / 2 := h₂₀ (fz ↑n)
         have g₁: |(G - 1)| * |(↑(fz ↑n) - G * ↑n)| ≤ (G - 1) * (1 / 2) := by
           rw [abs_of_nonneg ?_]
           · refine (mul_le_mul_iff_right₀ hg₁).mpr ?_

--- a/Compfiles/Imo1993P6.lean
+++ b/Compfiles/Imo1993P6.lean
@@ -169,8 +169,7 @@ lemma all_on_of_last_only {n : ℕ} [NeZero n] (hn : 1 < n)
         rw [pos_after, Nat.cast_add, hT0, zero_add]
       have hstep : step^[n * (n - 1) + (j + 1)] (initial n) =
           step (step^[n * (n - 1) + j] (initial n)) := by
-        rw [show n * (n - 1) + (j + 1) = (n * (n - 1) + j) + 1 from by omega,
-          Function.iterate_succ_apply']
+        rw [← add_assoc, Function.iterate_succ_apply']
       intro i
       show (step^[n * (n - 1) + (j + 1)] (initial n)).1 i =
         decide (i.val < j + 1 ∨ i.val = n - 1)
@@ -275,15 +274,12 @@ lemma all_on_of_lamp1_only {n : ℕ} [NeZero n] (hn : 2 < n)
       (step^[n * (n - 2)] (initial n)).1 := by
     have hcond : (step^[n * (n - 2) + 1] (initial n)).1
         ((step^[n * (n - 2) + 1] (initial n)).2 - 1) = false := by
-      rw [hidle1, pos_after,
-        show ((n * (n - 2) + 1 : ℕ) : Fin n) = 1 from by
-          rw [Nat.cast_add_one, hT0, zero_add],
+      rw [hidle1, pos_after, Nat.cast_add_one, hT0, zero_add,
         sub_self, h', decide_eq_false_iff_not]
       have hz : ((0 : Fin n) : ℕ) = 0 := by simp
       rw [hz]
       omega
-    rw [show n * (n - 2) + 2 = (n * (n - 2) + 1) + 1 from by omega,
-      Function.iterate_succ_apply', step_lamps_eq_of_pred_off hcond, hidle1]
+    rw [Function.iterate_succ_apply', step_lamps_eq_of_pred_off hcond, hidle1]
   -- Lamps `1, …, j - 1` are on after `n * (n - 2) + j` steps, for `2 ≤ j ≤ n`.
   have key : ∀ j : ℕ, 2 ≤ j → j ≤ n → ∀ i : Fin n,
       (step^[n * (n - 2) + j] (initial n)).1 i = decide (1 ≤ i.val ∧ i.val < j) := by
@@ -294,8 +290,8 @@ lemma all_on_of_lamp1_only {n : ℕ} [NeZero n] (hn : 2 < n)
       intro hj2 hjN
       by_cases hjbase : j + 1 = 2
       · intro i
-        rw [show n * (n - 2) + (j + 1) = n * (n - 2) + 2 from by omega, hidle2, h']
-        rw [Bool.decide_congr (by omega : (i.val = 1) ↔ (1 ≤ i.val ∧ i.val < j + 1))]
+        rw [hjbase, hidle2, h']
+        rw [Bool.decide_congr (by omega : (i.val = 1) ↔ (1 ≤ i.val ∧ i.val < 2))]
       · have hj2' : 2 ≤ j := by omega
         have ih' := ih hj2' (by omega : j ≤ n)
         have hj1 : j < n := by omega
@@ -312,8 +308,7 @@ lemma all_on_of_lamp1_only {n : ℕ} [NeZero n] (hn : 2 < n)
         intro i
         show (step^[n * (n - 2) + (j + 1)] (initial n)).1 i =
           decide (1 ≤ i.val ∧ i.val < j + 1)
-        rw [show n * (n - 2) + (j + 1) = (n * (n - 2) + j) + 1 from by omega,
-          Function.iterate_succ_apply', step_lamps_toggle hpred, hpos]
+        rw [← add_assoc, Function.iterate_succ_apply', step_lamps_toggle hpred, hpos]
         by_cases hi : i = (j : Fin n)
         · subst hi
           rw [if_pos rfl, ih', Fin.val_natCast, Nat.mod_eq_of_lt hj1]
@@ -343,9 +338,7 @@ lemma all_on_of_lamp1_only {n : ℕ} [NeZero n] (hn : 2 < n)
       · rw [zero_sub, Fin.coe_neg_one]
         omega
     intro i
-    show (step^[n * (n - 2) + (n + 1)] (initial n)).1 i = true
-    rw [show n * (n - 2) + (n + 1) = (n * (n - 2) + n) + 1 from by omega,
-      Function.iterate_succ_apply', step_lamps_toggle hpredN, hposN]
+    rw [← add_assoc, Function.iterate_succ_apply', step_lamps_toggle hpredN, hposN]
     by_cases hi : i = (0 : Fin n)
     · subst hi
       rw [if_pos rfl, key n (by omega) le_rfl]

--- a/Compfiles/Imo1994P3.lean
+++ b/Compfiles/Imo1994P3.lean
@@ -246,9 +246,7 @@ lemma f_ge (m : ℕ) (hm : 0 < m) : m ≤ f (2 ^ (m + 1) + 2) := by
       rw [show m + 1 = m - 1 + 2 by omega, pow_add]; ring
     refine ⟨⟨by omega, by omega⟩, ?_⟩
     have h4 : 2 ^ (m + 1) + 3 * 2 ^ i = 2 ^ i * (2 ^ (m + 1 - i) + 3) := by
-      rw [show 2 ^ (m + 1) = 2 ^ i * 2 ^ (m + 1 - i) from by
-        rw [← pow_add]; congr 1; omega]
-      ring
+      rw [Nat.mul_add, pow_mul_pow_sub _ <| Nat.le_succ_of_le him.le, mul_comm]
     rw [h4, ones_two_mul_pow]
     exact ones_two_pow_add_three' (by omega)
   have hcard := Finset.card_le_card hsub
@@ -305,9 +303,7 @@ lemma card_two_Ico (n : ℕ) :
           omega
         omega
       · have h4 : 2 ^ n + 2 ^ j = 2 ^ j * (2 ^ (n - j) + 1) := by
-          rw [show 2 ^ n = 2 ^ j * 2 ^ (n - j) from by
-            rw [← pow_add]; congr 1; omega]
-          ring
+          rw [mul_add, ← Nat.pow_add, Nat.add_sub_of_le hj.le, mul_one]
         rw [h4, ones_two_mul_pow]
         exact ones_two_pow_add_one' (by omega)
   rw [hset, Finset.card_image_of_injective _ (add_two_pow_injective n), Finset.card_range]

--- a/Compfiles/Imo1995P6.lean
+++ b/Compfiles/Imo1995P6.lean
@@ -126,7 +126,7 @@ theorem shift_iterate_mem_Icc {p : ℕ} (hp : 0 < p) {x : ℕ} (hx : x ∈ Finse
       rw [e, Nat.add_mul_mod_self_left]
     rw [h, hmod]
     have hx' : 1 ≤ x := (Finset.mem_Icc.1 hx).1
-    rw [show x - 1 + k + 1 = x - 1 + (k + 1) from by omega]
+    congr 1
 
 theorem shift_iterate_not_mem {p : ℕ} {x : ℕ} (hx : x ∉ Finset.Icc 1 p) (k : ℕ) :
     (shift p)^[k] x = x := by

--- a/Compfiles/Imo1997P6.lean
+++ b/Compfiles/Imo1997P6.lean
@@ -54,15 +54,13 @@ lemma f_odd (m : ℕ) : f (2 * m + 1) = f (2 * m) := by
 
 /-- The recurrence at even arguments. -/
 lemma f_even (m : ℕ) : f (2 * m + 2) = f (2 * m + 1) + f (m + 1) := by
-  show f (2 * m + 1 + 1) = f (2 * m + 1) + f (m + 1)
-  rw [f_succ, if_pos (by omega), show (2 * m + 1 + 1) / 2 = m + 1 from by omega]
+  rw [f_succ, add_assoc, Nat.add_mod_right, Nat.mul_mod_right, if_pos rfl]
+  congr
+  omega
 
 /-- The recurrence at even arguments, shifted form. -/
 lemma f_even' (m : ℕ) (hm : 1 ≤ m) : f (2 * m) = f (2 * m - 1) + f m := by
-  have h := f_even (m - 1)
-  rwa [show 2 * (m - 1) + 2 = 2 * m from by omega,
-    show 2 * (m - 1) + 1 = 2 * m - 1 from by omega,
-    show m - 1 + 1 = m from by omega] at h
+  convert f_even (m - 1) <;> lia
 
 lemma f_zero : f 0 = 1 := by simp only [f]
 
@@ -99,7 +97,7 @@ lemma f_sum (N : ℕ) : f (2 * N) = ∑ i ∈ Finset.range (N + 1), f i := by
   induction N with
   | zero => simp [f_zero]
   | succ N ih =>
-    rw [show 2 * (N + 1) = 2 * N + 2 from by ring, f_even N, f_odd N, ih]
+    rw [mul_add, mul_one, f_even N, f_odd N, ih]
     conv_rhs => rw [Finset.sum_range_succ]
 
 /-- The upper-bound engine: `f (2m)` is strictly less than `(m + 1) * f m`
@@ -120,14 +118,11 @@ lemma f_two_mul_lt (m : ℕ) (hm : 2 ≤ m) : f (2 * m) < (m + 1) * f m := by
 lemma f_pair_step (r k : ℕ) (hk : 1 ≤ k) (hkr : k < r) :
     f (k + 1) + f (2 * r - k) ≤ f k + f (2 * r + 1 - k) := by
   rcases Nat.even_or_odd k with ⟨t, rfl⟩ | ⟨t, rfl⟩
-  · rw [show t + t = 2 * t from (two_mul t).symm, f_odd t,
-      show 2 * r + 1 - 2 * t = 2 * (r - t) + 1 from by omega,
-      show 2 * r - 2 * t = 2 * (r - t) from by omega, f_odd (r - t)]
-  · rw [show 2 * t + 1 + 1 = 2 * t + 2 from rfl, f_even t,
-      show 2 * r + 1 - (2 * t + 1) = 2 * (r - t) from by omega,
-      show 2 * r - (2 * t + 1) = 2 * (r - t) - 1 from by omega,
-      f_even' (r - t) (by omega)]
-    have hle : f (t + 1) ≤ f (r - t) := f_mono (by omega)
+  · rw [← two_mul t, f_odd t,
+      show 2 * r + 1 - 2 * t = 2 * (r - t) + 1 by lia,
+      ← Nat.mul_sub, f_odd (r - t)]
+  · rw [f_even t, Nat.add_sub_add_right, Nat.sub_add_eq, ← Nat.mul_sub, f_even' (r - t) (by lia)]
+    have hle : f (t + 1) ≤ f (r - t) := f_mono (by lia)
     omega
 
 /-- Every pair in the sum is at least `2 * f r`. -/
@@ -138,9 +133,9 @@ lemma f_pair_ge (r k : ℕ) (hk : 1 ≤ k) (hkr : k ≤ r) :
     induction j with
     | zero =>
       intro _
-      rw [Nat.sub_zero, show 2 * r + 1 - r = r + 1 from by omega]
-      have h := f_mono (show r ≤ r + 1 by omega)
-      omega
+      rw [Nat.sub_zero, Nat.sub_add_comm <| Nat.le_mul_of_pos_left _ zero_lt_two, two_mul r, Nat.add_sub_self_right]
+      rw [two_mul, Nat.add_le_add_iff_left]
+      exact f_mono <| Nat.le_add_right r 1
     | succ j ih =>
       intro hj
       have step := f_pair_step r (r - (j + 1)) (by omega) (by omega)
@@ -157,7 +152,7 @@ lemma f_sum_pair (r : ℕ) (hr : 1 ≤ r) :
     2 * r * f r ≤ ∑ i ∈ Finset.range (2 * r), f (i + 1) := by
   have split : ∑ i ∈ Finset.range (2 * r), f (i + 1)
       = ∑ i ∈ Finset.range r, f (i + 1) + ∑ i ∈ Finset.range r, f (r + i + 1) := by
-    rw [show 2 * r = r + r from by ring, Finset.sum_range_add]
+    rw [two_mul, Finset.sum_range_add]
   have hrefl : ∑ i ∈ Finset.range r, f (r + i + 1) = ∑ i ∈ Finset.range r, f (2 * r - i) := by
     conv_lhs => rw [← Finset.sum_range_reflect (fun j => f (r + j + 1)) r]
     refine Finset.sum_congr rfl fun i hi => ?_
@@ -172,7 +167,7 @@ lemma f_sum_pair (r : ℕ) (hr : 1 ≤ r) :
   refine Finset.sum_le_sum fun i hi => ?_
   have hi' : i < r := Finset.mem_range.mp hi
   have h := f_pair_ge r (i + 1) (by omega) (by omega)
-  rwa [show 2 * r + 1 - (i + 1) = 2 * r - i from by omega] at h
+  rwa [Nat.add_sub_add_right] at h
 
 /-- The two-step lower-bound recurrence: `f (2^(n+1)) > 2^n * f (2^(n-1))`. -/
 lemma f_lower_step (n : ℕ) (hn : 1 ≤ n) :
@@ -199,20 +194,15 @@ lemma f_lower_main (n : ℕ) (hn : 1 ≤ n) : 2 ^ (n ^ 2) < (f (2 ^ n)) ^ 4 := b
     · norm_num [f_two]
     · norm_num [f_four]
     · have ihn := ih (n + 1) (by omega) (by omega)
-      show 2 ^ ((n + 3) ^ 2) < (f (2 ^ (n + 3))) ^ 4
       have step := f_lower_step (n + 2) (by omega)
-      rw [show n + 2 - 1 = n + 1 from by omega, show n + 2 + 1 = n + 3 from by omega] at step
-      have h1 : (2 ^ (n + 2) * f (2 ^ (n + 1))) ^ 4 < (f (2 ^ (n + 3))) ^ 4 :=
-        Nat.pow_lt_pow_left step (by norm_num)
-      have h2 : (2 ^ (n + 2) * f (2 ^ (n + 1))) ^ 4
-          = 2 ^ (4 * (n + 2)) * (f (2 ^ (n + 1))) ^ 4 := by
-        rw [mul_pow, ← pow_mul, show (n + 2) * 4 = 4 * (n + 2) from by ring]
-      have h4 : 2 ^ ((n + 3) ^ 2) < 2 ^ (4 * (n + 2)) * (f (2 ^ (n + 1))) ^ 4 := by
-        calc 2 ^ ((n + 3) ^ 2)
-            = 2 ^ (4 * (n + 2) + (n + 1) ^ 2) := by congr 1; ring
-          _ = 2 ^ (4 * (n + 2)) * 2 ^ ((n + 1) ^ 2) := pow_add 2 _ _
-          _ < 2 ^ (4 * (n + 2)) * (f (2 ^ (n + 1))) ^ 4 := by gcongr
-      omega
+      rw [Nat.add_succ_sub_one, add_assoc] at step
+      calc
+        2 ^ (n + 3) ^ 2
+        _ = 2 ^ (4 * (n + 2) + (n + 1) ^ 2) := by ring
+        _ = 2 ^ (4 * (n + 2)) * 2 ^ ((n + 1) ^ 2) := pow_add 2 _ _
+        _ < 2 ^ (4 * (n + 2)) * (f (2 ^ (n + 1))) ^ 4 := by gcongr
+        _ = (2 ^ (n + 2) * f (2 ^ (n + 1))) ^ 4 := by rw [mul_pow, ← pow_mul, mul_comm _ 4]
+        _ < (f (2 ^ (n + 3))) ^ 4 := Nat.pow_lt_pow_left step (by norm_num)
 
 /-- One step of the upper-bound induction, in squared form. -/
 lemma f_sq_step (n : ℕ) (hn : 2 ≤ n) (ih : (f (2 ^ n)) ^ 2 ≤ 2 ^ (n ^ 2)) :
@@ -256,8 +246,8 @@ lemma f_sq_le (n : ℕ) (hn : 2 ≤ n) : (f (2 ^ n)) ^ 2 ≤ 2 ^ (n ^ 2) := by
 
 /-- The upper bound in integer form, strict for `n ≥ 3`. -/
 lemma f_sq_lt (n : ℕ) (hn : 3 ≤ n) : (f (2 ^ n)) ^ 2 < 2 ^ (n ^ 2) := by
-  have h := f_sq_step (n - 1) (by omega) (f_sq_le (n - 1) (by omega))
-  rwa [show n - 1 + 1 = n from by omega] at h
+  have h := f_sq_step (n - 1) (Nat.le_sub_one_of_lt hn) (f_sq_le (n - 1) (Nat.le_sub_one_of_lt hn))
+  rwa [Nat.sub_add_cancel (by omega)] at h
 
 /-- The lower bound with real powers: `2^(n²/4) < f (2^n)`. -/
 lemma f_gt_lower (n : ℕ) (hn : 3 ≤ n) :

--- a/Compfiles/Imo1997P6.lean
+++ b/Compfiles/Imo1997P6.lean
@@ -139,13 +139,14 @@ lemma f_pair_ge (r k : ℕ) (hk : 1 ≤ k) (hkr : k ≤ r) :
     | succ j ih =>
       intro hj
       have step := f_pair_step r (r - (j + 1)) (by omega) (by omega)
-      have ihh := ih (by omega)
-      rw [show r - (j + 1) + 1 = r - j from by omega,
-        show 2 * r - (r - (j + 1)) = 2 * r + 1 - (r - j) from by omega] at step
-      omega
-  have hk1 : r - k ≤ r - 1 := by omega
-  rw [show k = r - (r - k) from by omega]
-  exact key (r - k) hk1
+      have : 1 ≤ r - j := by lia
+      calc
+        2 * f r
+        _ ≤ f (r - j) + f (2 * r + 1 - (r - j)) := ih <| Nat.le_of_succ_le hj
+        _ ≤ f (r - (j + 1)) + f (2 * r + 1 - (r - (j + 1))) := by
+          rwa [Nat.sub_add_eq, Nat.sub_add_cancel this, Nat.sub_sub_right (2 * r) this] at step
+  rw [← Nat.sub_sub_self hkr]
+  exact key (r - k) <| Nat.sub_le_sub_left hk r
 
 /-- The lemma `f 1 + f 2 + ... + f (2r) ≥ 2r * f r` of the official solution. -/
 lemma f_sum_pair (r : ℕ) (hr : 1 ≤ r) :

--- a/Compfiles/Imo1998P6.lean
+++ b/Compfiles/Imo1998P6.lean
@@ -106,7 +106,7 @@ lemma gf_one : gf f 1 = 1 := by
 lemma gf_mul (a b : ℕ+) : gf f (a * b) = gf f a * gf f b := by
   unfold gf
   rw [ Nat.div_mul_div_comm ]
-  · rw [ show ( f a : ℕ ) * f b = f 1 * f ( a * b ) by exact congr_arg PNat.val ( f_mul_rel f hf a b ) ]
+  · rw [ ← PNat.mul_coe, f_mul_rel f hf a b ]
     norm_num [ Nat.mul_div_mul_left ]
   · exact f1_dvd f hf a
   · exact f1_dvd f hf b
@@ -162,8 +162,8 @@ theorem f_1998_ge : (120 : ℕ) ≤ (f 1998 : ℕ) := by
     · by_cases hq3 : q = 3
       · rcases p with ( _ | _ | _ | _ | p ) <;> rcases r with ( _ | _ | _ | _ | r ) <;> simp_all +arith +decide
         nlinarith
-      · have hq_ge_5 : 5 ≤ q := by exact le_of_not_gt fun h => by interval_cases q <;> trivial
-        have hq3_ge_125 : 125 ≤ q^3 := by exact Nat.pow_le_pow_left hq_ge_5 3
+      · have hq_ge_5 : 5 ≤ q := le_of_not_gt fun h => by interval_cases q <;> trivial
+        have hq3_ge_125 : 125 ≤ q^3 := Nat.pow_le_pow_left hq_ge_5 3
         nlinarith [ hp.two_le, hr.two_le, mul_pos hp.pos hr.pos ]
   have h_final : (gf f 2 : ℕ) * (gf f 3 : ℕ) ^ 3 * (gf f 37 : ℕ) ≥ 120 := by
     apply h_min

--- a/Compfiles/Imo1998P6.lean
+++ b/Compfiles/Imo1998P6.lean
@@ -41,7 +41,7 @@ lemma f_injective : Function.Injective f := by
   rw [hab] at ha
   have : (a : ℕ) * ((f 1 : ℕ+) : ℕ) ^ 2 = (b : ℕ) * ((f 1 : ℕ+) : ℕ) ^ 2 := by
     exact_mod_cast ha.symm.trans hb
-  exact PNat.eq (by nlinarith [(show (0 : ℕ) < ((f 1 : ℕ+) : ℕ) ^ 2 from by positivity)])
+  rwa [Nat.mul_left_inj (by positivity), PNat.coe_inj] at this
 
 lemma f_sq_d (n : ℕ+) : f (n ^ 2 * f 1) = (f n) ^ 2 := by
   have h := hf 1 n
@@ -188,10 +188,9 @@ lemma primeSwap_invol (n : ℕ) : primeSwap (primeSwap n) = n := by
   all_goals simp only [primeSwap, *]
 
 lemma primeSwap_prime {p : ℕ} (hp : Nat.Prime p) : Nat.Prime (primeSwap p) := by
-  by_cases h2 : p = 2 <;> by_cases h3 : p = 3 <;> by_cases h5 : p = 5 <;> by_cases h37 : p = 37
-  all_goals (try subst_vars; try decide)
-  all_goals rw [show primeSwap p = p from by simp only [primeSwap, *]]
-  exact hp
+  by_cases! h2 : p = 2 ∨ p = 3 ∨ p = 5 ∨ p = 37
+  · rcases h2 with h | h | h | h <;> (subst h; decide)
+  · simp [primeSwap, h2, hp]
 
 lemma g_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) : g (a * b) = g a * g b := by
   simp only [g]
@@ -224,9 +223,7 @@ lemma g_invol {n : ℕ} (hn : n ≠ 0) : g (g n) = n := by
     exact ih m (by nlinarith [hp.one_lt, Nat.pos_of_ne_zero hm]) hm
 
 lemma g_func_eq {m n : ℕ} (hm : m ≠ 0) (hn : n ≠ 0) : g (n ^ 2 * g m) = m * g n ^ 2 := by
-  rw [g_mul (pow_ne_zero 2 hn) (g_ne_zero m),
-      show g (n ^ 2) = g n ^ 2 from by rw [sq, g_mul hn hn, sq],
-      g_invol hm, mul_comm]
+  rw [g_mul (pow_ne_zero 2 hn) (g_ne_zero m), sq, g_mul hn hn, sq, g_invol hm, mul_comm]
 
 lemma g_1998 : g 1998 = 120 := by decide +kernel
 

--- a/Compfiles/Imo2001P1.lean
+++ b/Compfiles/Imo2001P1.lean
@@ -53,9 +53,9 @@ lemma aux₀ {x y : ℝ} (h : ∃ k : ℤ, x = y * k)
       rw [← Int.cast_one, ← Int.cast_abs, Int.cast_le]
       exact Int.one_le_abs hx
     calc y
-        ≤ |y| := by exact le_abs_self y
-      _ = |y| * 1 := by exact (mul_one |y|).symm
-      _ ≤ |y| * |↑k| := by exact mul_le_mul_of_nonneg_left h₁ (abs_nonneg y)
+        ≤ |y| := le_abs_self y
+      _ = |y| * 1 := (mul_one |y|).symm
+      _ ≤ |y| * |↑k| := mul_le_mul_of_nonneg_left h₁ (abs_nonneg y)
 
 lemma aux₁ {x y z : ℝ}
   (hx' : 0 ≤ x) (hy' : y ≤ 0)
@@ -64,13 +64,13 @@ lemma aux₁ {x y z : ℝ}
     rw [abs_lt]
     constructor
     · calc -z
-          _ < y := by exact (abs_lt.mp hy).left
-          _ = 0 + y := by exact (zero_add y).symm
-          _ ≤ x + y := by exact add_le_add_left hx' y
+          _ < y := (abs_lt.mp hy).left
+          _ = 0 + y := (zero_add y).symm
+          _ ≤ x + y := add_le_add_left hx' y
     · calc x + y
-        _ ≤ x + 0 := by exact add_le_add_right hy' x
-        _ = x := by exact add_zero x
-        _ < z := by exact (abs_lt.mp hx).right
+        _ ≤ x + 0 := add_le_add_right hy' x
+        _ = x := add_zero x
+        _ < z := (abs_lt.mp hx).right
 
 lemma aux₂ {x y z : ℝ} (h : |x + y| = z)
   (hx : |x| < z) (hy : |y| < z)
@@ -98,17 +98,17 @@ lemma aux₃ {a b : Real.Angle} (h : 2 • a + 2 • b = Real.pi)
     repeat rw [Real.Angle.angle_eq_iff_two_pi_dvd_sub] at h
     have h₁ : |a' + b'| < Real.pi := by
       calc |a' + b'|
-          ≤ |a'| + |b'| := by exact abs_add_le a' b'
-        _ < Real.pi / 2 + Real.pi / 2 := by exact add_lt_add ha hb
+          ≤ |a'| + |b'| := abs_add_le a' b'
+        _ < Real.pi / 2 + Real.pi / 2 := add_lt_add ha hb
         _ = Real.pi := by ring
     have h₂ : 0 ≤ Real.pi / 2 := by
       apply div_nonneg Real.pi_nonneg
       norm_num
     have h₃ : |a' + b'| + |Real.pi / 2| < 2 * Real.pi := by
       calc |a' + b'| + |Real.pi / 2|
-            < Real.pi + |Real.pi / 2| := by exact add_lt_add_left h₁ _
-          _ = Real.pi + Real.pi / 2 := by exact (add_right_inj _).mpr (abs_eq_self.mpr h₂)
-          _ ≤ Real.pi + Real.pi / 2 + Real.pi / 2 := by exact (le_add_iff_nonneg_right _).mpr h₂
+            < Real.pi + |Real.pi / 2| := add_lt_add_left h₁ _
+          _ = Real.pi + Real.pi / 2 := (add_right_inj _).mpr (abs_eq_self.mpr h₂)
+          _ ≤ Real.pi + Real.pi / 2 + Real.pi / 2 := (le_add_iff_nonneg_right _).mpr h₂
           _ = 2 * Real.pi := by ring
     have h₄ : |a' + b'| = Real.pi / 2 := by
       rw [abs_eq h₂]
@@ -117,16 +117,16 @@ lemma aux₃ {a b : Real.Angle} (h : 2 • a + 2 • b = Real.pi)
         apply eq_of_sub_eq_zero
         apply aux₀ pos
         calc |a' + b' - Real.pi / 2|
-            ≤ |a' + b'| + |Real.pi / 2| := by exact abs_sub _ _
-          _ < 2 * Real.pi := by exact h₃
+            ≤ |a' + b'| + |Real.pi / 2| := abs_sub _ _
+          _ < 2 * Real.pi := h₃
       · right
         apply eq_of_sub_eq_zero
         rw [← neg_div]
         apply aux₀ neg
         rw [neg_div, sub_neg_eq_add]
         calc |a' + b' + Real.pi / 2|
-            ≤ |a' + b'| + |Real.pi / 2| := by exact abs_add_le _ _
-          _ < 2 * Real.pi := by exact h₃
+            ≤ |a' + b'| + |Real.pi / 2| := abs_add_le _ _
+          _ < 2 * Real.pi := h₃
     exact aux₂ h₄ ha hb
 
 lemma aux₄ {a : Real.Angle} (h : 2 • 2 • a = 0) (ha : |a.toReal| < Real.pi / 2)
@@ -258,7 +258,7 @@ lemma A_opposite_BC : {cfg.B, cfg.C} = Set.range (cfg.ABC.faceOpposite 0).points
       rfl
   · simp
     calc (Finset.image cfg.ABC.points {0}ᶜ).card
-        ≤ ({0}ᶜ : Finset (Fin (2 + 1))).card := by exact Finset.card_image_le
+        ≤ ({0}ᶜ : Finset (Fin (2 + 1))).card := Finset.card_image_le
       _ = 2 := by
         rw [Finset.card_compl]
         simp
@@ -503,9 +503,9 @@ lemma PC_lt_PO : dist cfg.P cfg.C < dist cfg.P cfg.O := by
     exact Collinear.subset (by grind:_) (h'.collinear)
   calc dist cfg.P cfg.C
       = 2 * dist cfg.P cfg.C - dist cfg.P cfg.C:= by ring
-    _ ≤ cfg.ABC.circumradius - dist cfg.P cfg.C := by exact sub_le_sub_right (two_mul_PC_le_circumradius cfg) _
+    _ ≤ cfg.ABC.circumradius - dist cfg.P cfg.C := sub_le_sub_right (two_mul_PC_le_circumradius cfg) _
     _ = dist cfg.O cfg.C - dist cfg.P cfg.C := by rw [CO_circumradius]
-    _ < dist cfg.O cfg.P + dist cfg.P cfg.C - dist cfg.P cfg.C := by exact sub_lt_sub_right h₁ _
+    _ < dist cfg.O cfg.P + dist cfg.P cfg.C - dist cfg.P cfg.C := sub_lt_sub_right h₁ _
     _ = dist cfg.O cfg.P := by ring
     _ = dist cfg.P cfg.O := by apply dist_comm
 

--- a/Compfiles/Imo2003P5.lean
+++ b/Compfiles/Imo2003P5.lean
@@ -191,7 +191,7 @@ problem imo2003_p5 (n : ℕ) (hn : 2 < n) (x : ℕ → ℝ) (hx : MonotoneOn x (
           rw [yeq i, yeq j]; congr 1; ring
     _ = (2 * ∑ i ∈ range n, (2 * (i : ℝ) + 1 - (n : ℝ)) * y i) ^ 2 := by rw [habsy]
     _ ≤ 4 * ((n : ℝ) * ((n : ℝ) ^ 2 - 1) / 3 * ∑ i ∈ range n, y i ^ 2) := by
-        rw [mul_pow, show ((2 : ℝ)) ^ 2 = 4 from by norm_num]
+        rw [mul_pow, show (2 : ℝ) ^ 2 = 4 by norm_num]
         exact mul_le_mul_of_nonneg_left hcs (by norm_num)
     _ = 2 / 3 * ((n : ℝ) ^ 2 - 1) * (2 * (n : ℝ) * ∑ i ∈ range n, y i ^ 2) := by ring
     _ = 2 / 3 * ((n : ℝ) ^ 2 - 1) * ∑ i ∈ range n, ∑ j ∈ range n, (y i - y j) ^ 2 := by

--- a/Compfiles/Imo2003P6.lean
+++ b/Compfiles/Imo2003P6.lean
@@ -91,7 +91,7 @@ problem imo2003_p6 (p : ℕ) (hp : p.Prime) :
   have N_mod_p_ne_1 : N % (p ^ 2) ≠ 1 := by
     have : (p + 1) % (p ^ 2) = p + 1 := by
       have : p + 1 < p ^ 2 := by
-        suffices 1 < p ^ 2 - p by exact Nat.add_lt_of_lt_sub' this
+        suffices 1 < p ^ 2 - p from Nat.add_lt_of_lt_sub' this
         calc
           1 < p * (p - 1) := by
             apply Nat.one_lt_mul_iff.mpr

--- a/Compfiles/Imo2005P6.lean
+++ b/Compfiles/Imo2005P6.lean
@@ -549,9 +549,9 @@ problem imo2005_p6 {n : ℕ} (s : Fin n → Finset (Fin 6))
       ≡ 1 + pairCount s'' {2, 5} + pairCount s'' {3, 5} + pairCount s'' {4, 5}
         + pairCount s'' {2, 3} + pairCount s'' {2, 4} + pairCount s'' {3, 4} [ZMOD 3] := by
     have h := pairCount_modEq hs''c0 hs''4 (P := {0, 1}) (by decide)
-    rw [show (Finset.univ.erase 5 \ {0, 1} : Finset (Fin 6)) = {2, 3, 4} from by decide] at h
+    rw [show (Finset.univ.erase 5 \ {0, 1} : Finset (Fin 6)) = {2, 3, 4} by decide] at h
     rw [show ({2, 3, 4} : Finset (Fin 6)).powersetCard 2 = {{2, 3}, {2, 4}, {3, 4}}
-      from by decide] at h
+      by decide] at h
     repeat rw [Finset.sum_insert (by decide)] at h
     repeat rw [Finset.sum_singleton] at h
     obtain ⟨r, hr⟩ := Int.modEq_iff_add_fac.mp h
@@ -560,9 +560,9 @@ problem imo2005_p6 {n : ℕ} (s : Fin n → Finset (Fin 6))
       ≡ 1 + pairCount s'' {1, 5} + pairCount s'' {3, 5} + pairCount s'' {4, 5}
         + pairCount s'' {1, 3} + pairCount s'' {1, 4} + pairCount s'' {3, 4} [ZMOD 3] := by
     have h := pairCount_modEq hs''c0 hs''4 (P := {0, 2}) (by decide)
-    rw [show (Finset.univ.erase 5 \ {0, 2} : Finset (Fin 6)) = {1, 3, 4} from by decide] at h
+    rw [show (Finset.univ.erase 5 \ {0, 2} : Finset (Fin 6)) = {1, 3, 4} by decide] at h
     rw [show ({1, 3, 4} : Finset (Fin 6)).powersetCard 2 = {{1, 3}, {1, 4}, {3, 4}}
-      from by decide] at h
+      by decide] at h
     repeat rw [Finset.sum_insert (by decide)] at h
     repeat rw [Finset.sum_singleton] at h
     obtain ⟨r, hr⟩ := Int.modEq_iff_add_fac.mp h
@@ -571,9 +571,9 @@ problem imo2005_p6 {n : ℕ} (s : Fin n → Finset (Fin 6))
       ≡ 1 + pairCount s'' {1, 5} + pairCount s'' {2, 5} + pairCount s'' {4, 5}
         + pairCount s'' {1, 2} + pairCount s'' {1, 4} + pairCount s'' {2, 4} [ZMOD 3] := by
     have h := pairCount_modEq hs''c0 hs''4 (P := {0, 3}) (by decide)
-    rw [show (Finset.univ.erase 5 \ {0, 3} : Finset (Fin 6)) = {1, 2, 4} from by decide] at h
+    rw [show (Finset.univ.erase 5 \ {0, 3} : Finset (Fin 6)) = {1, 2, 4} by decide] at h
     rw [show ({1, 2, 4} : Finset (Fin 6)).powersetCard 2 = {{1, 2}, {1, 4}, {2, 4}}
-      from by decide] at h
+      by decide] at h
     repeat rw [Finset.sum_insert (by decide)] at h
     repeat rw [Finset.sum_singleton] at h
     obtain ⟨r, hr⟩ := Int.modEq_iff_add_fac.mp h
@@ -582,9 +582,9 @@ problem imo2005_p6 {n : ℕ} (s : Fin n → Finset (Fin 6))
       ≡ 1 + pairCount s'' {1, 5} + pairCount s'' {2, 5} + pairCount s'' {3, 5}
         + pairCount s'' {1, 2} + pairCount s'' {1, 3} + pairCount s'' {2, 3} [ZMOD 3] := by
     have h := pairCount_modEq hs''c0 hs''4 (P := {0, 4}) (by decide)
-    rw [show (Finset.univ.erase 5 \ {0, 4} : Finset (Fin 6)) = {1, 2, 3} from by decide] at h
+    rw [show (Finset.univ.erase 5 \ {0, 4} : Finset (Fin 6)) = {1, 2, 3} by decide] at h
     rw [show ({1, 2, 3} : Finset (Fin 6)).powersetCard 2 = {{1, 2}, {1, 3}, {2, 3}}
-      from by decide] at h
+      by decide] at h
     repeat rw [Finset.sum_insert (by decide)] at h
     repeat rw [Finset.sum_singleton] at h
     obtain ⟨r, hr⟩ := Int.modEq_iff_add_fac.mp h
@@ -593,9 +593,9 @@ problem imo2005_p6 {n : ℕ} (s : Fin n → Finset (Fin 6))
       ≡ 1 + pairCount s'' {0, 5} + pairCount s'' {3, 5} + pairCount s'' {4, 5}
         + pairCount s'' {0, 3} + pairCount s'' {0, 4} + pairCount s'' {3, 4} [ZMOD 3] := by
     have h := pairCount_modEq hs''c0 hs''4 (P := {1, 2}) (by decide)
-    rw [show (Finset.univ.erase 5 \ {1, 2} : Finset (Fin 6)) = {0, 3, 4} from by decide] at h
+    rw [show (Finset.univ.erase 5 \ {1, 2} : Finset (Fin 6)) = {0, 3, 4} by decide] at h
     rw [show ({0, 3, 4} : Finset (Fin 6)).powersetCard 2 = {{0, 3}, {0, 4}, {3, 4}}
-      from by decide] at h
+      by decide] at h
     repeat rw [Finset.sum_insert (by decide)] at h
     repeat rw [Finset.sum_singleton] at h
     obtain ⟨r, hr⟩ := Int.modEq_iff_add_fac.mp h
@@ -604,9 +604,9 @@ problem imo2005_p6 {n : ℕ} (s : Fin n → Finset (Fin 6))
       ≡ 1 + pairCount s'' {0, 5} + pairCount s'' {2, 5} + pairCount s'' {4, 5}
         + pairCount s'' {0, 2} + pairCount s'' {0, 4} + pairCount s'' {2, 4} [ZMOD 3] := by
     have h := pairCount_modEq hs''c0 hs''4 (P := {1, 3}) (by decide)
-    rw [show (Finset.univ.erase 5 \ {1, 3} : Finset (Fin 6)) = {0, 2, 4} from by decide] at h
+    rw [show (Finset.univ.erase 5 \ {1, 3} : Finset (Fin 6)) = {0, 2, 4} by decide] at h
     rw [show ({0, 2, 4} : Finset (Fin 6)).powersetCard 2 = {{0, 2}, {0, 4}, {2, 4}}
-      from by decide] at h
+      by decide] at h
     repeat rw [Finset.sum_insert (by decide)] at h
     repeat rw [Finset.sum_singleton] at h
     obtain ⟨r, hr⟩ := Int.modEq_iff_add_fac.mp h
@@ -615,9 +615,9 @@ problem imo2005_p6 {n : ℕ} (s : Fin n → Finset (Fin 6))
       ≡ 1 + pairCount s'' {0, 5} + pairCount s'' {2, 5} + pairCount s'' {3, 5}
         + pairCount s'' {0, 2} + pairCount s'' {0, 3} + pairCount s'' {2, 3} [ZMOD 3] := by
     have h := pairCount_modEq hs''c0 hs''4 (P := {1, 4}) (by decide)
-    rw [show (Finset.univ.erase 5 \ {1, 4} : Finset (Fin 6)) = {0, 2, 3} from by decide] at h
+    rw [show (Finset.univ.erase 5 \ {1, 4} : Finset (Fin 6)) = {0, 2, 3} by decide] at h
     rw [show ({0, 2, 3} : Finset (Fin 6)).powersetCard 2 = {{0, 2}, {0, 3}, {2, 3}}
-      from by decide] at h
+      by decide] at h
     repeat rw [Finset.sum_insert (by decide)] at h
     repeat rw [Finset.sum_singleton] at h
     obtain ⟨r, hr⟩ := Int.modEq_iff_add_fac.mp h
@@ -626,9 +626,9 @@ problem imo2005_p6 {n : ℕ} (s : Fin n → Finset (Fin 6))
       ≡ 1 + pairCount s'' {0, 5} + pairCount s'' {1, 5} + pairCount s'' {4, 5}
         + pairCount s'' {0, 1} + pairCount s'' {0, 4} + pairCount s'' {1, 4} [ZMOD 3] := by
     have h := pairCount_modEq hs''c0 hs''4 (P := {2, 3}) (by decide)
-    rw [show (Finset.univ.erase 5 \ {2, 3} : Finset (Fin 6)) = {0, 1, 4} from by decide] at h
+    rw [show (Finset.univ.erase 5 \ {2, 3} : Finset (Fin 6)) = {0, 1, 4} by decide] at h
     rw [show ({0, 1, 4} : Finset (Fin 6)).powersetCard 2 = {{0, 1}, {0, 4}, {1, 4}}
-      from by decide] at h
+      by decide] at h
     repeat rw [Finset.sum_insert (by decide)] at h
     repeat rw [Finset.sum_singleton] at h
     obtain ⟨r, hr⟩ := Int.modEq_iff_add_fac.mp h
@@ -637,9 +637,9 @@ problem imo2005_p6 {n : ℕ} (s : Fin n → Finset (Fin 6))
       ≡ 1 + pairCount s'' {0, 5} + pairCount s'' {1, 5} + pairCount s'' {3, 5}
         + pairCount s'' {0, 1} + pairCount s'' {0, 3} + pairCount s'' {1, 3} [ZMOD 3] := by
     have h := pairCount_modEq hs''c0 hs''4 (P := {2, 4}) (by decide)
-    rw [show (Finset.univ.erase 5 \ {2, 4} : Finset (Fin 6)) = {0, 1, 3} from by decide] at h
+    rw [show (Finset.univ.erase 5 \ {2, 4} : Finset (Fin 6)) = {0, 1, 3} by decide] at h
     rw [show ({0, 1, 3} : Finset (Fin 6)).powersetCard 2 = {{0, 1}, {0, 3}, {1, 3}}
-      from by decide] at h
+      by decide] at h
     repeat rw [Finset.sum_insert (by decide)] at h
     repeat rw [Finset.sum_singleton] at h
     obtain ⟨r, hr⟩ := Int.modEq_iff_add_fac.mp h
@@ -648,9 +648,9 @@ problem imo2005_p6 {n : ℕ} (s : Fin n → Finset (Fin 6))
       ≡ 1 + pairCount s'' {0, 5} + pairCount s'' {1, 5} + pairCount s'' {2, 5}
         + pairCount s'' {0, 1} + pairCount s'' {0, 2} + pairCount s'' {1, 2} [ZMOD 3] := by
     have h := pairCount_modEq hs''c0 hs''4 (P := {3, 4}) (by decide)
-    rw [show (Finset.univ.erase 5 \ {3, 4} : Finset (Fin 6)) = {0, 1, 2} from by decide] at h
+    rw [show (Finset.univ.erase 5 \ {3, 4} : Finset (Fin 6)) = {0, 1, 2} by decide] at h
     rw [show ({0, 1, 2} : Finset (Fin 6)).powersetCard 2 = {{0, 1}, {0, 2}, {1, 2}}
-      from by decide] at h
+      by decide] at h
     repeat rw [Finset.sum_insert (by decide)] at h
     repeat rw [Finset.sum_singleton] at h
     obtain ⟨r, hr⟩ := Int.modEq_iff_add_fac.mp h

--- a/Compfiles/Imo2006P4.lean
+++ b/Compfiles/Imo2006P4.lean
@@ -151,7 +151,7 @@ problem imo2006_p4 :
         -- So $$ y=2^{x-1} m+\epsilon, \quad m \text { odd }, \quad \epsilon= \pm 1 $$
         obtain ⟨m, hm, ε, hε, hy⟩ : ∃ m : ℕ, Odd m ∧ ∃ (ε : ℤ), (ε = 1 ∨ ε = -1) ∧ (y = 2 ^ (x - 1) * m + ε) := by
           let n₁ := (y - 1).factorization 2
-          obtain ⟨t, ht⟩ : 2 ^ n₁ ∣ y - 1 := by exact Nat.ordProj_dvd (y - 1) 2
+          obtain ⟨t, ht⟩ : 2 ^ n₁ ∣ y - 1 := Nat.ordProj_dvd (y - 1) 2
           have hysub : ¬y - 1 = 0 := by
             by_contra hsub
             simp [hsub] at h
@@ -208,9 +208,9 @@ problem imo2006_p4 :
           · simp at h₁
             interval_cases n₁
             · simp at ht
-              have : Even (y - 1) := by exact (even_iff_exists_two_nsmul (y - 1)).mpr h2dvd
+              have : Even (y - 1) := (even_iff_exists_two_nsmul (y - 1)).mpr h2dvd
               rw [ht] at this
-              have : ¬ Even t := by exact Nat.not_even_iff_odd.mpr ht'
+              have : ¬ Even t := Nat.not_even_iff_odd.mpr ht'
               contradiction
             · simp at ht
               have : y + 1 = 2 * (t + 1) := by
@@ -219,7 +219,7 @@ problem imo2006_p4 :
                 rw [Nat.sub_add_cancel]
                 exact hypos
               let n₂ := (t + 1).factorization 2
-              obtain ⟨s, hs⟩ : 2 ^ n₂ ∣ t + 1 := by exact Nat.ordProj_dvd (t + 1) 2
+              obtain ⟨s, hs⟩ : 2 ^ n₂ ∣ t + 1 := Nat.ordProj_dvd (t + 1) 2
               have hs' : Odd s := by
                 by_contra hs'
                 simp at hs'
@@ -341,7 +341,7 @@ problem imo2006_p4 :
             interval_cases m
             · simp at hm
             · simp
-            · have : ¬ Odd 2 := by exact Nat.not_odd_iff.mpr rfl
+            · have : ¬ Odd 2 := Nat.not_odd_iff.mpr rfl
               exact this.elim hm
             · simp
           -- on the other hand $m$ cannot be 1 by (2).
@@ -365,7 +365,7 @@ problem imo2006_p4 :
             simp [t] at this
             rw [show 4 = 2 ^ 2 by simp] at this
             apply Nat.pow_right_injective (by simp) at this
-            apply Nat.sub_eq_iff_eq_add (by exact Nat.le_of_succ_le hxge3) |>.mp at this
+            apply Nat.sub_eq_iff_eq_add (Nat.le_of_succ_le hxge3) |>.mp at this
             simp [this]
           -- From (1) we get $y=23$.
           simp [hx, hε, this] at hy

--- a/Compfiles/Imo2008P5.lean
+++ b/Compfiles/Imo2008P5.lean
@@ -244,8 +244,7 @@ lemma claim (n k : ℕ) (hn : 0 < n) (hnk : n ≤ k) (_he : Even (k - n))
       · intro i hi1 hi2
         let i' : Fin n := ⟨i - n, by lia⟩
         have hi' : n + ↑i' = i := Nat.add_sub_of_le hi1
-        rw [show {j : Fin k | ↑(g1 j) = i} = {j | ↑(g1 j) = n + ↑i'} from by
-          ext j; simp [hi'], Nat.card_coe_set_eq, hhigh i']
+        rw [← hi', Nat.card_coe_set_eq, hhigh i']
         exact hsel_even i'
     let hgg : ψ n k ⟨g1, hg1⟩ = f := by
       rcases hg1 with ⟨hg1a, hg1b⟩
@@ -349,7 +348,7 @@ lemma claim (n k : ℕ) (hn : 0 < n) (hnk : n ≤ k) (_he : Even (k - n))
             · intro y
               exact ⟨⟨⟨y.1, hfi_of_high i y.1 y.2⟩, by simp [s, y.2]⟩, Subtype.ext rfl⟩
           have : s.card = Nat.card {j : Fin k | (gfun j).val = n + i} := by
-            rw [Nat.card_eq_fintype_card, ← show Fintype.card {x // x ∈ s} = s.card from by simp]
+            rw [Nat.card_eq_fintype_card, ← Fintype.card_coe]
             exact Fintype.card_of_bijective hbij
           rw [this]; exact hgN2 (n + i) (by lia) (by lia)
         ⟨s, hsEven⟩

--- a/Compfiles/Imo2009P1.lean
+++ b/Compfiles/Imo2009P1.lean
@@ -32,15 +32,12 @@ window `c i, c (i+1), …, c (i+m)` collapses to its first term `c i`. -/
 lemma telescope {R : Type*} [CommMonoid R] (c : ℕ → R)
     (hc : ∀ j, c j * c (j + 1) = c j) :
     ∀ m i, ∏ x ∈ Finset.range (m + 1), c (i + x) = c i := by
-  intro m
+  intro m i
   induction m with
-  | zero => intro i; simp
+  | zero => simp
   | succ m ih =>
-    intro i
-    rw [Finset.prod_range_succ, Finset.prod_range_succ, mul_assoc,
-        show i + (m + 1) = (i + m) + 1 from by ring, hc (i + m),
-        ← Finset.prod_range_succ]
-    exact ih i
+    rwa [Finset.prod_range_succ, Finset.prod_range_succ, mul_assoc,
+        ← add_assoc, hc (i + m), ← Finset.prod_range_succ]
 
 /-- If the relation `c j * c (j+1) = c j` holds and `c` is periodic with period
 `k ≥ 1`, then `c` is constant: `c i = c (i+1)` for all `i`. -/

--- a/Compfiles/Imo2009P6.lean
+++ b/Compfiles/Imo2009P6.lean
@@ -809,7 +809,7 @@ theorem imo2009_p6_aux1 (n : ℕ) (hn : 0 < n)
             intro h
             have hv := congrArg Fin.val h
             dsimp [emb, embedFinLE, hitFull] at hv
-            have hvlt : j.val < k.val := by exact hjlt
+            have hvlt : j.val < k.val := hjlt
             omega
           have hne_last : (emb j : Fin n) ≠ lastFull := by
             intro h

--- a/Compfiles/Imo2011P1.lean
+++ b/Compfiles/Imo2011P1.lean
@@ -287,7 +287,7 @@ problem imo2011_p1 (A : Finset ℕ) (hA : A.card = 4) (hApos : ∀ a ∈ A, 0 < 
     exact pairCount_le_four hab hbc hcd
   · intro h
     have hwitness := h {1, 5, 7, 11} (by decide) (by decide)
-    rw [show pairCount {1, 5, 7, 11} = 4 from by decide] at hwitness
+    rw [show pairCount {1, 5, 7, 11} = 4 by decide] at hwitness
     obtain ⟨a, b, c, d, hab, hbc, hcd, rfl⟩ := exists_sorted_four hA
     have ha : 0 < a := hApos a (by simp)
     obtain ⟨h1, h2, h3, h4⟩ := dvds_of_four_le hab hbc hcd hwitness

--- a/Compfiles/Imo2012P4.lean
+++ b/Compfiles/Imo2012P4.lean
@@ -264,8 +264,7 @@ problem imo2012_p4 (f : ℤ → ℤ) :
               · exact absurd h (by lia)
               · have hx2 : (x : ℤ) = 2 := by lia
                 have h1 : f (↑x + 1) = f 1 := by rw [«f(x+1)=(x-1)²*f1», hx2]; ring
-                have h2 : f (↑x + 1) = 9 * f 1 := by
-                  rw [show (↑x : ℤ) + 1 = 3 from by rw [hx2]; ring]; exact «f3=9*f1»
+                have h2 : f (↑x + 1) = 9 * f 1 := by rw [hx2]; exact «f3=9*f1»
                 have hf0 : f 1 = 0 := by rw [h1] at h2; lia
                 rw [«f(x+1)=(x-1)²*f1», hf0]; ring
               · rw [«f(x+1)=(x-1)²*f1», h]; ring

--- a/Compfiles/Imo2012P5.lean
+++ b/Compfiles/Imo2012P5.lean
@@ -68,7 +68,7 @@ theorem cospherical_or_collinear_of_mul_dist_eq_mul_dist_of_sbtw
       change ∀ p ∈ {Δ.circumsphere.secondInter (Δ.points 2) _,
         Δ.points 2, Δ.points 1, Δ.points 0}, p ∈ Δ.circumsphere
       simp [Δ.mem_circumsphere]
-    suffices a' = a by exact this ▸ h'
+    suffices a' = a from this ▸ h'
     have := mul_dist_eq_mul_dist_of_cospherical_of_angle_eq_pi h'
       ha'pb.angle₁₂₃_eq_pi hcpd.angle₁₂₃_eq_pi
     rw [← this] at h

--- a/Compfiles/Imo2014P6.lean
+++ b/Compfiles/Imo2014P6.lean
@@ -315,11 +315,7 @@ lemma closure_cell {L : Finset Line} {σ : Line → Bool} (hne : (Cell L σ).Non
             (1 - t) * (sgn (σ ℓ) * ℓ.val p) + t * (sgn (σ ℓ) * ℓ.val q) := by ring
         rw [h3]
         nlinarith [ht0, ht1, hp', hq']
-      · have h4 : dist p (p + t • (q - p)) = t * dist q p := by
-          rw [dist_eq_norm, show p - (p + t • (q - p)) = -(t • (q - p)) from by module,
-            norm_neg, norm_smul, Real.norm_eq_abs, abs_of_pos ht0, ← dist_eq_norm]
-        rw [h4]
-        exact htε
+      · rwa [dist_eq_norm, sub_add_cancel_left, norm_neg, norm_smul, Real.norm_eq_abs, abs_of_pos ht0, ← dist_eq_norm]
 
 /-- The frontier of a cell: its closure minus itself. -/
 lemma frontier_cell (L : Finset Line) (σ : Line → Bool) :

--- a/Compfiles/Imo2016P4.lean
+++ b/Compfiles/Imo2016P4.lean
@@ -70,13 +70,7 @@ lemma two_not_dvd_P (n : ℕ) : ¬ 2 ∣ P n := by
 lemma nine_not_dvd_P (n : ℕ) : ¬ 9 ∣ P n := by
   intro h
   obtain ⟨m, hm⟩ : ∃ m, n = 3 * m ∨ n = 3 * m + 1 ∨ n = 3 * m + 2 := ⟨n / 3, by lia⟩
-  rcases hm with rfl | rfl | rfl
-  · rw [show P (3 * m) = 9 * m ^ 2 + 3 * m + 1 from by simp only [P]; ring] at h
-    lia
-  · rw [show P (3 * m + 1) = 9 * (m ^ 2 + m) + 3 from by simp only [P]; ring] at h
-    lia
-  · rw [show P (3 * m + 2) = 9 * m ^ 2 + 15 * m + 7 from by simp only [P]; ring] at h
-    lia
+  rcases hm with rfl | rfl | rfl <;> lia
 
 lemma dvd_of_dvd_two_mul {g x : ℕ} (hg : ¬ 2 ∣ g) (h : g ∣ 2 * x) : g ∣ x :=
   ((Nat.Prime.coprime_iff_not_dvd Nat.prime_two).mpr hg).symm.dvd_of_dvd_mul_left h
@@ -97,7 +91,7 @@ lemma coprime_P_succ (b : ℕ) : Nat.Coprime (P (b + 1)) (P b) := by
   rw [Nat.coprime_iff_gcd_eq_one]
   have h1 : (P (b + 1)).gcd (P b) ∣ b + 1 := gcd_P_dvd_of_eq (by simp only [P]; ring)
   refine Nat.dvd_one.mp ((Nat.dvd_add_right (h1.mul_left b)).mp ?_)
-  rw [show b * (b + 1) + 1 = P b from by simp only [P]; ring]
+  rw [show b * (b + 1) + 1 = P b by ring]
   exact Nat.gcd_dvd_right _ _
 
 /-- The gcd of values of `P` at distance two divides 7. -/
@@ -107,10 +101,10 @@ lemma gcd_P_add_two_dvd (b : ℕ) : (P (b + 2)).gcd (P b) ∣ 7 := by
   have h1 : g ∣ 2 * b + 3 := gcd_P_dvd_of_eq (by simp only [P]; ring)
   have h2 : g ∣ 8 * b + 5 := by
     have h := h1.mul_left (2 * b + 3)
-    rw [show (2 * b + 3) * (2 * b + 3) = 4 * P b + (8 * b + 5) from by simp only [P]; ring] at h
+    rw [show (2 * b + 3) * (2 * b + 3) = 4 * P b + (8 * b + 5) by simp only [P]; ring] at h
     exact (Nat.dvd_add_right (hg2.mul_left 4)).mp h
   have h3 := h1.mul_left 4
-  rw [show 4 * (2 * b + 3) = (8 * b + 5) + 7 from by ring] at h3
+  rw [show 4 * (2 * b + 3) = (8 * b + 5) + 7 by ring] at h3
   exact (Nat.dvd_add_right h2).mp h3
 
 /-- The gcd of values of `P` at distance three divides 3. -/
@@ -120,11 +114,11 @@ lemma gcd_P_add_three_dvd (b : ℕ) : (P (b + 3)).gcd (P b) ∣ 3 := by
   have h1 : g ∣ 3 * b + 6 := gcd_P_dvd_of_eq (by simp only [P]; ring)
   have h2 : g ∣ 27 * b + 27 := by
     have h := h1.mul_left (3 * b + 6)
-    rw [show (3 * b + 6) * (3 * b + 6) = 9 * P b + (27 * b + 27) from by simp only [P]; ring] at h
+    rw [show (3 * b + 6) * (3 * b + 6) = 9 * P b + (27 * b + 27) by simp only [P]; ring] at h
     exact (Nat.dvd_add_right (hg2.mul_left 9)).mp h
   have h27 : g ∣ 27 := by
     have h := h1.mul_left 9
-    rw [show 9 * (3 * b + 6) = (27 * b + 27) + 27 from by ring] at h
+    rw [show 9 * (3 * b + 6) = (27 * b + 27) + 27 by ring] at h
     exact (Nat.dvd_add_right h2).mp h
   -- since 9 never divides a value of P, the gcd must divide 3
   have h9 : ¬ 9 ∣ g := fun h ↦ nine_not_dvd_P b (h.trans hg2)

--- a/Compfiles/Imo2017P3.lean
+++ b/Compfiles/Imo2017P3.lean
@@ -645,10 +645,8 @@ lemma phaseStep_spec_escape (σ : Strategy) (hσ : ValidStrategy σ) (s : PState
     dist s.a (σ s.L) ^ 2 + 1 / 2 ≤ dist ((phaseStep σ s).1.a) (σ (phaseStep σ s).1.L) ^ 2 := by
   obtain ⟨hu1, hw1, huw, hspan, hb⟩ :=
     Classical.choose_spec (Classical.choose_spec (frame_exists s.a (σ s.L)))
-  rw [show phaseStep σ s = escStep σ s (Classical.choose (frame_exists s.a (σ s.L)))
-      (Classical.choose (Classical.choose_spec (frame_exists s.a (σ s.L)))) from by
-    unfold phaseStep
-    rw [dif_pos ⟨hd, hj⟩]]
+  unfold phaseStep
+  rw [dif_pos ⟨hd, hj⟩]
   exact escStep_spec σ hσ s _ _ hd hu1 hw1 huw hspan hb
 
 lemma maintSeq_succ_fst (σ : Strategy) (a : Pt) (L : List Pt) (k : ℕ) :

--- a/Compfiles/Imo2018P5.lean
+++ b/Compfiles/Imo2018P5.lean
@@ -81,7 +81,7 @@ lemma step (a : ℕ → ℤ) (apos : ∀ n, 0 < a n) (N : ℕ)
       field_simp
       ring
     exact_mod_cast hcast
-  · rw [show a 0 * (z₂ - z₁) - (a n - a (n - 1)) + a n - a (n - 1) = a 0 * (z₂ - z₁) from by ring]
+  · rw [add_sub_assoc, sub_add_cancel]
     exact Dvd.intro _ rfl
 
 /- The valuation rule. For a prime `p`, write `α, κ, V, V'` for the `p`-adic valuations of
@@ -201,12 +201,11 @@ lemma val_rule (a : ℕ → ℤ) (apos : ∀ n, 0 < a n) {p : ℕ} (hp : p.Prime
         have hge := padicValRat.min_le_padicValRat_add (p := p) (q := (k : ℚ))
           (r := -((k + a n - a (n - 1) : ℤ) : ℚ)) (by rwa [sub_eq_add_neg] at hne3)
         rw [padicValRat.neg, hqD, hqk] at hge
-        rw [show (k : ℚ) + -((k + a n - a (n - 1) : ℤ) : ℚ) = ((a (n - 1) - a n : ℤ) : ℚ) from by
-          push_cast; ring] at hge
+        nth_rw 2 [Int.add_sub_assoc] at hge
+        rw [Rat.intCast_add, Rat.neg_add, add_neg_cancel_left, ← Rat.intCast_neg, Int.neg_sub] at hge
         rw [padicValRat.of_int, hdiff_int hne] at hge
         have hmin : α ≤ min κ (padicValInt p (k + a n - a (n - 1))) := le_min (by omega) hvD'
-        have hge' : min κ (padicValInt p (k + a n - a (n - 1))) ≤ V' := by exact_mod_cast hge
-        exact le_trans hmin hge'
+        exact hmin.trans (by exact_mod_cast hge)
     exact ⟨by omega, hV'α⟩
 
 /- Boundedness: for `n ≥ N - 1` and every prime `p`,
@@ -220,7 +219,7 @@ lemma bound (a : ℕ → ℤ) (apos : ∀ n, 0 < a n) (N : ℕ) (hN : 0 < N)
   | succ n hn ih =>
     obtain ⟨k, hk1, hk2⟩ := step a apos N h (n := n + 1) (by omega) (by omega)
     obtain ⟨c1, c2, c3⟩ := val_rule a apos hp hk1 hk2
-    rw [show n + 1 - 1 = n from by omega] at c1 c2 c3
+    rw [Nat.add_sub_cancel] at c1 c2 c3
     rcases lt_trichotomy (padicValInt p k) (padicValInt p (a 0)) with hlt | heq | hgt
     · obtain ⟨-, e2⟩ := c1 hlt
       rw [e2]
@@ -291,7 +290,7 @@ lemma walk_const (a : ℕ → ℤ) (apos : ∀ n, 0 < a n) (N : ℕ) (hN : 0 < N
           rw [Finset.mem_Ioc]
           omega
         have hprev : padicValInt p (a 0) ≤ padicValInt p (a (s + (m + 1) - 1)) := by
-          rw [show s + (m + 1) - 1 = s + m from by omega]
+          rw [Nat.add_succ_sub_one]
           exact ihm (by omega)
         exact F (s + (m + 1)) hmem hprev
     -- dichotomy: either all valuations are `≥ α`, or all are `< α`
@@ -303,16 +302,15 @@ lemma walk_const (a : ℕ → ℤ) (apos : ∀ n, 0 < a n) (N : ℕ) (hN : 0 < N
         push Not at hall
         obtain ⟨j₁, hj₁mem, hj₁⟩ := hall
         intro i himem
-        by_contra hcon
-        push Not at hcon
+        by_contra! hcon
         have h1 : padicValInt p (a 0) ≤ padicValInt p (a n₂) := by
           have hgi := Fgen i himem hcon (n₂ - i) (by have := Finset.mem_Icc.mp himem; omega)
-          rwa [show i + (n₂ - i) = n₂ from by have := Finset.mem_Icc.mp himem; omega] at hgi
+          rwa [Nat.add_sub_of_le <| Finset.mem_Icc.mp himem |>.right] at hgi
         have h2 : padicValInt p (a 0) ≤ padicValInt p (a n₁) := by rwa [← heq] at h1
         have h3 : padicValInt p (a 0) ≤ padicValInt p (a j₁) := by
           have hgi := Fgen n₁ (by rw [Finset.mem_Icc]; omega) h2 (j₁ - n₁)
             (by have := Finset.mem_Icc.mp hj₁mem; omega)
-          rwa [show n₁ + (j₁ - n₁) = j₁ from by have := Finset.mem_Icc.mp hj₁mem; omega] at hgi
+          rwa [Nat.add_sub_of_le <| Finset.mem_Icc.mp hj₁mem |>.left] at hgi
         omega
     rcases hsplit with hall | hall
     · -- all `≥ α`: the valuations are all equal, hence `κᵢ = α`
@@ -334,7 +332,7 @@ lemma walk_const (a : ℕ → ℤ) (apos : ∀ n, 0 < a n) (N : ℕ) (hN : 0 < N
           intro hm
           have hmem : n₁ + (m + 1) ∈ Finset.Ioc n₁ n₂ := by rw [Finset.mem_Ioc]; omega
           have hle := T (n₁ + (m + 1)) hmem
-          rw [show n₁ + (m + 1) - 1 = n₁ + m from by omega] at hle
+          rw [Nat.add_succ_sub_one] at hle
           exact le_trans hle (ihm (by omega))
       have hlower : ∀ m, n₁ ≤ n₂ - m → padicValInt p (a n₂) ≤ padicValInt p (a (n₂ - m)) := by
         intro m
@@ -344,16 +342,15 @@ lemma walk_const (a : ℕ → ℤ) (apos : ∀ n, 0 < a n) (N : ℕ) (hN : 0 < N
           intro hm
           have hmem : n₂ - m ∈ Finset.Ioc n₁ n₂ := by rw [Finset.mem_Ioc]; omega
           have hle := T (n₂ - m) hmem
-          rw [show n₂ - m - 1 = n₂ - (m + 1) from by omega] at hle
+          rw [Nat.sub_sub] at hle
           exact le_trans (ihm (by omega)) hle
       have hVeq : ∀ i ∈ Finset.Icc n₁ n₂, padicValInt p (a i) = padicValInt p (a n₁) := by
         intro i hi
         rw [Finset.mem_Icc] at hi
         have hu := hupper (i - n₁) (by omega)
-        rw [show n₁ + (i - n₁) = i from by omega] at hu
+        rw [Nat.add_sub_of_le <| hi.left] at hu
         have hl := hlower (n₂ - i) (by omega)
-        rw [show n₂ - (n₂ - i) = i from by omega] at hl
-        rw [← heq] at hl
+        rw [Nat.sub_sub_self <| hi.right, ← heq] at hl
         exact le_antisymm hu hl
       intro i hi
       obtain ⟨hk1, hk2⟩ := hkk i hi
@@ -410,12 +407,10 @@ lemma walk_const (a : ℕ → ℤ) (apos : ∀ n, 0 < a n) (N : ℕ) (hN : 0 < N
     | succ m ihm =>
       intro hm
       have hmem : n₁ + (m + 1) ∈ Finset.Ioc n₁ n₂ := by rw [Finset.mem_Ioc]; omega
-      have hst := hstay (n₁ + (m + 1)) hmem
-      rw [show n₁ + (m + 1) - 1 = n₁ + m from by omega] at hst
-      rw [hst]
+      rw [hstay (n₁ + (m + 1)) hmem, Nat.add_succ_sub_one]
       exact ihm (by omega)
   have := hfinal (j - n₁) (by omega)
-  rwa [show n₁ + (j - n₁) = j from by omega] at this
+  rwa [Nat.add_sub_of_le hj1] at this
 
 snip end
 

--- a/Compfiles/Imo2022P2.lean
+++ b/Compfiles/Imo2022P2.lean
@@ -139,7 +139,7 @@ problem imo2022_p2 (f : ℝ+ → ℝ+) :
     have hf' : ∀ x, f x ≤ 1 / x := fun x ↦ by
       have h12 := h11 x
       rw [h1] at h12
-      suffices H : x * f x ≤ 1 by exact le_div_iff_mul_le'.mpr H
+      suffices H : x * f x ≤ 1 from le_div_iff_mul_le'.mpr H
       have h14 : (⟨2, two_pos⟩ : ℝ+) = ⟨2, two_pos⟩ * 1 := left_eq_mul.mpr rfl
       have h13 : x * f x + x * f x = ⟨2, two_pos⟩ * (x * f x) := lemma1 _
       rw [h14, h13] at h12

--- a/Compfiles/Imo2022P5.lean
+++ b/Compfiles/Imo2022P5.lean
@@ -54,8 +54,8 @@ lemma mylemma_3
   (h₁ : a ^ p = b.factorial + p)
   (hbp : p ≤ b) :
   (p ∣ a) := by
-  have h₂: p ∣ b.factorial := by exact Nat.dvd_factorial (Nat.Prime.pos hp) hbp
-  have h₃: p ∣ b.factorial + p := by exact Nat.dvd_add_self_right.mpr h₂
+  have h₂: p ∣ b.factorial := Nat.dvd_factorial (Nat.Prime.pos hp) hbp
+  have h₃: p ∣ b.factorial + p := Nat.dvd_add_self_right.mpr h₂
   have h₄: p ∣ a^p := by
     rw [h₁]
     exact h₃
@@ -109,7 +109,7 @@ lemma mylemma_41
   have h₁: b.factorial ≤ (2*p - 1).factorial := by
     refine Nat.factorial_le ?_
     exact Nat.le_pred_of_lt hb2p
-  have gp: 2 ≤ p := by exact Nat.Prime.two_le hp
+  have gp: 2 ≤ p := Nat.Prime.two_le hp
   have gp1: (p - 1) + 1 = p := Nat.sub_add_cancel (Nat.one_le_of_lt gp)
   let f: (ℕ → ℕ) := (fun (x : ℕ) => x + 1)
   have h₂: (Finset.range (2 * p - 1)).prod f =
@@ -184,7 +184,7 @@ lemma mylemma_4
     (h₂ : p ∣ a)
     (hb2p : b < 2 * p) :
     (a = p) := by
-  have gp: p ≤ a := by exact Nat.le_of_dvd h₀.1 h₂
+  have gp: p ≤ a := Nat.le_of_dvd h₀.1 h₂
   obtain h₃ | h₃ := lt_or_eq_of_le gp
   · exfalso
     obtain ⟨c, h₂⟩ := h₂
@@ -200,7 +200,7 @@ lemma mylemma_4
       have h₆: c ∣ p := by
         rw [g₂]
         exact Nat.dvd_sub h₄ h₅
-      have h₇: c = 1 ∨ c = p := by exact (Nat.dvd_prime hp).mp h₆
+      have h₇: c = 1 ∨ c = p := (Nat.dvd_prime hp).mp h₆
       obtain h₇₀ | h₇₁ := h₇
       · rw [h₇₀, mul_one] at h₂
         lia
@@ -213,7 +213,7 @@ lemma mylemma_4
       have h₃: p^(2*p) ≤ a^p := by
         rw [pow_mul]
         exact pow_left_mono p g₃
-      have h₇: b.factorial + p < p^(2*p) := by exact mylemma_41 b p hp hb2p
+      have h₇: b.factorial + p < p^(2*p) := mylemma_41 b p hp hb2p
       lia
   exact h₃.symm
 
@@ -352,10 +352,10 @@ lemma mylemma_5
     False := by
   -- first prove that b = p cannot be
   by_cases h₄: b = p
-  · have h₅: p + p.factorial < p^p := by exact mylemma_51 p hp5
+  · have h₅: p + p.factorial < p^p := mylemma_51 p hp5
     rw [h₄] at h₁
     linarith
-  · have hpb: p < b := by exact lt_of_le_of_ne' hbp h₄
+  · have hpb: p < b := lt_of_le_of_ne' hbp h₄
     clear hbp h₄
     have h₂: (p + 1) ^ 2 ∣ b.factorial := by
       have g₁: p + 1 ≤ b := Nat.succ_le_iff.mpr hpb
@@ -368,7 +368,7 @@ lemma mylemma_5
           norm_num
         exact even_iff_two_dvd.mp gg₂
       have g₃: 2 * ((p+1)/2) * (p + 1) ∣ b.factorial := by
-        have gg₁: (p + 1).factorial ∣ b.factorial := by exact Nat.factorial_dvd_factorial g₁
+        have gg₁: (p + 1).factorial ∣ b.factorial := Nat.factorial_dvd_factorial g₁
         have gg₂: (p + 1).factorial = (p + 1) * p.factorial := Nat.factorial_succ p
         rw [mul_comm] at gg₂
         have gg₃: 6/2 ≤ (p + 1)/2 := by lia
@@ -394,7 +394,7 @@ lemma mylemma_5
       rw [g₄] at g₃
       ring_nf at *
       exact g₃
-    have h₃: b.factorial = p ^ p - p := by exact eq_tsub_of_add_eq (h₁.symm)
+    have h₃: b.factorial = p ^ p - p := eq_tsub_of_add_eq (h₁.symm)
     rw [h₃] at h₂
     exact mylemma_52 p hp hp5 h₂
 
@@ -404,17 +404,17 @@ lemma mylemma_6
     (h₂ : p ∣ a)
     (hb2p : 2 * p ≤ b) :
     (p ^ 2 ∣ a ^ p - b.factorial) := by
-  have g₁: p^p ∣ a^p := by exact pow_dvd_pow_of_dvd h₂ p
+  have g₁: p^p ∣ a^p := pow_dvd_pow_of_dvd h₂ p
   have g₂: 2 ≤ p := Nat.Prime.two_le hp
   have h₃: p^2 ∣ a^p := Nat.pow_dvd_of_le_of_pow_dvd g₂ g₁
   have g₃: (2*p).factorial ∣ b.factorial := Nat.factorial_dvd_factorial hb2p
   have g₄: p.factorial * p.factorial ∣ (p+p).factorial :=
     Nat.factorial_mul_factorial_dvd_factorial_add p p
   rw [← pow_two, ← two_mul] at g₄
-  have g₅: p ∣ p.factorial := by exact Nat.dvd_factorial (by lia) (by lia)
-  have h₄: p ^ 2 ∣ p.factorial ^ 2 := by exact pow_dvd_pow_of_dvd g₅ 2
-  have g₆: p ^ 2 ∣ (2 * p).factorial := by exact dvd_trans h₄ g₄
-  have h₅: p^2 ∣ b.factorial := by exact dvd_trans g₆ g₃
+  have g₅: p ∣ p.factorial := Nat.dvd_factorial (by lia) (by lia)
+  have h₄: p ^ 2 ∣ p.factorial ^ 2 := pow_dvd_pow_of_dvd g₅ 2
+  have g₆: p ^ 2 ∣ (2 * p).factorial := dvd_trans h₄ g₄
+  have h₅: p^2 ∣ b.factorial := dvd_trans g₆ g₃
   exact Nat.dvd_sub h₃ h₅
 
 snip end
@@ -432,12 +432,12 @@ problem imo2022_p5 (a b p : ℕ) (ha : 0 < a) (hb : 0 < b) (hp : p.Prime) :
   by_cases hbp: b < p -- no solution
   · exfalso
     by_cases hab: a ≤ b
-    · have h₂: a ∣ b.factorial := by exact Nat.dvd_factorial ha hab
+    · have h₂: a ∣ b.factorial := Nat.dvd_factorial ha hab
       have g₃: a ∣ b.factorial + p := by
         rw [← h₁]
         refine dvd_pow_self a ?_
         exact Nat.Prime.ne_zero hp
-      have h₃: a ∣ p := by exact (Nat.dvd_add_right h₂).mp g₃
+      have h₃: a ∣ p := (Nat.dvd_add_right h₂).mp g₃
       have h₄: a = 1 := by
         have g₄: a = 1 ∨ a = p := by
           exact (Nat.dvd_prime hp).mp h₃
@@ -457,18 +457,18 @@ problem imo2022_p5 (a b p : ℕ) (ha : 0 < a) (hb : 0 < b) (hp : p.Prime) :
         refine mul_le_mul rfl.ge hb ?_ ?_
         · norm_num
         · exact Nat.zero_le p
-      have g₄: b.factorial ≤ b^b := by exact Nat.factorial_le_pow b
+      have g₄: b.factorial ≤ b^b := Nat.factorial_le_pow b
       have g₅: b^b ≤ b^p := by
         refine Nat.pow_le_pow_right hb ?_
         exact le_of_lt hbp
       lia
   · push Not at hbp
-    have h₂: p ∣ a := by exact mylemma_3 a b p hp h₁ hbp
+    have h₂: p ∣ a := mylemma_3 a b p hp h₁ hbp
     by_cases hb2p: b < 2*p
-    · have h₃ : a = p := by exact mylemma_4 a b p ⟨ha, hb⟩ hp h₁ hbp h₂ hb2p
+    · have h₃ : a = p := mylemma_4 a b p ⟨ha, hb⟩ hp h₁ hbp h₂ hb2p
       rw [h₃] at h₁ ⊢
       by_cases hp5: p < 5
-      · have h₄: 2 ≤ p := by exact Nat.Prime.two_le hp
+      · have h₄: 2 ≤ p := Nat.Prime.two_le hp
         interval_cases p
         · left
           norm_num at h₁
@@ -482,7 +482,7 @@ problem imo2022_p5 (a b p : ℕ) (ha : 0 < a) (hb : 0 < b) (hp : p.Prime) :
         · right
           norm_num at h₁
           have h₄: b.factorial = 24 := by lia
-          have g₅: (4:ℕ).factorial = 24 := by exact rfl
+          have g₅: (4:ℕ).factorial = 24 := rfl
           rw [← g₅] at h₄
           have h₅: b = 4 := by
             refine (Nat.factorial_inj ?_).mp h₄
@@ -495,15 +495,15 @@ problem imo2022_p5 (a b p : ℕ) (ha : 0 < a) (hb : 0 < b) (hp : p.Prime) :
         exact mylemma_5 b p hp hbp h₁ hp5
     · push Not at hb2p
       exfalso
-      have h₃: p^2 ∣ a^p - b.factorial := by exact mylemma_6 a b p hp h₂ hb2p
+      have h₃: p^2 ∣ a^p - b.factorial := mylemma_6 a b p hp h₂ hb2p
       have g₄: a^p - b.factorial = p := by lia
       have h₄: p^2 ∣ p := by
         rw [g₄] at h₃
         exact h₃
-      have gp: 0 < p := by exact Nat.Prime.pos hp
-      have h₅: p^2 ≤ p := by exact Nat.le_of_dvd gp h₄
-      have g₆: 1 < p := by exact Nat.Prime.one_lt hp
-      have h₆: p^1 < p^2 := by exact Nat.pow_lt_pow_succ g₆
+      have gp: 0 < p := Nat.Prime.pos hp
+      have h₅: p^2 ≤ p := Nat.le_of_dvd gp h₄
+      have g₆: 1 < p := Nat.Prime.one_lt hp
+      have h₆: p^1 < p^2 := Nat.pow_lt_pow_succ g₆
       linarith
 
 end Imo2022P5

--- a/Compfiles/Imo2022P6.lean
+++ b/Compfiles/Imo2022P6.lean
@@ -1067,8 +1067,7 @@ theorem NordicSquare.good_count {n : ℕ} (hn : 2 ≤ n) (ns : NordicSquare n) (
         rw [if_neg (show ¬ ns.Valley c from fun hvc ↦ hc.1 (huniq c hvc))]
     rw [h1, if_pos hv]
   rw [NordicSquare.card_eq_sum_countTo, Finset.sum_congr rfl (fun c _ ↦ hcnt c)]
-  rw [show 2 * n * (n - 1) + 1 = 2 * (n * (n - 1)) + 1 from by ring]
-  rw [← hsum, key, Nat.sub_add_cancel hge]
+  rw [mul_assoc, ← hsum, key, Nat.sub_add_cancel hge]
 
 /-- The number of uphill paths on a 1×1 board is 1. -/
 theorem nat_card_uphillPath_one (ns : NordicSquare 1) : Nat.card ns.UphillPath = 1 := by

--- a/Compfiles/Imo2023P2.lean
+++ b/Compfiles/Imo2023P2.lean
@@ -239,9 +239,9 @@ lemma aux₇ {x y : ℝ} (h : ∃ k : ℤ, x = y * k)
       rw [← Int.cast_one, ← Int.cast_abs, Int.cast_le]
       exact Int.one_le_abs hx
     calc y
-        ≤ |y| := by exact le_abs_self y
-      _ = |y| * 1 := by exact (mul_one |y|).symm
-      _ ≤ |y| * |↑k| := by exact mul_le_mul_of_nonneg_left h₁ (abs_nonneg y)
+        ≤ |y| := le_abs_self y
+      _ = |y| * 1 := (mul_one |y|).symm
+      _ ≤ |y| * |↑k| := mul_le_mul_of_nonneg_left h₁ (abs_nonneg y)
 
 lemma aux₈ {x y z : ℝ}
   (hx' : 0 ≤ x) (hy' : y ≤ 0)
@@ -250,13 +250,13 @@ lemma aux₈ {x y z : ℝ}
     rw [abs_lt]
     constructor
     · calc -z
-          _ < y := by exact (abs_lt.mp hy).left
-          _ = 0 + y := by exact (zero_add y).symm
-          _ ≤ x + y := by exact add_le_add_left hx' y
+          _ < y := (abs_lt.mp hy).left
+          _ = 0 + y := (zero_add y).symm
+          _ ≤ x + y := add_le_add_left hx' y
     · calc x + y
-        _ ≤ x + 0 := by exact add_le_add_right hy' x
-        _ = x := by exact add_zero x
-        _ < z := by exact (abs_lt.mp hx).right
+        _ ≤ x + 0 := add_le_add_right hy' x
+        _ = x := add_zero x
+        _ < z := (abs_lt.mp hx).right
 
 lemma aux₉ {x y z : ℝ} (h : |x + y| = z)
   (hx : |x| < z) (hy : |y| < z)
@@ -284,17 +284,17 @@ lemma aux₁₀ {a b : Real.Angle} (h : 2 • a + 2 • b = Real.pi)
     repeat rw [Real.Angle.angle_eq_iff_two_pi_dvd_sub] at h
     have h₁ : |a' + b'| < Real.pi := by
       calc |a' + b'|
-          ≤ |a'| + |b'| := by exact abs_add_le a' b'
-        _ < Real.pi / 2 + Real.pi / 2 := by exact add_lt_add ha hb
+          ≤ |a'| + |b'| := abs_add_le a' b'
+        _ < Real.pi / 2 + Real.pi / 2 := add_lt_add ha hb
         _ = Real.pi := by ring
     have h₂ : 0 ≤ Real.pi / 2 := by
       apply div_nonneg Real.pi_nonneg
       norm_num
     have h₃ : |a' + b'| + |Real.pi / 2| < 2 * Real.pi := by
       calc |a' + b'| + |Real.pi / 2|
-            < Real.pi + |Real.pi / 2| := by exact add_lt_add_left h₁ _
-          _ = Real.pi + Real.pi / 2 := by exact (add_right_inj _).mpr (abs_eq_self.mpr h₂)
-          _ ≤ Real.pi + Real.pi / 2 + Real.pi / 2 := by exact (le_add_iff_nonneg_right _).mpr h₂
+            < Real.pi + |Real.pi / 2| := add_lt_add_left h₁ _
+          _ = Real.pi + Real.pi / 2 := (add_right_inj _).mpr (abs_eq_self.mpr h₂)
+          _ ≤ Real.pi + Real.pi / 2 + Real.pi / 2 := (le_add_iff_nonneg_right _).mpr h₂
           _ = 2 * Real.pi := by ring
     have h₄ : |a' + b'| = Real.pi / 2 := by
       rw [abs_eq h₂]
@@ -303,16 +303,16 @@ lemma aux₁₀ {a b : Real.Angle} (h : 2 • a + 2 • b = Real.pi)
         apply eq_of_sub_eq_zero
         apply aux₇ pos
         calc |a' + b' - Real.pi / 2|
-            ≤ |a' + b'| + |Real.pi / 2| := by exact abs_sub _ _
-          _ < 2 * Real.pi := by exact h₃
+            ≤ |a' + b'| + |Real.pi / 2| := abs_sub _ _
+          _ < 2 * Real.pi := h₃
       · right
         apply eq_of_sub_eq_zero
         rw [← neg_div]
         apply aux₇ neg
         rw [neg_div, sub_neg_eq_add]
         calc |a' + b' + Real.pi / 2|
-            ≤ |a' + b'| + |Real.pi / 2| := by exact abs_add_le _ _
-          _ < 2 * Real.pi := by exact h₃
+            ≤ |a' + b'| + |Real.pi / 2| := abs_add_le _ _
+          _ < 2 * Real.pi := h₃
     exact aux₉ h₄ ha hb
 
 lemma angle_eq_of_oangle_eq {A₁ A₂ A₃ B₁ B₂ B₃ : Pt}

--- a/Compfiles/Imo2023P3.lean
+++ b/Compfiles/Imo2023P3.lean
@@ -143,10 +143,8 @@ lemma key_recurrence {k : ℕ} {P : Polynomial ℤ} {A : ℕ → ℕ}
   set f := fun i => (A (m + 1 + i) : ℤ) with hf
   have h1 : (∏ i ∈ Finset.range k, (A (m + 1 + 1 + i) : ℤ)) =
       ∏ i ∈ Finset.range k, f (i + 1) := by
-    apply Finset.prod_congr rfl
-    intro i _
-    rw [hf]
-    rw [show m + 1 + 1 + i = m + 1 + (i + 1) from by omega]
+    refine Finset.prod_congr rfl fun i _ => ?_
+    rw [hf, Nat.add_right_comm, Nat.add_assoc]
   rw [h1]
   have h2 : (A (m + 1) : ℤ) = f 0 := by rw [hf]
   have h3 : (A (m + 1 + k) : ℤ) = f k := by rw [hf]
@@ -237,7 +235,7 @@ lemma seq_monotone {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P.Monic
         (A (n₀ + 1) : ℤ) * P.eval (A n₀ : ℤ) :=
       mul_lt_mul_of_pos_left h1 (by exact_mod_cast hpos (n₀ + 1))
     have h3 := key_recurrence hA n₀
-    rw [show n₀ + 1 + k = n₀ + k + 1 from by omega] at h3
+    rw [Nat.add_right_comm] at h3
     rw [← h3] at h2
     have h4 : (A (n₀ + k + 1) : ℤ) < (A (n₀ + 1) : ℤ) :=
       lt_of_mul_lt_mul_right h2 (le_of_lt (eval_pos hk hmon hdeg hcoef
@@ -266,8 +264,10 @@ lemma seq_monotone {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P.Monic
                 A (n₀ + j') ≤ A (n₀ + j' + 1) := by
               intro j' hj'1 hj'2
               exact iht (by omega) j' (by omega) (by omega)
-            have hc := chain_le_nat hstep (t := t + 1) (by omega)
-            rwa [show (k - (t + 1)) + 1 + (t + 1) = k + 1 from by omega] at hc
+            have h : k - (t + 1) + 1 + (t + 1) = k + 1 := by
+              rw [Nat.add_right_comm, Nat.sub_add_cancel ht]
+            have hc := chain_le_nat hstep (t := t + 1) h.le
+            rwa [h] at hc
           have hle := hmin (n₀ + (k - (t + 1))) hlt'
           rw [← hv₀] at hle
           exact absurd ((hge.trans_lt hestep).trans_le hle) (lt_irrefl _)
@@ -277,8 +277,8 @@ lemma seq_monotone {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P.Monic
       intro j hj1 hj2
       exact key k (le_refl k) j (by omega) (by omega)
     have hc := chain_le_nat hstep (t := k) (by omega)
-    rwa [show (1 : ℕ) + k = k + 1 from by omega] at hc
-  rw [show n₀ + (k + 1) = n₀ + k + 1 from by omega] at hchain
+    rwa [add_comm 1] at hc
+  rw [← add_assoc] at hchain
   exact absurd (hchain.trans_lt hestep) (lt_irrefl _)
 
 /-- Bounded consecutive differences: `A (m+1) ≤ A m + C` where `C = (Csum P k).toNat`. -/
@@ -299,7 +299,7 @@ lemma diff_le {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P.Monic)
       exact hmono (by omega)
   have h6 : (A m) ^ k + CN * (A m) ^ (k - 1) ≤ (A m + CN) ^ k := by
     have h7 := pow_ge_add_mul (A m) CN (k - 1)
-    rw [show k - 1 + 1 = k from by omega] at h7
+    rw [Nat.sub_add_cancel (by omega)] at h7
     calc (A m) ^ k + CN * (A m) ^ (k - 1)
         ≤ (A m) ^ k + k * (A m) ^ (k - 1) * CN := by
           apply Nat.add_le_add_left
@@ -376,32 +376,23 @@ lemma coeff_prod_linear_bound {S : ℤ} (hS : 0 ≤ S) (σ : ℕ → ℤ) :
       have ih' : ∀ j, |(∏ i ∈ s, (X + C (σ i))).coeff j| ≤ (1 + S) ^ s.card :=
         ih (fun i' hi' => hσ i' (Finset.mem_insert_of_mem hi'))
       rw [Finset.prod_insert hi, Finset.card_insert_of_notMem hi]
-      rw [show (X + C (σ i)) * ∏ i ∈ s, (X + C (σ i)) =
-          X * ∏ i ∈ s, (X + C (σ i)) + C (σ i) * ∏ i ∈ s, (X + C (σ i)) from by ring]
+      ring_nf
       rw [coeff_add, coeff_C_mul]
       rcases eq_or_ne j 0 with rfl | hj0
       · rw [coeff_X_mul_zero]
-        simp only [zero_add]
-        calc |(σ i) * (∏ i ∈ s, (X + C (σ i))).coeff 0|
-            = |σ i| * |(∏ i ∈ s, (X + C (σ i))).coeff 0| := abs_mul _ _
+        simp only [zero_add, abs_mul]
+        calc
           _ ≤ S * (1 + S) ^ s.card := mul_le_mul hSi (ih' 0) (abs_nonneg _) hS
-          _ ≤ (1 + S) ^ (s.card + 1) := by
-              rw [pow_succ]
-              have e : (1 + S) ^ s.card * (1 + S) =
-                  (1 + S) ^ s.card + S * (1 + S) ^ s.card := by ring
-              rw [e]
-              exact le_add_of_nonneg_left (pow_nonneg (by linarith) _)
+          _ ≤ S * (1 + S) ^ s.card + (1 + S) ^ s.card := le_add_of_nonneg_right (pow_nonneg (by linarith) _)
       · obtain ⟨j', rfl⟩ := Nat.exists_eq_succ_of_ne_zero hj0
         rw [coeff_X_mul]
-        calc |(∏ i ∈ s, (X + C (σ i))).coeff j' + (σ i) * (∏ i ∈ s, (X + C (σ i))).coeff (j' + 1)|
-            ≤ |(∏ i ∈ s, (X + C (σ i))).coeff j'| +
-              |(σ i) * (∏ i ∈ s, (X + C (σ i))).coeff (j' + 1)| := abs_add_le _ _
-          _ ≤ (1 + S) ^ s.card + S * (1 + S) ^ s.card := by
-              apply add_le_add (ih' j') _
-              rw [abs_mul]
+        calc
+          -- make terms implicit to make calc faster
+          _ ≤ _ := abs_add_le _ _
+          _ ≤ S * (1 + S) ^ s.card + (1 + S) ^ s.card := by
+              rw [add_comm, abs_mul]
+              apply add_le_add ?_ (ih' j')
               exact mul_le_mul hSi (ih' (j' + 1)) (abs_nonneg _) hS
-          _ = (1 + S) ^ (s.card + 1) := by
-              rw [pow_succ]; ring
 
 /-- `Fpoly P A k m := ∏_{i=1}^{k} (X + C (A (m+i) - A m)) - P`; it vanishes at `A m`. -/
 noncomputable def Fpoly (P : Polynomial ℤ) (A : ℕ → ℕ) (k m : ℕ) : Polynomial ℤ :=
@@ -446,7 +437,7 @@ lemma Fpoly_coeff_bound {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P.
       apply coeff_prod_linear_bound (by positivity) _ (Finset.range k) _ j
       intro i hi
       have hb := shift_bounds hk hmon hdeg hcoef hA hpos hmono m (1 + i)
-      rw [show m + (1 + i) = m + 1 + i from by omega] at hb
+      rw [← add_assoc] at hb
       rw [abs_of_nonneg hb.1]
       calc (A (m + 1 + i) : ℤ) - A m ≤ (1 + i) * Csum P k := hb.2
         _ ≤ k * Csum P k := by
@@ -532,7 +523,7 @@ lemma root_bound {F : Polynomial ℤ} {B : ℤ} (hF : F ≠ 0) (hB : ∀ j, |F.c
             mul_le_mul_of_nonneg_right hbn (pow_nonneg (by omega) _)
         _ ≤ B * F.natDegree * x ^ (F.natDegree - 1) := h4
     have h6 : x ^ F.natDegree = x * x ^ (F.natDegree - 1) := by
-      rw [← pow_succ', show F.natDegree - 1 + 1 = F.natDegree from by omega]
+      rw [← pow_succ', Nat.sub_add_cancel (by omega)]
     rw [h6] at h5
     have h7 : x ≤ B * F.natDegree :=
       le_of_mul_le_mul_right h5 (pow_pos (by omega : 0 < x) _)
@@ -576,8 +567,8 @@ lemma eval_sum_eq {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P.Monic)
     sub_eq_zero.1 hF0
   have hcoeff : P.coeff (k - 1) = ∑ i ∈ Finset.range k, ((A (m + 1 + i) : ℤ) - A m) := by
     conv_lhs => rw [← hprod]
-    rw [Finset.prod_X_add_C_coeff (Finset.range k) _ (by rw [Finset.card_range]; omega)]
-    rw [Finset.card_range, show k - (k - 1) = 1 from by omega, Finset.powersetCard_one,
+    rw [Finset.prod_X_add_C_coeff (Finset.range k) _ (by rw [Finset.card_range]; exact Nat.sub_le _ _)]
+    rw [Finset.card_range, Nat.sub_sub_self (by omega), Finset.powersetCard_one,
       Finset.sum_map]
     exact Finset.sum_congr rfl fun i _ => by simp
   have hsum : ∑ i ∈ Finset.range k, ((A (m + 1 + i) : ℤ) - A m) =
@@ -621,26 +612,9 @@ lemma diff_eventually_const {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon 
     intro j hj
     have e1 := hE j hj
     have e2 := hE (j + 1) (by omega)
-    rw [show (∑ i ∈ Finset.range k, (A (j + 1 + 1 + i) : ℤ)) =
-        ∑ i ∈ Finset.range k, (A (j + 1 + (i + 1)) : ℤ) from
-      Finset.sum_congr rfl fun i _ => by rw [show j + 1 + 1 + i = j + 1 + (i + 1) from by omega]] at e2
-    have hsub : ∀ (f g : ℕ → ℤ), (∑ l ∈ Finset.range k, (f l - g l)) =
-        (∑ l ∈ Finset.range k, f l) - (∑ l ∈ Finset.range k, g l) := by
-      intro f g
-      rw [show (∑ l ∈ Finset.range k, (f l - g l)) =
-          ∑ l ∈ Finset.range k, (f l + (-g l)) from
-        Finset.sum_congr rfl fun l _ => by rw [sub_eq_add_neg]]
-      rw [Finset.sum_add_distrib, Finset.sum_neg_distrib, sub_eq_add_neg]
-    have htele : ∑ l ∈ Finset.range k, Dif A (j + 1 + l) =
-        (∑ l ∈ Finset.range k, (A (j + 1 + (l + 1)) : ℤ)) -
-        (∑ l ∈ Finset.range k, (A (j + 1 + l) : ℤ)) := by
-      rw [show (∑ l ∈ Finset.range k, Dif A (j + 1 + l)) =
-          ∑ l ∈ Finset.range k, ((A (j + 1 + (l + 1)) : ℤ) - A (j + 1 + l)) from
-        Finset.sum_congr rfl fun l _ => by
-          rw [Dif, show j + 1 + l + 1 = j + 1 + (l + 1) from by omega]]
-      exact hsub _ _
-    rw [htele, Dif]
-    linarith [e1, e2]
+    simp only [Nat.add_right_comm (j+1), Nat.add_assoc (j+1)] at e2
+    simp only [Dif, add_assoc (j+1), Finset.sum_sub_distrib]
+    linarith only [e1, e2]
   -- the set of difference magnitudes and its maximum
   set S : Set ℕ := {v | ∃ j ≥ N₀, v = (Dif A j).toNat} with hS
   have hSne : S.Nonempty := ⟨_, N₀, le_refl _, rfl⟩
@@ -682,7 +656,7 @@ lemma diff_eventually_const {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon 
     | succ t iht =>
         exact hkey (m + t) (by omega) iht 0 (Finset.mem_range.2 (by omega))
   exact ⟨m, M, fun j hj => by
-    rw [show j = m + (j - m) from by omega]
+    rw [← Nat.add_sub_of_le hj]
     exact hconst (j - m)⟩
 
 lemma apPoly_coeff_nonneg_aux (d : ℕ) (s : Finset ℕ) (n : ℕ) :
@@ -784,12 +758,12 @@ lemma backward_bounded {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P.M
   -- conclusion
   have hfin : ∀ n, A n = V := by
     intro n
-    by_cases hn : n ≤ N
+    by_cases! hn : n ≤ N
     · have h := hdown (N - n) (by omega)
-      rwa [show N - (N - n) = n from by omega] at h
-    · push Not at hn
-      exact hN n (by omega)
+      rwa [Nat.sub_sub_self hn] at h
+    · exact hN n (by omega)
   exact ⟨V, 0, fun n => by rw [hfin n]; simp⟩
+
 /-- The unbounded case: once the sequence exceeds the root bound, it is an
 arithmetic progression. -/
 lemma backward_unbounded {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P.Monic)
@@ -820,7 +794,7 @@ lemma backward_unbounded {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P
         have h : Dif A (m₂ + t) = c := hconst2 (m₂ + t) (by omega)
         rw [Dif] at h
         have e : (A (m₂ + (t + 1)) : ℤ) = (A (m₂ + t) : ℤ) + c := by
-          rw [show m₂ + (t + 1) = m₂ + t + 1 from by omega]
+          rw [← add_assoc]
           linarith [h]
         rw [e, iht]
         push_cast
@@ -856,8 +830,7 @@ lemma backward_unbounded {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P
     have hσ : ∀ i ∈ Finset.range k, ((A (m₂ + 1 + i) : ℤ) - A m₂) = ((i + 1) * dN : ℤ) := by
       intro i hi
       have ht := htail (1 + i)
-      rw [show m₂ + (1 + i) = m₂ + 1 + i from by omega] at ht
-      rw [← hdNc] at ht
+      rw [← add_assoc, ← hdNc] at ht
       push_cast at ht
       linarith [ht]
     rw [apPoly, ← hprod]
@@ -880,7 +853,7 @@ lemma backward_unbounded {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P
           have hi' : i < k := Finset.mem_range.1 hi
           by_cases hcase : m₂ ≤ m' + 1 + i
           · have ht := htail (m' + 1 + i - m₂)
-            rw [show m₂ + (m' + 1 + i - m₂) = m' + 1 + i from by omega] at ht
+            rw [Nat.add_sub_of_le hcase] at ht
             have hcast2 : ((m' + 1 + i - m₂ : ℕ) : ℤ) = (m' : ℤ) + 1 + (i : ℤ) - (m₂ : ℤ) := by
               omega
             have hm'' : (m' : ℤ) = (m₂ : ℤ) - (j : ℤ) := by omega
@@ -952,16 +925,15 @@ lemma backward_unbounded {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P
   have hfin : ∀ n, (A n : ℤ) = (A 0 : ℤ) + (n : ℤ) * c := by
     intro n
     have h0 := hback m₂ (le_refl m₂)
-    rw [show m₂ - m₂ = 0 from by omega] at h0
-    by_cases hn : n ≤ m₂
+    rw [Nat.sub_self] at h0
+    by_cases! hn : n ≤ m₂
     · have h := hback (m₂ - n) (by omega)
-      rw [show m₂ - (m₂ - n) = n from by omega] at h
+      rw [Nat.sub_sub_self hn] at h
       have hcast : ((m₂ - n : ℕ) : ℤ) = (m₂ : ℤ) - (n : ℤ) := Nat.cast_sub hn
       rw [hcast] at h
       linarith [h, h0]
-    · push Not at hn
-      have ht := htail (n - m₂)
-      rw [show m₂ + (n - m₂) = n from by omega] at ht
+    · have ht := htail (n - m₂)
+      rw [Nat.add_sub_of_le hn.le] at ht
       have hcast : ((n - m₂ : ℕ) : ℤ) = (n : ℤ) - (m₂ : ℤ) := Nat.cast_sub (by omega)
       rw [hcast] at ht
       linarith [ht, h0]

--- a/Compfiles/Imo2023P3.lean
+++ b/Compfiles/Imo2023P3.lean
@@ -334,7 +334,7 @@ lemma shift_bounds {k : ℕ} (hk : 2 ≤ k) {P : Polynomial ℤ} (hmon : P.Monic
     | succ i ih =>
         calc A (m + (i + 1)) = A ((m + i) + 1) := by ring_nf
           _ ≤ A (m + i) + CN := diff_le hk hmon hdeg hcoef hA hpos hmono (m + i)
-          _ ≤ (A m + i * CN) + CN := by exact Nat.add_le_add_right ih CN
+          _ ≤ (A m + i * CN) + CN := Nat.add_le_add_right ih CN
           _ = A m + (i + 1) * CN := by ring
   constructor
   · have h := hmono (show m ≤ m + i by omega)

--- a/Compfiles/Imo2025P1.lean
+++ b/Compfiles/Imo2025P1.lean
@@ -1061,9 +1061,9 @@ end FindLines
 lemma coverGridNoEdgeConfig.cover_edge (C : coverGridNoEdgeConfig) : C.n = 3 ∧ C.nS = 3 := by
   have : C.n ≥ 3 := by
     calc
-    _ = #C.lines := by exact C.lines_count.symm
-    _ ≥ #C.corner_set := by exact Finset.card_le_card C.corner_set_subset_lines
-    _ = 3 := by exact C.corner_set_card
+    _ = #C.lines := C.lines_count.symm
+    _ ≥ #C.corner_set := Finset.card_le_card C.corner_set_subset_lines
+    _ = 3 := C.corner_set_card
   by_cases C.n = 3
   · have := C.cover_no_edge_3_lines; tauto
   · have : C.n ≥ 4 := by lia
@@ -1372,7 +1372,7 @@ problem imo2025_p1 (n : Set.Ici 3) :
     have := C.any_cover
     grind
   · intro hS
-    have : n.val ≥ 3 := by exact n.property
+    have : n.val ≥ 3 := n.property
     have : nS ≤ n.val := by lia
     obtain ⟨C, h⟩ := existsStrongCover n nS this hS
     use C.lines

--- a/Compfiles/Imo2025P4.lean
+++ b/Compfiles/Imo2025P4.lean
@@ -341,7 +341,7 @@ lemma mem_of_dvd_mem_threeSmallest (hmin : ThreeMinDivisors x d₁ d₂ d₃) (h
   by_cases hcase : d₃ < k
   · by_contra
     simp at hd_mem
-    rcases hd_mem with hd | hd | hd <;> grind [show k ≤ d by exact Nat.le_of_dvd (by lia) hk_dvd]
+    rcases hd_mem with hd | hd | hd <;> grind [Nat.le_of_dvd (by lia) hk_dvd]
   · have hd_dvd_x : d ∣ x := by grind only [List.mem_cons, List.not_mem_nil]
     have hmem := mem_divisors_erase_one_of_dvd_ne_one (dvd_trans hk_dvd hd_dvd_x) hx0 (by lia)
     exact (mem_take_or_gt_of_divisor hx hmem hmin.hdiv).resolve_right hcase

--- a/Compfiles/Imo2025P5.lean
+++ b/Compfiles/Imo2025P5.lean
@@ -254,8 +254,7 @@ lemma sum_range_two_mul (f : ℕ → ℝ) (k : ℕ) :
   induction k with
   | zero => simp
   | succ k ih =>
-    rw [Finset.sum_range_succ, ← ih, show 2 * (k + 1) = 2 * k + 1 + 1 from by ring,
-      Finset.sum_range_succ, Finset.sum_range_succ]
+    simp [mul_add, Finset.sum_range_succ, ← ih]
     ring
 
 /-- Cauchy-Schwarz bound: if a sequence vanishes at even indices below `2 * k`, is
@@ -450,7 +449,7 @@ lemma zeros_sum_le {c : ℝ} {x : ℕ → ℝ} (t : ℕ)
   | zero => simp
   | succ t' =>
     have h := (hvalid (2 * t' + 1) (by lia)).2.2 (Nat.odd_iff.mpr (by lia))
-    rw [show 2 * t' + 1 + 1 = 2 * (t' + 1) from by ring] at h
+    rw [add_assoc, ← two_mul, ← mul_add 2] at h
     push_cast at h ⊢
     linarith
 

--- a/Compfiles/Imo2025P6.lean
+++ b/Compfiles/Imo2025P6.lean
@@ -2726,7 +2726,7 @@ lemma b_st_props (s t : Int)
                 0 ≤ b.1 ∧ b.1 < n ∧ 0 ≤ b.2 ∧ b.2 < n) :
     BlackPointProps k s t (make_b_point k s t h_bounds) := by
   let p := make_b_point k s t h_bounds
-  have h_pos : 0 < mod_base k := by exact Int.add_pos_of_nonneg_of_pos (sq_nonneg _) (by decide)
+  have h_pos : 0 < mod_base k := Int.add_pos_of_nonneg_of_pos (sq_nonneg _) (by decide)
   have h_coords : (p.1 : ℤ) = (b_st_coords k s t).1 ∧ (p.2 : ℤ) = (b_st_coords k s t).2 := by
     dsimp [p, make_b_point]
     exact ⟨Int.toNat_of_nonneg h_bounds.1, Int.toNat_of_nonneg h_bounds.2.2.1⟩
@@ -3194,7 +3194,7 @@ lemma unique_col_all_black (k : ℕ) (hk : 2 ≤ k) :
   have h_step1 : (p1.1 : ℤ) + k * p2.2 + k + 1 = p1.1 + C := by dsimp [C]; ring
   have h_step2 : (p2.1 : ℤ) + k * p2.2 + k + 1 = p2.1 + C := by dsimp [C]; ring
   rw [h_step1, h_step2] at h_equiv
-  have h_x_equiv : (p1.1 : ℤ) ≡ p2.1 [ZMOD M] := by exact Int.ModEq.add_right_cancel' C h_equiv
+  have h_x_equiv : (p1.1 : ℤ) ≡ p2.1 [ZMOD M] := Int.ModEq.add_right_cancel' C h_equiv
   have h_x_eq : p1.1 = p2.1 := eq_of_modEq_fin hk h_x_equiv
   ext
   · rw [h_x_eq]

--- a/Compfiles/Imo2025P6.lean
+++ b/Compfiles/Imo2025P6.lean
@@ -2777,26 +2777,24 @@ lemma M_subset_rect (s t : Int) (p : Point n) (hk : 2 ≤ k) :
   · -- x lower: ds + k*dt > 0 and M > 0, so p.1 - xb ≥ 1
     by_contra hc; push Not at hc
     have := Int.lt_add_one_iff.mp hc
-    linarith [mul_nonpos_of_nonneg_of_nonpos hM.le (show (p.1 : ℤ) - ((s-1)+(t-1)*k) ≤ 0 from by linarith)]
+    linarith [mul_nonpos_of_nonneg_of_nonpos hM.le (show (p.1 : ℤ) - ((s-1)+(t-1)*k) ≤ 0 by linarith)]
   · -- x upper: ds + k*dt < M + k*M = M*(k+1)
     by_contra hc; push Not at hc
     have h1 := Int.add_one_le_iff.mpr hc
     have h2 : (t : ℤ) * k - (t - 1) * k = k := by ring
-    have h3 := mul_le_mul_of_nonneg_left (show (k : ℤ)+1 ≤ (p.1 : ℤ)-((s-1)+(t-1)*k) from by linarith) hM.le
+    have h3 := mul_le_mul_of_nonneg_left (show (k : ℤ)+1 ≤ (p.1 : ℤ) - ((s - 1) + (t - 1) * k) by linarith) hM.le
     have h4 : mod_base k + k * mod_base k = mod_base k * (↑k + 1) := by ring
     linarith [hds.2, Int.mul_lt_mul_of_pos_left hdt.2 hk_pos]
   · -- y lower: k*ds - dt > -M
     by_contra hc; push Not at hc
-    have h1 := mul_le_mul_of_nonneg_left (show (p.2 : ℤ) - (s * k - t) ≤ -1 from by
-      linarith [Int.lt_add_one_iff.mp (show (p.2 : ℤ) < s * k - t + 1 by linarith)]) hM.le
-    have h2 : mod_base k * (-1 : ℤ) = -mod_base k := by ring
+    have h1 := mul_le_mul_of_nonneg_left (show (p.2 : ℤ) - (s * k - t) ≤ -1 by clear * - hc; omega) hM.le
     linarith [hy, hdt.2]
   · -- y upper: k*ds - dt < k*M
     by_contra hc; push Not at hc
     have h1 := Int.add_one_le_iff.mpr hc
     have h2 : (s + 1 : ℤ) * k - s * k = k := by ring
-    have h3 := mul_le_mul_of_nonneg_left (show (k : ℤ) ≤ (p.2 : ℤ)-(s*k-t) from by linarith) hM.le
-    have h4 : k * mod_base k = mod_base k * k := by ring
+    have h3 := mul_le_mul_of_nonneg_left (show (k : ℤ) ≤ (p.2 : ℤ) - (s * k - t) by linarith) hM.le
+    clear * - h3 hds hdt hk_pos
     linarith [Int.mul_lt_mul_of_pos_left hds.2 hk_pos, hdt.1]
 
 lemma rect_subset_M (s t : Int) (p : Point n)

--- a/Compfiles/Imo2026P3.lean
+++ b/Compfiles/Imo2026P3.lean
@@ -1674,7 +1674,7 @@ theorem codex_lower_bound_complete (n : ℕ) (_hn : 0 < n) :
     exact Set.union_subset hA.1 hB.1
   obtain ⟨l, hlmap, hlweight⟩ := exists_tagged_piece_refinement
     (S := A) (T := T) (Finset.subset_union_left) hA.1 hT
-  have hAcard : A.card = n := by exact codexLowerCuts_card n
+  have hAcard : A.card = n := codexLowerCuts_card n
   let D := codexDenom n
   let ls := l.mergeSort (fun a b : ℝ × Fin (A.card + 1) => a.1 ≥ b.1)
   let scaled := ls.map fun z => (D * z.1, z.2)
@@ -3713,7 +3713,7 @@ theorem exists_positive_close_refinement (p : List ℝ)
   have hlne : l ≠ [] := flattenFinBlocks_ne_nil b hm hbne
   have hlpos : ∀ z ∈ l, 0 < z := flattenFinBlocks_pos b hbpos
   have hlsum : l.sum = 1 := by
-    rw [show l.sum = p.sum by exact flattenFinBlocks_sum p b hbsum]
+    rw [flattenFinBlocks_sum p b hbsum]
     exact hpsum
   have hlcuts : cutsOfLengths p ⊆ cutsOfLengths l := by
     exact cutsOfLengths_subset_assembleTwoSelectedBlocks p hpne hppos hpsum
@@ -3833,7 +3833,7 @@ theorem exists_singleton_close_refinement (p : List ℝ)
   have hlne : l ≠ [] := flattenFinBlocks_ne_nil b hm hbne
   have hlpos : ∀ z ∈ l, 0 < z := flattenFinBlocks_pos b hbpos
   have hlsum : l.sum = 1 := by
-    rw [show l.sum = p.sum by exact flattenFinBlocks_sum p b hbsum]
+    rw [flattenFinBlocks_sum p b hbsum]
     exact hpsum
   have hlcuts : cutsOfLengths p ⊆ cutsOfLengths l := by
     exact cutsOfLengths_subset_assembleTwoSelectedBlocks p hpne hppos hpsum
@@ -3981,7 +3981,7 @@ theorem exists_hard_reply (n : ℕ) (A : Finset ℝ)
   obtain ⟨l, hlne, hlpos, hlsum, hlcuts, hllen, hlshare⟩ :=
     exists_close_refinement p hpne hppos hpsum
   have hplen : p.length = n + 1 := by
-    rw [show p.length = A.card + 1 by exact pieceLengths_length A, hcard]
+    rw [pieceLengths_length A, hcard]
   have hreplyLen : l.length ≤ A.card + n + 1 := by
     rw [hplen] at hllen
     omega

--- a/Compfiles/UK2024R1P1.lean
+++ b/Compfiles/UK2024R1P1.lean
@@ -230,8 +230,8 @@ lemma S'_k_card_eq_S_succ_k_card (hm : m ≤ 1) : (S' k m).ncard = (S (k + 1)).n
 lemma S_succ_succ_k_card_eq_two_mul_S_succ_k_card : (S (k + 2)).ncard = (S (k + 1)).ncard * 2 := by
     let S₁ := S' k 0
     let S₂ := S' k 1
-    have h1 : S₁.ncard = (S (k + 1)).ncard := by exact S'_k_card_eq_S_succ_k_card (by norm_num)
-    have h2 : S₂.ncard = (S (k + 1)).ncard := by exact S'_k_card_eq_S_succ_k_card (by norm_num)
+    have h1 : S₁.ncard = (S (k + 1)).ncard := S'_k_card_eq_S_succ_k_card (by norm_num)
+    have h2 : S₂.ncard = (S (k + 1)).ncard := S'_k_card_eq_S_succ_k_card (by norm_num)
     have h3 : Disjoint S₁ S₂ := by {
       rw [Set.disjoint_left]
       rintro f ⟨_, hf⟩

--- a/Compfiles/Usa1982P4.lean
+++ b/Compfiles/Usa1982P4.lean
@@ -43,7 +43,7 @@ lemma some_useful_mod_lemma : ∀ (n a b c d : ℕ),
     symm
     apply H a n b c d h1.symm h2 han
   · rw [(by simp : d ^ n = 1 * d ^ n)]
-    have ann : a = (a - n + n) := by exact (Nat.sub_eq_iff_eq_add h).mp rfl
+    have ann : a = (a - n + n) := (Nat.sub_eq_iff_eq_add h).mp rfl
     rw [←(zero_add n : 0 + n = n)] at h1
     rw [ann] at h1
     apply Nat.ModEq.add_right_cancel' at h1

--- a/Compfiles/Usa1984P5.lean
+++ b/Compfiles/Usa1984P5.lean
@@ -112,7 +112,7 @@ lemma fwdDiff_iter_zero (m : ℕ) (f : ℕ → ℝ) :
           = -((-1 : ℝ) ^ (m - i) * (m.choose i : ℝ) * f i) := by
       intro i hi
       rw [Finset.mem_range] at hi
-      rw [show m + 1 - i = (m - i) + 1 from by omega, pow_succ]
+      rw [Nat.sub_add_comm <| Nat.le_of_succ_le_succ hi, pow_succ]
       ring
     rw [Finset.sum_congr rfl gneg, Finset.sum_neg_distrib]
     ring
@@ -123,28 +123,26 @@ lemma poly_fwdDiff (m : ℕ) (P : ℝ[X]) (hP : P.natDegree < m) (k : ℕ) :
   induction m generalizing P with
   | zero => simp at hP
   | succ m ih =>
-    have hz : ∀ t : ℕ, fwdDiff^[t] (fun _ : ℕ ↦ (0 : ℝ)) k = 0 := by
+    have fwdDiff_const {a : ℝ} : fwdDiff (fun _ : ℕ ↦ (a : ℝ)) = (fun _ : ℕ ↦ (0 : ℝ)) := by
+      unfold fwdDiff
+      simp
+    have hz {a : ℝ} : ∀ t : ℕ, fwdDiff^[t + 1] (fun _ : ℕ ↦ (a : ℝ)) k = 0 := by
       intro t
-      induction t with
-      | zero => rfl
+      induction t generalizing a with
+      | zero =>
+        rw [Function.iterate_one]
+        apply funext_iff.mp fwdDiff_const
       | succ t iht =>
-        rw [Function.iterate_succ_apply,
-          show fwdDiff (fun _ : ℕ ↦ (0 : ℝ)) = (fun _ : ℕ ↦ (0 : ℝ)) from by
-            ext j; simp [fwdDiff]]
-        exact iht
+        rw [Function.iterate_succ_apply, fwdDiff_const]
+        apply iht
     by_cases hP0 : P = 0
     · subst hP0
-      rw [show (fun (j : ℕ) ↦ (0 : ℝ[X]).eval (j : ℝ)) = (fun _ : ℕ ↦ (0 : ℝ)) from by ext j; simp]
-      exact hz (m + 1)
+      simp_rw [eval_zero]
+      exact hz m
     · by_cases hdeg0 : P.natDegree = 0
       · have hPc : P = C (P.coeff 0) := Polynomial.eq_C_of_natDegree_eq_zero hdeg0
-        rw [show (fun (j : ℕ) ↦ P.eval (j : ℝ)) = (fun _ : ℕ ↦ P.coeff 0) from by
-          ext j
-          rw [hPc]
-          simp]
-        rw [Function.iterate_succ_apply,
-          show fwdDiff (fun _ : ℕ ↦ P.coeff 0) = (fun _ : ℕ ↦ (0 : ℝ)) from by
-            ext j; simp [fwdDiff]]
+        rw [hPc]
+        simp only [eval_C]
         exact hz m
       · have hPm : P.natDegree ≤ m := by omega
         have hP1 : 1 ≤ P.natDegree := by omega
@@ -172,16 +170,9 @@ lemma poly_fwdDiff (m : ℕ) (P : ℝ[X]) (hP : P.natDegree < m) (k : ℕ) :
           · rw [hz0, Polynomial.natDegree_zero]; omega
           · have h2 := (Polynomial.natDegree_lt_natDegree_iff hnz).mpr hdeg_lt
             omega
-        rw [Function.iterate_succ_apply,
-          show fwdDiff (fun (j : ℕ) ↦ P.eval (j : ℝ))
-              = (fun (j : ℕ) ↦ (P.comp (X + C 1) - P).eval (j : ℝ)) from by
-            ext j
-            show P.eval ((j + 1 : ℕ) : ℝ) - P.eval (j : ℝ) = (P.comp (X + C 1) - P).eval (j : ℝ)
-            rw [Polynomial.eval_sub, Polynomial.eval_comp]
-            have e1 : ((j + 1 : ℕ) : ℝ) = (j : ℝ) + 1 := by push_cast; ring
-            have e2 : (X + C (1 : ℝ)).eval (j : ℝ) = (j : ℝ) + 1 := by simp
-            rw [e1, e2]]
-        exact ih _ hQ
+        rw [Function.iterate_succ_apply]
+        convert ih _ hQ with j
+        simp [fwdDiff]
 
 snip end
 
@@ -254,34 +245,34 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
     · have hjk0 : j = 3 * k := by omega
       have hk2 : k ∈ Finset.range (n + 1) := by rw [Finset.mem_range]; omega
       have hvc : (↑(P.eval (j : ℝ)) : ℂ) = 2 := by
-        rw [show (j : ℝ) = ((3 * k : ℕ) : ℝ) from by rw [hjk0], h0 k hk2]
+        rw [hjk0, h0 k hk2]
         simp
       have hzj : ζ ^ j = 1 := by rw [hjk0, pow_mul, h3, one_pow]
       have hz2j : ζ ^ (2 * j) = 1 := by
-        rw [hjk0, show 2 * (3 * k) = 3 * (2 * k) from by ring, pow_mul, h3, one_pow]
+        rw [hjk0, Nat.mul_left_comm, pow_mul, h3, one_pow]
       rw [hvc, hzj, hz2j]
       linear_combination (1 / 3) * hsum
     · have hjk1 : j = 3 * k + 1 := by omega
       have hk2 : k ∈ Finset.range n := by rw [Finset.mem_range]; omega
       have hvc : (↑(P.eval (j : ℝ)) : ℂ) = 1 := by
-        rw [show (j : ℝ) = ((3 * k + 1 : ℕ) : ℝ) from by rw [hjk1], h1 k hk2]
+        rw [hjk1, h1 k hk2]
         simp
       have hzj : ζ ^ j = ζ := by
         rw [hjk1, pow_add, pow_mul, h3, one_pow, one_mul, pow_one]
       have hz2j : ζ ^ (2 * j) = ζ ^ 2 := by
-        rw [hjk1, show 2 * (3 * k + 1) = 3 * (2 * k) + 2 from by ring, pow_add, pow_mul, h3,
+        rw [hjk1, show 2 * (3 * k + 1) = 3 * (2 * k) + 2 by ring, pow_add, pow_mul, h3,
           one_pow, one_mul]
       rw [hvc, hzj, hz2j]
       linear_combination (ζ / 3) * h3
     · have hjk2 : j = 3 * k + 2 := by omega
       have hk2 : k ∈ Finset.range n := by rw [Finset.mem_range]; omega
       have hvc : (↑(P.eval (j : ℝ)) : ℂ) = 0 := by
-        rw [show (j : ℝ) = ((3 * k + 2 : ℕ) : ℝ) from by rw [hjk2], h2 k hk2]
+        rw [hjk2, h2 k hk2]
         simp
       have hzj : ζ ^ j = ζ ^ 2 := by
         rw [hjk2, pow_add, pow_mul, h3, one_pow, one_mul]
       have hz2j : ζ ^ (2 * j) = ζ := by
-        rw [hjk2, show 2 * (3 * k + 2) = 3 * (2 * k + 1) + 1 from by ring, pow_add, pow_mul, h3,
+        rw [hjk2, show 2 * (3 * k + 2) = 3 * (2 * k + 1) + 1 by ring, pow_add, pow_mul, h3,
           one_pow, one_mul, pow_one]
       rw [hvc, hzj, hz2j]
       linear_combination (-(1 / 3)) * hsum + (2 / 3) * h3
@@ -290,13 +281,12 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
       (-1 : ℂ) ^ (3 * n + 1 - j) = (-1 : ℂ) ^ (3 * n + 1) * (-1) ^ j := by
     intro j hj
     rw [Finset.mem_range] at hj
-    have h2j : (-1 : ℂ) ^ (2 * j) = 1 := by
-      rw [pow_mul, show ((-1 : ℂ) ^ 2) = 1 from by norm_num, one_pow]
-    calc (-1 : ℂ) ^ (3 * n + 1 - j) = (-1 : ℂ) ^ (3 * n + 1 - j) * (-1) ^ (2 * j) := by
-            rw [h2j, mul_one]
-      _ = (-1 : ℂ) ^ (3 * n + 1 - j + 2 * j) := by rw [← pow_add]
-      _ = (-1 : ℂ) ^ (3 * n + 1 + j) := by congr 1; omega
-      _ = (-1 : ℂ) ^ (3 * n + 1) * (-1) ^ j := by rw [pow_add]
+    have h2j : (-1 : ℂ) ^ (2 * j) = 1 := Even.neg_one_pow <| even_two_mul _
+    conv_lhs => rw [← mul_one (_ ^ _)]
+    nth_rw 2 [← h2j]
+    rw [← pow_add, ← pow_add]
+    congr 1
+    omega
   -- truncated binomial sums
   have hS : ∀ x : ℂ, ∑ j ∈ Finset.range (3 * n + 1), ((3 * n + 1).choose j : ℂ) * x ^ j
       = (x + 1) ^ (3 * n + 1) - x ^ (3 * n + 1) := by
@@ -311,22 +301,17 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
   have hS0 : ∑ j ∈ Finset.range (3 * n + 1), ((3 * n + 1).choose j : ℂ) * (-1) ^ j
       = -(-1 : ℂ) ^ (3 * n + 1) := by
     have h := hS (-1)
-    rwa [show (-1 : ℂ) + 1 = 0 from by ring, zero_pow (by omega : 3 * n + 1 ≠ 0), zero_sub] at h
+    rwa [neg_add_cancel, zero_pow (by omega : 3 * n + 1 ≠ 0), zero_sub] at h
   have hzpow : ζ ^ (3 * n + 1) = ζ := by
     rw [pow_succ, pow_mul, h3, one_pow, one_mul]
   have hzpow2 : (ζ ^ 2) ^ (3 * n + 1) = ζ ^ 2 := by
-    rw [← pow_mul, show 2 * (3 * n + 1) = 3 * (2 * n) + 2 from by ring, pow_add, pow_mul, h3,
+    rw [← pow_mul, show 2 * (3 * n + 1) = 3 * (2 * n) + 2 by ring, pow_add, pow_mul, h3,
       one_pow, one_mul]
-  have hS1 : ∑ j ∈ Finset.range (3 * n + 1), ((3 * n + 1).choose j : ℂ) * ((-1) * ζ) ^ j
-      = (1 - ζ) ^ (3 * n + 1) - (-1 : ℂ) ^ (3 * n + 1) * ζ := by
-    have h := hS ((-1) * ζ)
-    rw [show (-1 : ℂ) * ζ + 1 = 1 - ζ from by ring, mul_pow, hzpow] at h
-    exact h
-  have hS2 : ∑ j ∈ Finset.range (3 * n + 1), ((3 * n + 1).choose j : ℂ) * ((-1) * ζ ^ 2) ^ j
-      = (1 - ζ ^ 2) ^ (3 * n + 1) - (-1 : ℂ) ^ (3 * n + 1) * ζ ^ 2 := by
-    have h := hS ((-1) * ζ ^ 2)
-    rw [show (-1 : ℂ) * ζ ^ 2 + 1 = 1 - ζ ^ 2 from by ring, mul_pow, hzpow2] at h
-    exact h
+  replace hS {z : ℂ} (hz : z ^ (3 * n + 1) = z) : ∑ j ∈ Finset.range (3 * n + 1), ((3 * n + 1).choose j : ℂ) * ((-1) * z) ^ j
+      = (1 - z) ^ (3 * n + 1) - (-1 : ℂ) ^ (3 * n + 1) * z := by
+    convert hS ((-1) * z) using 1
+    nth_rw 1 [neg_one_mul]
+    rw [neg_add_eq_sub z 1, mul_pow, hz]
   -- substitute the values and split the sum
   have per : ∀ j ∈ Finset.range (3 * n + 1),
       (-1 : ℂ) ^ (3 * n + 1 - j) * ((3 * n + 1).choose j : ℂ) * (↑(P.eval (j : ℝ)) : ℂ)
@@ -338,9 +323,8 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
     rw [hpt j hj, hsign j hj]
     simp only [mul_pow, pow_mul]
     ring
-  rw [Finset.sum_congr rfl per, Finset.sum_add_distrib, Finset.sum_add_distrib,
-    ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum,
-    hS0, hS1, hS2] at hsumℂ
+  simp only [Finset.sum_congr rfl per, Finset.sum_add_distrib, ← Finset.mul_sum, hS0, hS hzpow, hS hzpow2] at hsumℂ
+  clear per
   have hpow1 : (1 - ζ) / 3 * (1 - ζ) ^ (3 * n + 1) = (1 - ζ) ^ (3 * n + 2) / 3 := by ring
   have hpow2 : (1 - ζ ^ 2) / 3 * (1 - ζ ^ 2) ^ (3 * n + 1) = (1 - ζ ^ 2) ^ (3 * n + 2) / 3 := by ring
   have step1 : (-1 : ℂ) ^ (3 * n + 1)
@@ -354,6 +338,7 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
         - (-1 : ℂ) ^ (3 * n + 1) * ((-1 : ℂ) ^ (3 * n + 1) * ((1 - ζ ^ 2) / 3 * ζ ^ 2)) := by
     linear_combination ((-1 : ℂ) ^ (3 * n + 1)) * hpow2
   rw [step1, step2] at hsumℂ
+  clear step1 step2 hpow1 hpow2
   have hA2 : (-1 : ℂ) ^ (3 * n + 1) * (-1 : ℂ) ^ (3 * n + 1) = 1 := by
     rw [← mul_pow]; simp
   -- the key equation
@@ -381,8 +366,7 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
     have habs : (27 : ℝ) ^ s = 729 := by
       have h := congrArg (fun x : ℝ ↦ |x|) hR
       simp only [abs_pow, abs_neg] at h
-      rw [abs_of_nonneg (by norm_num : (0 : ℝ) ≤ 27)] at h
-      rwa [abs_of_nonneg (by norm_num : (0 : ℝ) ≤ 729)] at h
+      rwa [abs_of_nonneg <| Nat.ofNat_nonneg' _, abs_of_nonneg <| Nat.ofNat_nonneg' _] at h
     have hs2 : s = 2 := by
       rcases Nat.lt_or_ge s 3 with hlt | hge
       · interval_cases s <;> norm_num at habs
@@ -395,14 +379,12 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
   · -- n = 2s + 1 odd
     subst hs
     have hA : (-1 : ℂ) ^ (3 * (2 * s + 1) + 1) = 1 := by
-      rw [show 3 * (2 * s + 1) + 1 = 2 * (3 * s + 2) from by ring, pow_mul,
-        show ((-1 : ℂ) ^ 2) = 1 from by norm_num, one_pow]
+      rw [show 3 * (2 * s + 1) + 1 = 2 * (3 * s + 2) by ring, pow_mul,
+        neg_one_pow_two, one_pow]
     have e1 : (1 - ζ) ^ (3 * (2 * s + 1) + 2) = (-27) ^ s * (1 - ζ) ^ 5 := by
-      rw [show 3 * (2 * s + 1) + 2 = 3 * (2 * s) + 5 from by ring, pow_add,
-        pow_mul (1 - ζ) 3 (2 * s), h3a, pow_mul (3 * (ζ ^ 2 - ζ)) 2 s, h9]
+      rw [show 3 * (2 * s + 1) + 2 = 3 * (2 * s) + 5 by ring, pow_add, pow_mul, h3a, pow_mul, h9]
     have e2 : (1 - ζ ^ 2) ^ (3 * (2 * s + 1) + 2) = (-27) ^ s * (1 - ζ ^ 2) ^ 5 := by
-      rw [show 3 * (2 * s + 1) + 2 = 3 * (2 * s) + 5 from by ring, pow_add,
-        pow_mul (1 - ζ ^ 2) 3 (2 * s), h3b, pow_mul (-3 * (ζ ^ 2 - ζ)) 2 s, h9']
+      rw [show 3 * (2 * s + 1) + 2 = 3 * (2 * s) + 5 by ring, pow_add, pow_mul, h3b, pow_mul, h9']
     rw [e1, e2, hA] at hW
     have hC : (-27 : ℂ) ^ (s + 1) = -2187 := by
       linear_combination hW + (-(-27 : ℂ) ^ s) * h5sum
@@ -410,18 +392,17 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
       apply Complex.ofReal_injective
       push_cast
       exact hC
-    have habs : (27 : ℝ) ^ (s + 1) = 2187 := by
+    have habs : 27 ^ (s + 1) = 2187 := by
       have h := congrArg (fun x : ℝ ↦ |x|) hR
       simp only [abs_pow, abs_neg] at h
-      rw [abs_of_nonneg (by norm_num : (0 : ℝ) ≤ 27)] at h
-      rwa [abs_of_nonneg (by norm_num : (0 : ℝ) ≤ 2187)] at h
+      rw [abs_of_nonneg <| Nat.ofNat_nonneg' _, abs_of_nonneg <| Nat.ofNat_nonneg' _] at h
+      exact_mod_cast h
     exfalso
+    clear * - s habs
     rcases Nat.lt_or_ge s 2 with hlt | hge
-    · have h4 : (27 : ℝ) ^ (s + 1) ≤ 27 ^ 2 := pow_le_pow_right₀ (by norm_num) (by omega)
-      norm_num at h4
-      linarith
-    · have h4 : (27 : ℝ) ^ 3 ≤ 27 ^ (s + 1) := pow_le_pow_right₀ (by norm_num) (by omega)
-      norm_num at h4
-      linarith
+    · have h4 : 27 ^ (s + 1) ≤ 27 ^ 2 := pow_le_pow_right₀ (by decide) (by omega)
+      omega
+    · have h4 : 27 ^ 3 ≤ 27 ^ (s + 1) := pow_le_pow_right₀ (by decide) (by omega)
+      omega
 
 end Usa1984P5

--- a/Compfiles/Usa1984P5.lean
+++ b/Compfiles/Usa1984P5.lean
@@ -69,8 +69,7 @@ lemma fwdDiff_iter_zero (m : ℕ) (f : ℕ → ℝ) :
             (-1 : ℝ) ^ (m + 1 - (j + 1)) * ((m + 1).choose (j + 1) : ℝ) * f (j + 1))
           + (-1 : ℝ) ^ (m + 1) * f 0 := by
       simp only [Finset.sum_range_succ']
-      rw [show (-1 : ℝ) ^ (m + 1 - 0) * ((m + 1).choose 0 : ℝ) * f 0
-          = (-1 : ℝ) ^ (m + 1) * f 0 from by simp]
+      rw [Nat.sub_zero, Nat.choose_zero_right, Nat.cast_one, mul_one]
     rw [rhs_eq]
     have key : ∀ j ∈ Finset.range (m + 1),
         (-1 : ℝ) ^ (m + 1 - (j + 1)) * ((m + 1).choose (j + 1) : ℝ) * f (j + 1)
@@ -94,7 +93,7 @@ lemma fwdDiff_iter_zero (m : ℕ) (f : ℕ → ℝ) :
         intro j _
         show (-1 : ℝ) ^ (m - j) * (m.choose (j + 1) : ℝ) * f (j + 1)
           = (-1 : ℝ) ^ (m + 1 - (j + 1)) * (m.choose (j + 1) : ℝ) * f (j + 1)
-        rw [show m + 1 - (j + 1) = m - j from by omega]
+        rw [Nat.succ_sub_succ]
       have hge := Finset.sum_congr rfl g_def
       rw [hge]
       have h1 := Finset.sum_range_succ'
@@ -296,8 +295,7 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
     calc (-1 : ℂ) ^ (3 * n + 1 - j) = (-1 : ℂ) ^ (3 * n + 1 - j) * (-1) ^ (2 * j) := by
             rw [h2j, mul_one]
       _ = (-1 : ℂ) ^ (3 * n + 1 - j + 2 * j) := by rw [← pow_add]
-      _ = (-1 : ℂ) ^ (3 * n + 1 + j) := by
-            rw [show 3 * n + 1 - j + 2 * j = 3 * n + 1 + j from by omega]
+      _ = (-1 : ℂ) ^ (3 * n + 1 + j) := by congr 1; omega
       _ = (-1 : ℂ) ^ (3 * n + 1) * (-1) ^ j := by rw [pow_add]
   -- truncated binomial sums
   have hS : ∀ x : ℂ, ∑ j ∈ Finset.range (3 * n + 1), ((3 * n + 1).choose j : ℂ) * x ^ j
@@ -343,12 +341,8 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
   rw [Finset.sum_congr rfl per, Finset.sum_add_distrib, Finset.sum_add_distrib,
     ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum,
     hS0, hS1, hS2] at hsumℂ
-  have hpow1 : (1 - ζ) / 3 * (1 - ζ) ^ (3 * n + 1) = (1 - ζ) ^ (3 * n + 2) / 3 := by
-    rw [show 3 * n + 2 = (3 * n + 1) + 1 from by ring, pow_succ]
-    ring
-  have hpow2 : (1 - ζ ^ 2) / 3 * (1 - ζ ^ 2) ^ (3 * n + 1) = (1 - ζ ^ 2) ^ (3 * n + 2) / 3 := by
-    rw [show 3 * n + 2 = (3 * n + 1) + 1 from by ring, pow_succ]
-    ring
+  have hpow1 : (1 - ζ) / 3 * (1 - ζ) ^ (3 * n + 1) = (1 - ζ) ^ (3 * n + 2) / 3 := by ring
+  have hpow2 : (1 - ζ ^ 2) / 3 * (1 - ζ ^ 2) ^ (3 * n + 1) = (1 - ζ ^ 2) ^ (3 * n + 2) / 3 := by ring
   have step1 : (-1 : ℂ) ^ (3 * n + 1)
         * ((1 - ζ) / 3 * ((1 - ζ) ^ (3 * n + 1) - (-1 : ℂ) ^ (3 * n + 1) * ζ))
       = (-1 : ℂ) ^ (3 * n + 1) * ((1 - ζ) ^ (3 * n + 2) / 3)
@@ -371,14 +365,11 @@ problem usa1984_p5 (n : ℕ) (hn : 0 < n) (P : ℝ[X])
   · -- n = s + s even
     subst hs
     have hA : (-1 : ℂ) ^ (3 * (s + s) + 1) = -1 := by
-      rw [show 3 * (s + s) + 1 = 2 * (3 * s) + 1 from by ring, pow_add, pow_mul,
-        show ((-1 : ℂ) ^ 2) = 1 from by norm_num, one_pow, one_mul, pow_one]
+      rw [← two_mul, Nat.mul_left_comm, pow_add, pow_mul, neg_one_pow_two, one_pow, one_mul, pow_one]
     have e1 : (1 - ζ) ^ (3 * (s + s) + 2) = (-27) ^ s * (1 - ζ) ^ 2 := by
-      rw [show 3 * (s + s) + 2 = 3 * (2 * s) + 2 from by ring, pow_add, pow_mul (1 - ζ) 3 (2 * s),
-        h3a, pow_mul (3 * (ζ ^ 2 - ζ)) 2 s, h9]
+      rw [← two_mul, pow_add, pow_mul, h3a, pow_mul, h9]
     have e2 : (1 - ζ ^ 2) ^ (3 * (s + s) + 2) = (-27) ^ s * (1 - ζ ^ 2) ^ 2 := by
-      rw [show 3 * (s + s) + 2 = 3 * (2 * s) + 2 from by ring, pow_add,
-        pow_mul (1 - ζ ^ 2) 3 (2 * s), h3b, pow_mul (-3 * (ζ ^ 2 - ζ)) 2 s, h9']
+      rw [← two_mul, pow_add, pow_mul, h3b, pow_mul, h9']
     rw [e1, e2, hA] at hW
     have hW' : (-27 : ℂ) ^ s * 3 = 2187 := by
       linear_combination -hW + (-(-27 : ℂ) ^ s) * h2sum

--- a/Compfiles/Usa1985P2.lean
+++ b/Compfiles/Usa1985P2.lean
@@ -109,19 +109,12 @@ lemma region2_key {x y : ℝ} (hxy : x < y) (C : ℝ)
     (e1 : (x ^ 2 - C) ^ 2 = x + 5 / 4) (e2 : (y ^ 2 - C) ^ 2 = y + 5 / 4) :
     (y + x) * ((y ^ 2 - C) + (x ^ 2 - C)) = 1 := by
   have hyx : (0:ℝ) < y - x := sub_pos.mpr hxy
-  have e3 : (y ^ 2 - C) - (x ^ 2 - C) = (y - x) * (y + x) := by ring
-  have e4 : (y ^ 2 - C) ^ 2 - (x ^ 2 - C) ^ 2 = y - x := by rw [e2, e1]; ring
-  have e5 : (y ^ 2 - C) ^ 2 - (x ^ 2 - C) ^ 2 =
-      ((y - x) * (y + x)) * ((y ^ 2 - C) + (x ^ 2 - C)) := by
-    rw [show (y ^ 2 - C) ^ 2 - (x ^ 2 - C) ^ 2 =
-        ((y ^ 2 - C) - (x ^ 2 - C)) * ((y ^ 2 - C) + (x ^ 2 - C)) by ring, e3]
-  have e4' : ((y - x) * (y + x)) * ((y ^ 2 - C) + (x ^ 2 - C)) = y - x := by
-    rw [← e5]; exact e4
-  have e6 : (y - x) * ((y + x) * ((y ^ 2 - C) + (x ^ 2 - C))) = (y - x) * 1 := by
-    rw [show (y - x) * ((y + x) * ((y ^ 2 - C) + (x ^ 2 - C))) =
-        ((y - x) * (y + x)) * ((y ^ 2 - C) + (x ^ 2 - C)) from by ring, e4']
-    ring
-  exact mul_left_cancel₀ (ne_of_gt hyx) e6
+  have e3 := calc
+    (y - x) * ((y + x) * ((y ^ 2 - C) + (x ^ 2 - C)))
+    _ = ((y - x) * (y + x)) * ((y ^ 2 - C) + (x ^ 2 - C)) := by rw [mul_assoc]
+    _ = (y ^ 2 - C) ^ 2 - (x ^ 2 - C) ^ 2 := by rw [sq_sub_sq, sub_sub_sub_cancel_right, sq_sub_sq, mul_comm, mul_comm (y + x)]
+    _ = (y - x) * 1 := by rw [e2, e1]; ring
+  exact mul_left_cancel₀ (ne_of_gt hyx) e3
 
 /-- But for `N = 10^10` two roots in `{x² ≥ N + 1/2}` are impossible:
 the left side of the identity above exceeds `2 * 10^5 * 316`. -/

--- a/Compfiles/Usa1986P2.lean
+++ b/Compfiles/Usa1986P2.lean
@@ -140,9 +140,8 @@ problem usa1986_p2 (s e : Fin 5 → Fin 2 → ℝ)
   classical
   -- There are ten pairs of professors.
   have hcard_pairs : pairs.card = 10 := by
-    have h1 : pairs = Finset.powersetCard 2 (Finset.univ : Finset (Fin 5)) := rfl
-    rw [h1, Finset.card_powersetCard, Finset.card_univ, Fintype.card_fin,
-      show Nat.choose 5 2 = 10 from by decide]
+    rw [pairs, Finset.card_powersetCard, Finset.card_univ, Fintype.card_fin]
+    decide
   by_cases hinj : ∀ A B : PairSet, F hsleep A = F hsleep B → A = B
   swap
   · -- If two different pairs have the same first common moment, then at that

--- a/Compfiles/Usa1989P2.lean
+++ b/Compfiles/Usa1989P2.lean
@@ -116,7 +116,7 @@ problem usa1989_p2
       #(s.biUnion Sym2.toFinset) = 12 := by
   obtain ⟨s, hsub, hcard', hdisj⟩ := exists_pairwise_disjoint_edges G hdeg
   rw [hcard, Fintype.card_fin] at hcard'
-  obtain ⟨t, hts, htc⟩ := Finset.exists_subset_card_eq (show 6 ≤ #s from by omega)
+  obtain ⟨t, hts, htc⟩ := Finset.exists_subset_card_eq (show 6 ≤ #s by omega)
   refine ⟨t, hts.trans hsub, htc, ?_⟩
   have hpair : (t : Set (Sym2 (Fin 20))).PairwiseDisjoint Sym2.toFinset := by
     intro e₁ he₁ e₂ he₂ hne

--- a/Compfiles/Usa1992P1.lean
+++ b/Compfiles/Usa1992P1.lean
@@ -93,7 +93,7 @@ lemma lemma3 {m : ℕ} (hm : (m % 10) + 1 < 10) :
   · simp [h]
   nth_rw 2 [Nat.digits_eq_cons_digits_div (by norm_num) (by exact h)]
   simp only [List.sum_cons]
-  rw [show (m + 1) / 10 = m / 10 from by lia, show (m + 1) % 10 = m % 10 + 1 from by lia]
+  rw [Nat.add_div_eq_of_add_mod_lt hm, Nat.add_mod_of_add_mod_lt hm]
   lia
 
 theorem lemma6 {b : ℕ} {l1 l2 : List ℕ} (hg : List.Forall₂ (· ≥ ·) l1 l2) :

--- a/Compfiles/Usa1993P3.lean
+++ b/Compfiles/Usa1993P3.lean
@@ -43,8 +43,7 @@ theorem lemma1 (c1 : ℝ) :
         (∀ (x y : ↑(Set.Icc 0 1)) (h : (x:ℝ) + (y:ℝ) ∈ Set.Icc 0 1), f x + f y ≤ f ⟨↑x + ↑y, h⟩) →
            2 ≤ c1 := by
   intro f h1 h2 h3 h4
-  by_contra h
-  push Not at h
+  by_contra! h
   have hc1 : c1 ≥ 0 := by
     have h1' := h1 (1 / 2 : ℝ) (by norm_num)
     have h5 : f ⟨(1 / 2 : ℝ), by norm_num⟩ = (0 : ℝ) := by
@@ -55,19 +54,18 @@ theorem lemma1 (c1 : ℝ) :
       rw [h5] at h7
       exact h7
     linarith
-  have h9 : ∃ a : ℝ, a > (1 / 2 : ℝ) ∧ a ≤ (1 : ℝ) ∧ 1 > c1 * a := by
+  have h9 : ∃ a : ℝ, (1 / 2 : ℝ) < a ∧ a ≤ (1 : ℝ) ∧ c1 * a < 1 := by
     use (1 + (2 - c1) / 4) / 2
-    constructor
+    and_intros
     · -- Show a > 1/2
       linarith
-    constructor
     · -- Show a ≤ 1
       linarith
     · -- Show 1 > c1 * a
       linarith [sq_nonneg (c1 - 1), sq_nonneg ((1 + (2 - c1) / 4) / 2 - 1 / 2), hc1]
   rcases h9 with ⟨a, ha1, ha2, h10⟩
-  have h1' := h1 a ⟨by linarith, ha2⟩
-  simp only [f, show ¬(a ≤ 1 / 2) from by linarith, ite_false] at h1'
+  replace h1 := h1 a ⟨by linarith, ha2⟩
+  simp only [f, show ¬(a ≤ 1 / 2) by linarith, ite_false] at h1
   linarith
 
 private lemma dyadicBracket

--- a/Compfiles/Usa1999P5.lean
+++ b/Compfiles/Usa1999P5.lean
@@ -917,7 +917,7 @@ lemma exists_second_setup {q p r : ℕ} {lq lr : Piece}
           Function.update b₃ t (some Piece.S) (p + 3) = some Piece.S
         rw [Function.update_of_ne (by omega : p ≠ t),
           Function.update_of_ne (by omega : p + 1 ≠ t),
-          Function.update_of_ne (by omega : p + 2 ≠ t), show p + 3 = t from by omega]
+          Function.update_of_ne (by omega : p + 2 ≠ t), ← ht1]
         exact ⟨hbp, hb₃ _ (by omega) (by omega) (by omega),
           hb₃ _ (by omega) (by omega) (by omega), Function.update_self _ _ _⟩
       · refine ⟨t, Finset.mem_range.mpr (by omega), ?_⟩
@@ -927,7 +927,7 @@ lemma exists_second_setup {q p r : ℕ} {lq lr : Piece}
           Function.update b₃ t (some Piece.S) (t + 3) = some Piece.S
         rw [Function.update_self, Function.update_of_ne (by omega : t + 1 ≠ t),
           Function.update_of_ne (by omega : t + 2 ≠ t),
-          Function.update_of_ne (by omega : t + 3 ≠ t), show t + 3 = p from by omega]
+          Function.update_of_ne (by omega : t + 3 ≠ t), ht1]
         exact ⟨rfl, hb₃ _ (by omega) (by omega) (by omega),
           hb₃ _ (by omega) (by omega) (by omega), hbp⟩
     exact ⟨hte, hnoThr, hnoSOS, htrap⟩

--- a/Compfiles/Usa2000P3.lean
+++ b/Compfiles/Usa2000P3.lean
@@ -504,7 +504,7 @@ lemma fewestWays_rec (A B C : ℕ) (h : 0 < A + B + C) :
         simp_rw [eLHS, hL]
         have c1f : ¬ (0 < A ∧ 3 * A * B = A * C) := by
           intro hh
-          have e : 3 * A * B = A * C := by exact hh.2
+          have e : 3 * A * B = A * C := hh.2
           nlinarith only [e, hC3, hA']
         have c3t : 3 * A * B = 2 * B * C := by rw [hAC]; ring
         rw [if_neg c1f]

--- a/Compfiles/Usa2002P4.lean
+++ b/Compfiles/Usa2002P4.lean
@@ -101,7 +101,7 @@ lemma four_additive {f : ℝ → ℝ} (hf : FE f) (a : ℝ) (b : ℝ) (c : ℝ) 
 lemma main_proof {f : ℝ → ℝ} (hf : FE f) (x : ℝ)  :
     f x = f 1 * x := by
   have h := squarish hf (x+1)
-  rw [show (f (x+1)) = _ by exact additive hf x 1] at h
+  rw [additive hf x 1] at h
   rw [show (x+1)^2 = x^2 + x + x + 1 by ring] at h
   rw [four_additive hf] at h
   rw [squarish hf] at h

--- a/Compfiles/Usa2002P5.lean
+++ b/Compfiles/Usa2002P5.lean
@@ -157,8 +157,7 @@ theorem linked_to_three : ∀ n : ℕ, ∀ t : ℤ, t = n + 3 → Linked t 3 := 
   intro n
   induction n with
   | zero =>
-    intro t ht
-    rw [show t = 3 from by omega]
+    rintro t rfl
     exact .refl (by norm_num)
   | succ n ih =>
     intro t ht

--- a/Compfiles/Usa2002P5.lean
+++ b/Compfiles/Usa2002P5.lean
@@ -55,6 +55,8 @@ inductive Linked : ℤ → ℤ → Prop where
   | snoc {a b c : ℤ} (hab : Linked a b) (hc : 0 < c) (hbc : b + c ∣ b * c) :
       Linked a c
 
+scoped notation a " ~ " b => Linked a b
+
 namespace Linked
 
 theorem pos_left {a b : ℤ} (h : Linked a b) : 0 < a := by
@@ -67,11 +69,14 @@ theorem pos_right {a b : ℤ} (h : Linked a b) : 0 < b := by
   | refl ha => exact ha
   | snoc _ hc _ _ => exact hc
 
+@[trans]
 theorem trans {a b c : ℤ} (hab : Linked a b) (hbc : Linked b c) : Linked a c := by
   revert hab
   induction hbc with
   | refl _ => exact id
   | snoc _ hd hcd ih => exact fun hab => Linked.snoc (ih hab) hd hcd
+
+instance : Trans Linked Linked Linked := ⟨Linked.trans⟩
 
 theorem symm {a b : ℤ} (h : Linked a b) : Linked b a := by
   induction h with
@@ -106,58 +111,46 @@ theorem link_mul_left {m : ℤ} (hm : 0 < m) {a b : ℤ} (h : Linked a b) :
 
 /-- Doubling: every `2 < t` links to `2 * t`. -/
 theorem link_two_mul {t : ℤ} (ht : 2 < t) : Linked t (2 * t) := by
-  have h1 : 1 < t := by omega
-  -- `t ~ t * (t - 1)`
-  have s1 : Linked t (t * (t - 1)) := link_pred_mul h1
-  -- `t * (t - 1) ~ t * (t - 1) * (t - 2)`
-  have s2 : Linked (t * (t - 1)) (t * (t - 1) * (t - 2)) := by
-    have h := link_mul_left (show (0 : ℤ) < t by omega)
-      (link_pred_mul (show 1 < t - 1 by omega))
-    rwa [show t - 1 - 1 = t - 2 from by ring, ← mul_assoc] at h
-  -- `t * (t - 1) * (t - 2) ~ t * (t - 2)`
-  have s3 : Linked (t * (t - 1) * (t - 2)) (t * (t - 2)) := by
-    have h := (link_mul_left (show (0 : ℤ) < t - 2 by omega) (link_pred_mul h1)).symm
-    rwa [show (t - 2) * t = t * (t - 2) from by ring,
-      show (t - 2) * (t * (t - 1)) = t * (t - 1) * (t - 2) from by ring] at h
-  -- `t * (t - 2) ~ 2 * t`
-  have s4 : Linked (t * (t - 2)) (2 * t) := (link_two_mul_pred ht).symm
-  exact (((s1.trans s2).trans s3).trans s4)
+  have h1 : t ~ t * (t - 1) := link_pred_mul (by omega)
+  calc t
+    _ ~ t * (t - 1) := h1
+    _ ~ t * (t - 1) * (t - 2) := by
+      have h := link_mul_left (show (0 : ℤ) < t by omega)
+        (link_pred_mul (show 1 < t - 1 by omega))
+      rwa [Int.sub_sub, ← mul_assoc] at h
+    _ ~ t * (t - 2) := by
+      have h := (link_mul_left (Int.sub_pos.mpr ht) h1).symm
+      rwa [mul_comm _ t, Int.mul_comm] at h
+    _ ~ 2 * t := (link_two_mul_pred ht).symm
 
 /-- Reduction: every `3 < t` links to `t - 1`. -/
 theorem link_pred {t : ℤ} (ht : 3 < t) : Linked t (t - 1) := by
   have h1 : 1 < t := by omega
   have hpm1 : Linked (t - 1) ((t - 1) * (t - 2)) := by
     have h := link_pred_mul (show 1 < t - 1 by omega)
-    rwa [show t - 1 - 1 = t - 2 from by ring] at h
+    rwa [show t - 1 - 1 = t - 2 by ring] at h
   have hpm2 : Linked (t - 2) ((t - 2) * (t - 3)) := by
     have h := link_pred_mul (show 1 < t - 2 by omega)
-    rwa [show t - 2 - 1 = t - 3 from by ring] at h
+    rwa [show t - 2 - 1 = t - 3 by ring] at h
   have hu2 : 2 < (t - 1) * (t - 2) := by
     have hpos : 0 < t * (t - 3) := mul_pos (by omega) (by omega)
     have heq : (t - 1) * (t - 2) = t * (t - 3) + 2 := by ring
     omega
-  -- `t ~ t * (t - 1)`
-  have e1 : Linked t (t * (t - 1)) := link_pred_mul h1
-  -- `t * (t - 1) ~ t * (t - 1) * (t - 2)`
-  have e2 : Linked (t * (t - 1)) (t * (t - 1) * (t - 2)) := by
-    have h := link_mul_left (show (0 : ℤ) < t by omega) hpm1
-    rwa [← mul_assoc] at h
-  -- `t * (t - 1) * (t - 2) ~ t * (t - 1) * (t - 2) * (t - 3)`
-  have e3 : Linked (t * (t - 1) * (t - 2)) (t * (t - 1) * (t - 2) * (t - 3)) := by
-    have h := link_mul_left (mul_pos (show (0 : ℤ) < t by omega)
-      (show (0 : ℤ) < t - 1 by omega)) hpm2
-    rwa [← mul_assoc] at h
-  -- `t * (t - 1) * (t - 2) * (t - 3) ~ 2 * ((t - 1) * (t - 2))`
-  have e4 : Linked (t * (t - 1) * (t - 2) * (t - 3)) (2 * ((t - 1) * (t - 2))) := by
-    have h := (link_two_mul_pred hu2).symm
-    rwa [show (t - 1) * (t - 2) * ((t - 1) * (t - 2) - 2)
-        = t * (t - 1) * (t - 2) * (t - 3) from by ring] at h
-  -- `2 * ((t - 1) * (t - 2)) ~ (t - 1) * (t - 2)`, a whole sub-chain
-  have e5 : Linked (2 * ((t - 1) * (t - 2))) ((t - 1) * (t - 2)) :=
-    (link_two_mul hu2).symm
-  -- `(t - 1) * (t - 2) ~ (t - 1)`
-  have e6 : Linked ((t - 1) * (t - 2)) (t - 1) := hpm1.symm
-  exact ((((e1.trans e2).trans e3).trans e4).trans e5).trans e6
+  calc t
+    _ ~ t * (t - 1) := link_pred_mul h1
+    _ ~ t * (t - 1) * (t - 2) := by
+      have h := link_mul_left (show (0 : ℤ) < t by omega) hpm1
+      rwa [← mul_assoc] at h
+    _ ~ (t * (t - 1) * (t - 2) * (t - 3)) := by
+      have h := link_mul_left (mul_pos (show (0 : ℤ) < t by omega)
+        (show (0 : ℤ) < t - 1 by omega)) hpm2
+      rwa [← mul_assoc] at h
+    _ ~ (2 * ((t - 1) * (t - 2))) := by
+      have h := (link_two_mul_pred hu2).symm
+      rwa [show (t - 1) * (t - 2) * ((t - 1) * (t - 2) - 2)
+          = t * (t - 1) * (t - 2) * (t - 3) by ring] at h
+    _ ~ ((t - 1) * (t - 2)) := (link_two_mul hu2).symm
+    _ ~ (t - 1) := hpm1.symm
 
 /-- Every integer `≥ 3` links to `3`. -/
 theorem linked_to_three : ∀ n : ℕ, ∀ t : ℤ, t = n + 3 → Linked t 3 := by

--- a/Compfiles/Usa2003P3.lean
+++ b/Compfiles/Usa2003P3.lean
@@ -145,7 +145,7 @@ lemma iter_stable_add (a : ℕ → ℕ) {N p : ℕ}
   | zero => exact fun i hi => h i hi
   | succ q IH =>
     intro i hi
-    rw [show p + (q + 1) = p + q + 1 from by omega, iter_succ (p+q) a,
+    rw [← add_assoc, iter_succ (p+q) a,
       iter_succ ((p+q)+1) a, t_def, t_def]
     congr 1
     apply Finset.filter_congr
@@ -279,7 +279,7 @@ lemma comm2 {a : ℕ → ℕ} {n k : ℕ} (hk1 : 1 ≤ k)
       have hp1 := hge (l+k) (by omega) (by omega) m
       have hp2 := hge (j+k) (by omega) hj m
       constructor <;> intro h3 <;> omega
-    rw [hfilter, show m + 1 + 2 = m + 2 + 1 from by omega, iter_succ (m+2) a, t_def]
+    rw [hfilter, add_right_comm, iter_succ (m+2) a, t_def]
     have h0 : ∀ m' < k, t^[m+2] a m' ≠ t^[m+2] a (j+k) := by
       intro m' hm'
       have e1 : t^[m+2] a m' = 0 := hz (m+1) m' hm'
@@ -350,11 +350,11 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
             rwa [show n - 2 + 1 = n - 1 from by omega, show i - 1 + 1 = i from by omega] at e
           have h2 : t^[n-1] (fun j => t a (j+1) - 1) (i-1) + 1 = t^[n] a i := by
             have e := hcomm (n-1) (i-1) (by omega)
-            rwa [show n - 1 + 1 = n from by omega, show i - 1 + 1 = i from by omega] at e
+            rwa [Nat.sub_one_add_one_eq_of_pos hn, Nat.sub_one_add_one_eq_of_pos hi1] at e
           have h3 : t^[n-2] (fun j => t a (j+1) - 1) (i-1)
               = t^[n-1] (fun j => t a (j+1) - 1) (i-1) := by
             have e := IHb (i-1) (by omega)
-            rwa [show n - 1 - 1 = n - 2 from by omega] at e
+            rwa [Nat.sub_succ'] at e
           omega
       · -- Case 2: `a₁ = 0`.
         have ha10 : a 1 = 0 := by omega
@@ -449,10 +449,8 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
             have e1 : t^[n-1] a i = t^[n-2] (t a) i := by
               rw [show n - 1 = n - 2 + 1 from by omega, Function.iterate_add_apply,
                 Function.iterate_one]
-            have e2 : t^[n] a i = t^[n-2] (t^[2] a) i := by
-              rw [← Function.iterate_add_apply, show n - 2 + 2 = n from by omega]
-            rw [e1, e2]
-            exact iter_congr (fun j hj => hstep j (le_trans hj hi)) (n-2) i le_rfl
+            rw [e1, ← Nat.sub_add_cancel hn2, Function.iterate_add_apply]
+            exact iter_congr (hstep · <| ·.trans hi) (n-2) i le_rfl
           · -- Sub-case `k < n`: shift by `k` and apply the induction hypothesis.
             have hklt : k < n := by omega
             have hcomm : ∀ m, ∀ j, j + k ≤ n →
@@ -480,8 +478,7 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
                 have h2 : t^[n-k] (fun j => t^[2] a (j+k) - k) (i'-k) + k
                     = t^[n-k+1+1] a i' := by
                   have e := hcomm (n-k) (i'-k) (by omega)
-                  rwa [show n - k + 2 = n - k + 1 + 1 from by omega,
-                    show i' - k + k = i' from by omega] at e
+                  rwa [Nat.add_succ, Nat.sub_add_cancel hik2] at e
                 have h3 : t^[n-k-1] (fun j => t^[2] a (j+k) - k) (i'-k)
                     = t^[n-k] (fun j => t^[2] a (j+k) - k) (i'-k) := IHc (i'-k) (by omega)
                 omega

--- a/Compfiles/Usa2003P3.lean
+++ b/Compfiles/Usa2003P3.lean
@@ -318,6 +318,7 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
           omega
     · -- Inductive step, `n ≥ 2`.
       have hn2 : 2 ≤ n := by omega
+      have hn3 : n - 1 = n - 2 + 1 := by omega
       have ha1 : a 1 ≤ 1 := ha 1 (by omega)
       by_cases hcase : a 1 = 1
       · -- Case 1: `a₁ = 1`.  Then `t^[m] a i ≥ 1` for all `m ≥ 1`, `1 ≤ i ≤ n`.
@@ -343,11 +344,10 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
         have IHb : ∀ j ≤ n - 1, t^[n-1-1] (fun j => t a (j+1) - 1) j
             = t^[n-1] (fun j => t a (j+1) - 1) j := IH (n-1) (by omega) (by omega) _ hbvalid
         rcases (by omega : i = 0 ∨ 1 ≤ i) with rfl | hi1
-        · rw [show n - 1 = (n - 2) + 1 from by omega, iter_t_zero a (n-2),
-            show n = (n - 1) + 1 from by omega, iter_t_zero a (n-1)]
+        · rw [hn3, iter_t_zero a (n-2), ← Nat.sub_one_add_one_eq_of_pos hn, iter_t_zero a (n-1)]
         · have h1 : t^[n-2] (fun j => t a (j+1) - 1) (i-1) + 1 = t^[n-1] a i := by
             have e := hcomm (n-2) (i-1) (by omega)
-            rwa [show n - 2 + 1 = n - 1 from by omega, show i - 1 + 1 = i from by omega] at e
+            rwa [← hn3, Nat.sub_one_add_one_eq_of_pos hi1] at e
           have h2 : t^[n-1] (fun j => t a (j+1) - 1) (i-1) + 1 = t^[n] a i := by
             have e := hcomm (n-1) (i-1) (by omega)
             rwa [Nat.sub_one_add_one_eq_of_pos hn, Nat.sub_one_add_one_eq_of_pos hi1] at e
@@ -360,10 +360,9 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
         have ha10 : a 1 = 0 := by omega
         by_cases hall : ∀ i ≤ n, a i = 0
         · -- All terms are zero; the sequence is already stable after one step.
-          have hz : ∀ i' < n + 1, a i' = 0 := fun i' hi' => hall i' (by omega)
+          have hz : ∀ i' < n + 1, a i' = 0 := (hall · <| Nat.le_of_succ_le_succ ·)
           have hz' := iter_eq_zero hz
-          rw [show n - 1 = (n - 2) + 1 from by omega, hz' (n-2) i (by omega),
-            show n = (n - 1) + 1 from by omega, hz' (n-1) i (by omega)]
+          rw [hn3, hz' (n-2) i (by omega), ← Nat.sub_one_add_one_eq_of_pos hn, hz' (n-1) i (by omega)]
         · push Not at hall
           obtain ⟨k0, hk0n, hk0⟩ := hall
           -- Let `k` be the first index with `aₖ ≠ 0`; then `2 ≤ k`.
@@ -411,21 +410,15 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
               omega
             rw [← Finset.card_range k]
             exact Finset.card_le_card sub
-          by_cases hkeq : k = n
+          by_cases hkeq : n = k
           · -- Sub-case `k = n`: only `aₙ ≠ 0`; then `t a = t^[2] a` on `{0, …, n}`.
-            have hnk : n = k := hkeq.symm
-            subst hnk
+            subst hkeq
             have hstep : ∀ i' ≤ n, t a i' = t^[2] a i' := by
               intro i' hi'
-              by_cases hi2 : i' < n
-              · have e1 : t a i' = 0 := hz' 0 i' hi2
-                have e2 : t^[2] a i' = 0 := hz' 1 i' hi2
-                rw [e1, e2]
-              · have hii : n = i' := by omega
-                subst hii
-                have e1 : t a n = n := by
+              rcases hi'.eq_or_lt with rfl | hi2
+              · have e1 : t a i' = i' := by
                   rw [t_def]
-                  have hf : (Finset.range n).filter (fun j => a j ≠ a n) = Finset.range n := by
+                  have hf : (Finset.range i').filter (fun j => a j ≠ a i') = Finset.range i' := by
                     apply Finset.filter_true_of_mem
                     intro j hj
                     rw [Finset.mem_range] at hj
@@ -433,11 +426,11 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
                     rw [e3]
                     exact fun hh => hknz hh.symm
                   rw [hf, Finset.card_range]
-                have e2 : t^[2] a n = n := by
-                  show t (t a) n = n
+                have e2 : t^[2] a i' = i' := by
+                  show t (t a) i' = i'
                   rw [t_def]
-                  have hf : (Finset.range n).filter (fun j => t a j ≠ t a n)
-                      = Finset.range n := by
+                  have hf : (Finset.range i').filter (fun j => t a j ≠ t a i')
+                      = Finset.range i' := by
                     apply Finset.filter_true_of_mem
                     intro j hj
                     rw [Finset.mem_range] at hj
@@ -446,9 +439,11 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
                     omega
                   rw [hf, Finset.card_range]
                 rw [e1, e2]
+              · have e1 : t a i' = 0 := hz' 0 i' hi2
+                have e2 : t^[2] a i' = 0 := hz' 1 i' hi2
+                rw [e1, e2]
             have e1 : t^[n-1] a i = t^[n-2] (t a) i := by
-              rw [show n - 1 = n - 2 + 1 from by omega, Function.iterate_add_apply,
-                Function.iterate_one]
+              rw [hn3, Function.iterate_add_apply, Function.iterate_one]
             rw [e1, ← Nat.sub_add_cancel hn2, Function.iterate_add_apply]
             exact iter_congr (hstep · <| ·.trans hi) (n-2) i le_rfl
           · -- Sub-case `k < n`: shift by `k` and apply the induction hypothesis.
@@ -472,9 +467,8 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
               · have hik2 : k ≤ i' := by omega
                 have h1 : t^[n-k-1] (fun j => t^[2] a (j+k) - k) (i'-k) + k
                     = t^[n-k+1] a i' := by
-                  have e := hcomm (n-k-1) (i'-k) (by omega)
-                  rwa [show n - k - 1 + 2 = n - k + 1 from by omega,
-                    show i' - k + k = i' from by omega] at e
+                  have e := hcomm (n-k-1) (i'-k) (by rwa [Nat.sub_add_cancel hik2])
+                  rwa [← Nat.sub_add_comm (by omega), Nat.add_succ_sub_one, Nat.sub_add_cancel hik2] at e
                 have h2 : t^[n-k] (fun j => t^[2] a (j+k) - k) (i'-k) + k
                     = t^[n-k+1+1] a i' := by
                   have e := hcomm (n-k) (i'-k) (by omega)
@@ -484,8 +478,7 @@ theorem main_aux (n : ℕ) : 1 ≤ n → ∀ a : ℕ → ℕ, (∀ i ≤ n, a i 
                 omega
             have hpers : t^[n-k+1+(k-2)] a i = t^[n-k+1+(k-2)+1] a i :=
               iter_stable_add a hstab (k-2) i hi
-            rwa [show n - k + 1 + (k - 2) = n - 1 from by omega,
-              show n - 1 + 1 = n from by omega] at hpers
+            rwa [Nat.add_right_comm, Nat.sub_add_sub_cancel hkn hk2, ← hn3, Nat.sub_one_add_one_eq_of_pos hn] at hpers
 
 snip end
 
@@ -493,7 +486,7 @@ snip end
 problem usa2003_p3 (n : ℕ) (hn : 0 < n) (a : ℕ → ℕ) (ha : ∀ i ≤ n, a i ≤ i) :
     ∃ k, k < n ∧ ∀ i ≤ n, t^[k] a i = t^[k+1] a i := by
   refine ⟨n - 1, by omega, fun i hi => ?_⟩
-  rw [show n - 1 + 1 = n from by omega]
+  rw [Nat.sub_one_add_one_eq_of_pos hn]
   exact main_aux n hn a ha i hi
 
 end Usa2003P3

--- a/Compfiles/Usa2005P4.lean
+++ b/Compfiles/Usa2005P4.lean
@@ -161,14 +161,12 @@ lemma sum_pairCount_sq (n : ℕ) :
     rw [pairCount_eq_of_le (show i ≤ n by omega)]
   have h4 : ∑ r ∈ Finset.Ico (n + 1) (2 * n + 1), (pairCount n r) ^ 2 =
       ∑ i ∈ Finset.range n, (i + 1) ^ 2 := by
-    rw [Finset.sum_Ico_eq_sum_range, show 2 * n + 1 - (n + 1) = n from by omega,
-      ← Finset.sum_range_reflect (fun i => (i + 1) ^ 2) n]
-    refine Finset.sum_congr rfl ?_
-    intro i hi
+    rw [Finset.sum_Ico_eq_sum_range, ← Finset.sum_range_reflect (fun i => (i + 1) ^ 2) n]
+    refine Finset.sum_congr (by rw [two_mul, add_assoc, Nat.add_sub_cancel]) fun i hi => ?_
     simp only [Finset.mem_range] at hi
-    rw [pairCount_symm (r := n + 1 + i) (show n + 1 + i ≤ 2 * n by omega),
-      show 2 * n - (n + 1 + i) = n - 1 - i from by omega,
-      pairCount_eq_of_le (r := n - 1 - i) (show n - 1 - i ≤ n by omega)]
+    rw [pairCount_symm (by omega),
+      Nat.sub_add_eq, Nat.sub_add_eq, two_mul, Nat.add_sub_cancel,
+      pairCount_eq_of_le (by rw [Nat.sub_sub]; exact Nat.sub_le _ _)]
   rw [h1, h2, h3, h4, pairCount_eq_of_le (le_refl n), Finset.sum_range_succ']
   ring
 

--- a/Compfiles/Usa2010P3.lean
+++ b/Compfiles/Usa2010P3.lean
@@ -231,14 +231,14 @@ problem usa2010_p3 :
       x = ∏ i ∈ Finset.range 2010, a i} answer := by
   constructor
   · refine ⟨constr, fun i _ ↦ constr_pos i, fun i j hij _ ↦ constr_ineq hij, ?_⟩
-    rw [show (2010 : ℕ) = 2 * 1005 from by norm_num, prod_range_pair constr 1005]
+    rw [prod_range_pair constr 1005]
     show (∏ k ∈ Finset.range 1005, (4 * (k : ℝ) + 3))
       = ∏ k ∈ Finset.range 1005, constr (2 * k) * constr (2 * k + 1)
     exact Finset.prod_congr rfl fun k _ ↦ (constr_pair k).symm
   · intro y hy
     obtain ⟨a, hpos, hineq, heq⟩ := hy
     rw [heq]
-    rw [show (2010 : ℕ) = 2 * 1005 from by norm_num, prod_range_pair a 1005]
+    rw [prod_range_pair a 1005]
     show (∏ k ∈ Finset.range 1005, a (2 * k) * a (2 * k + 1))
       ≤ ∏ k ∈ Finset.range 1005, (4 * (k : ℝ) + 3)
     refine Finset.prod_le_prod (fun k hk ↦ ?_) (fun k hk ↦ ?_)

--- a/Compfiles/Usa2010P5.lean
+++ b/Compfiles/Usa2010P5.lean
@@ -40,15 +40,11 @@ lemma sum_range_triple (f : ℕ → ℚ) (t : ℕ) :
   induction t with
   | zero => simp
   | succ t ih =>
-    rw [Finset.sum_range_succ, ih,
-      show (3 * (t + 1) + 1 : ℕ) = 3 * t + 4 from by omega,
-      show (3 * t + 4 : ℕ) = (3 * t + 3) + 1 from by omega,
-      Finset.sum_Icc_succ_top (by omega : (2 : ℕ) ≤ 3 * t + 3 + 1),
-      show (3 * t + 3 : ℕ) = (3 * t + 2) + 1 from by omega,
-      Finset.sum_Icc_succ_top (by omega : (2 : ℕ) ≤ 3 * t + 2 + 1),
-      show (3 * t + 2 : ℕ) = (3 * t + 1) + 1 from by omega,
-      Finset.sum_Icc_succ_top (by omega : (2 : ℕ) ≤ 3 * t + 1 + 1)]
-    ring
+    rw [Finset.sum_range_succ, ih]
+    simp_rw [← add_assoc]
+    repeat rw [← sum_Icc_succ_top ?_ f]
+    · congr 2
+    all_goals omega
 
 /-- A sum of reciprocals as a single fraction with the product
 of all denominators as denominator. -/
@@ -183,7 +179,8 @@ problem usa2010_p5 (p q : ℕ) (hpp : Nat.Prime p) (hpo : Odd p) (hq : q = (3*p-
     rw [h2'] at h1
     have hnz1 : ((2*t+1 : ℕ):ℚ) - ((1:ℚ) + (i:ℚ)) ≠ 0 := ne_of_gt (sub_pos.mpr h1)
     have hnz2 : ((2*t+1 : ℕ):ℚ) + ((1:ℚ) + (i:ℚ)) ≠ 0 := ne_of_gt (by positivity)
-    rw [div_add_div _ _ hnz1 hnz2, show ((1+i : ℕ):ℚ) = (1:ℚ) + (i:ℚ) from by push_cast; ring]
+    rw [div_add_div _ _ hnz1 hnz2]
+    push_cast
     ring
   have h9 : (∑ i ∈ Finset.range t, ((1:ℚ)/((2*t+1 : ℕ)-(1+i)) +
         (1:ℚ)/((2*t+1 : ℕ)+(1+i)))) =
@@ -272,8 +269,7 @@ problem usa2010_p5 (p q : ℕ) (hpp : Nat.Prime p) (hpo : Odd p) (hq : q = (3*p-
     have hP2 : ((2*t+1 : ℕ):ℤ) ∣ ((2*t+1 : ℕ):ℤ)^2 := ⟨_, by ring⟩
     have hi2 : ((2*t+1 : ℕ):ℤ) ∣ ((1+i : ℕ):ℤ)^2 := by
       have hsub := dvd_sub hP2 hdiv
-      rwa [show ((2*t+1 : ℕ):ℤ)^2 - (((2*t+1 : ℕ):ℤ)^2 - ((1+i : ℕ):ℤ)^2) =
-        ((1+i : ℕ):ℤ)^2 from by ring] at hsub
+      rwa [Int.sub_sub_self] at hsub
     have hiP : ((2*t+1 : ℕ):ℤ) ∣ ((1+i : ℕ):ℤ) := hpZ.dvd_of_dvd_pow hi2
     have hPdvdN : (2*t+1) ∣ (1+i) := by exact_mod_cast hiP
     have hle : (2*t+1) ≤ (1+i) := Nat.le_of_dvd (by omega) hPdvdN

--- a/Compfiles/Usa2010P6.lean
+++ b/Compfiles/Usa2010P6.lean
@@ -91,31 +91,9 @@ lemma cond_weight (n : ℕ) (q : ℚ) (S₀ S₁ : Finset (Fin n)) (hd : Disjoin
       · by_cases h1 : i ∈ S₁
         · simp [f, g, h0, h1]
         · simp [f, g, h0, h1]
-    rw [Finset.prod_congr rfl (fun i _ => hfg i)]
-    rw [show (∏ i ∈ (Finset.univ : Finset (Fin n)), (if i ∈ S₀ then q else if i ∈ S₁ then 1 - q else 1 : ℚ))
-        = (∏ i ∈ (Finset.univ : Finset (Fin n)) ∩ S₀, q) *
-          (∏ i ∈ (Finset.univ : Finset (Fin n)) \ S₀, (if i ∈ S₁ then 1 - q else 1 : ℚ)) from by
-      rw [← Finset.prod_piecewise]
-      apply Finset.prod_congr rfl
-      intro i _
-      simp only [Finset.piecewise]]
-    rw [Finset.univ_inter, Finset.prod_const]
-    have h2 : ∏ x ∈ (Finset.univ \ S₀), (if x ∈ S₁ then (1:ℚ) - q else 1) = (1 - q) ^ S₁.card := by
-      rw [show (∏ x ∈ (Finset.univ : Finset (Fin n)) \ S₀, (if x ∈ S₁ then (1:ℚ) - q else 1))
-          = (∏ x ∈ (Finset.univ \ S₀) ∩ S₁, (1 - q : ℚ)) *
-            (∏ x ∈ (Finset.univ \ S₀) \ S₁, (1 : ℚ)) from by
-        rw [← Finset.prod_piecewise]
-        apply Finset.prod_congr rfl
-        intro i _
-        simp only [Finset.piecewise]]
-      have hsub : (Finset.univ \ S₀) ∩ S₁ = S₁ := by
-        ext i
-        simp only [Finset.mem_inter, Finset.mem_sdiff, Finset.mem_univ, true_and]
-        constructor
-        · intro h; exact h.2
-        · intro h; exact ⟨fun h0 => (Finset.disjoint_right.mp hd h) h0, h⟩
-      rw [hsub, Finset.prod_const, Finset.prod_const_one, mul_one]
-    rw [h2]
+    rw [Finset.prod_congr rfl (fun i _ => hfg i), Finset.prod_ite, Finset.prod_ite_mem, Finset.prod_const, Finset.prod_const
+      , Finset.inter_comm, Finset.filter_univ_mem, Finset.filter_notMem_eq_sdiff
+      , ← Finset.inter_sdiff_assoc, Finset.inter_univ, Finset.sdiff_eq_self_of_disjoint hd.symm]
   have hterm : ∀ t : Finset (Fin n),
       (∏ i ∈ t, f i) * (∏ i ∈ (Finset.univ : Finset (Fin n)) \ t, g i)
         = if S₀ ⊆ t ∧ Disjoint t S₁ then w n q t else 0 := by

--- a/Compfiles/Usa2012P4.lean
+++ b/Compfiles/Usa2012P4.lean
@@ -135,13 +135,13 @@ lemma eq_two_const_of_f_one_two_eq_two {f : ℕ → ℕ} (hpos : ∀ n, 0 < n �
     (hdiv : ∀ (m n : ℕ), 0 < m → 0 < n → m ≠ n → (m : ℤ) - n ∣ (f m : ℤ) - f n)
     (hf1 : f 1 = 2) (hf2 : f 2 = 2) (n : ℕ) (hn : 0 < n) : f n = 2 := by
   have hf6 : f 6 = (f 3)! := by
-    have h := hfact 3 (by norm_num)
+    have h := hfact 3 (Nat.zero_lt_succ _)
     rwa [show 3 ! = 6 from rfl] at h
   have hf3 : f 3 = 2 := by
-    have h := hdiv 6 1 (by norm_num) (by norm_num) (by norm_num)
-    rw [hf6, hf1, show ((6 : ℕ) : ℤ) - ((1 : ℕ) : ℤ) = ((5 : ℕ) : ℤ) from by norm_num] at h
+    have h := hdiv 6 1 (Nat.zero_lt_succ _) (Nat.zero_lt_succ _) (by norm_num)
+    rw [hf6, hf1] at h
     have hlt : f 3 < 5 := lt_of_dvd_factorial_sub (d := 5) h (by norm_num) (by decide)
-    have hp : 0 < f 3 := hpos 3 (by norm_num)
+    have hp : 0 < f 3 := hpos 3 (Nat.zero_lt_succ _)
     interval_cases f 3
     · exact absurd h (by decide)
     · rfl
@@ -177,14 +177,12 @@ lemma eq_id_of_f_one_eq_one {f : ℕ → ℕ} (hpos : ∀ n, 0 < n → 0 < f n)
     (hfact : ∀ n, 0 < n → f (n !) = (f n)!)
     (hdiv : ∀ (m n : ℕ), 0 < m → 0 < n → m ≠ n → (m : ℤ) - n ∣ (f m : ℤ) - f n)
     (hf1 : f 1 = 1) (hf2 : f 2 = 2) (n : ℕ) (hn : 0 < n) : f n = n := by
-  have hf6 : f 6 = (f 3)! := by
-    have h := hfact 3 (by norm_num)
-    rwa [show 3 ! = 6 from rfl] at h
+  have hf6 : f 6 = (f 3)! := hfact 3 (Nat.zero_lt_succ _)
   have hf3 : f 3 = 3 := by
-    have h1 := hdiv 6 1 (by norm_num) (by norm_num) (by norm_num)
-    rw [hf6, hf1, show ((6 : ℕ) : ℤ) - ((1 : ℕ) : ℤ) = ((5 : ℕ) : ℤ) from by norm_num] at h1
-    have h2 := hdiv 6 2 (by norm_num) (by norm_num) (by norm_num)
-    rw [hf6, hf2, show ((6 : ℕ) : ℤ) - ((2 : ℕ) : ℤ) = ((4 : ℕ) : ℤ) from by norm_num] at h2
+    have h1 := hdiv 6 1 (Nat.zero_lt_succ _) (Nat.zero_lt_succ _) (by norm_num)
+    rw [hf6, hf1] at h1
+    have h2 := hdiv 6 2 (Nat.zero_lt_succ _) (Nat.zero_lt_succ _) (by norm_num)
+    rw [hf6, hf2] at h2
     have hlt : f 3 < 5 := lt_of_dvd_factorial_sub (d := 5) h1 (by norm_num) (by decide)
     have hp : 0 < f 3 := hpos 3 (by norm_num)
     interval_cases f 3

--- a/Compfiles/Usa2013P3.lean
+++ b/Compfiles/Usa2013P3.lean
@@ -216,7 +216,7 @@ private lemma period_shift (q : ℕ → Bool) (hq : ∀ i, q (i + 4) = q i) (i k
   induction k with
   | zero => simp
   | succ k ih =>
-    rw [show i + 4 * (k + 1) = i + 4 * k + 4 from by omega, hq (i + 4 * k), ih]
+    rw [Nat.mul_add, mul_one, ← add_assoc, hq (i + 4 * k), ih]
 
 private lemma card_filter_range_four_mul (q : ℕ → Bool) (hq : ∀ i, q (i + 4) = q i) (k : ℕ) :
     ((Finset.range (4 * k)).filter fun i => q i = true).card =
@@ -241,7 +241,7 @@ private lemma card_filter_range_four_mul (q : ℕ → Bool) (hq : ∀ i, q (i + 
       intro i _
       simp only [Function.comp_apply, addLeftEmbedding_apply, Nat.add_comm (4 * k) i,
         period_shift q hq i k]
-    rw [show 4 * (k + 1) = 4 * k + 4 from by omega, Finset.range_add, Finset.filter_union,
+    rw [mul_add, mul_one, Finset.range_add, Finset.filter_union,
       Finset.card_union_of_disjoint hdisj, ih, hmap, Nat.succ_mul]
 
 /-- Count of a periodic (period 4) predicate over `Finset.range (4 * k + r)`. -/

--- a/Compfiles/Usa2013P3.lean
+++ b/Compfiles/Usa2013P3.lean
@@ -290,14 +290,11 @@ lemma card_range_modeq (n : ℕ) :
   | zero => decide
   | one => decide
   | more n ih0 _ =>
-    have hmod : (n + 2) % 2 = n % 2 := Nat.add_mod_right n 2
-    have hn1 : ¬ ((n + 1) % 2 = n % 2) := by omega
     have hnin : n ∉ (Finset.range n).filter fun i => i % 2 = n % 2 :=
       fun h => Finset.notMem_range_self (Finset.mem_filter.1 h).1
-    rw [hmod, show n + 2 = (n + 1) + 1 from by omega, Finset.range_add_one, Finset.range_add_one,
-      Finset.filter_insert, Finset.filter_insert, if_neg hn1, if_pos rfl,
-      Finset.card_insert_of_notMem hnin, ih0]
-    omega
+    rw [Nat.add_mod_right, Finset.range_add_one, Finset.range_add_one,
+      Finset.filter_insert, Finset.filter_insert, if_neg (by lia), if_pos rfl,
+      Finset.card_insert_of_notMem hnin, ih0, Nat.add_div_right n (Nat.zero_lt_succ _)]
 
 end Count
 
@@ -830,7 +827,7 @@ lemma kernel_of_reduction {n : ℕ} (hn : 0 < n) (hn2 : 2 ≤ n) (v S : Moves n)
 times is one of the eight span elements. -/
 lemma kernel_eq_span {n : ℕ} (hn : 0 < n) {v : Moves n}
     (hv : applyMoves v = fun _ => false) : ∃ ε : Bool × Bool × Bool, v = sp n ε := by
-  rcases (show n = 1 ∨ 2 ≤ n from by omega) with rfl | hn2
+  rcases (show n = 1 ∨ 2 ≤ n by omega) with rfl | hn2
   · -- n = 1: direct case analysis on the three line-values
     set z : Fin 1 := ⟨0, by omega⟩ with hzdef
     have hzv : z.val = 0 := rfl

--- a/Compfiles/Usa2014P6.lean
+++ b/Compfiles/Usa2014P6.lean
@@ -83,7 +83,7 @@ lemma sum_Icc_one_div_le_clog (M : ℕ) :
     omega
   have h1 : ∑ k ∈ Finset.Icc 1 M, (1 : ℚ) / k
       = ∑ j ∈ Finset.range M, (1 : ℚ) / ((1 + j : ℕ) : ℚ) := by
-    rw [hIcc, Finset.sum_Ico_eq_sum_range, show M + 1 - 1 = M from by omega]
+    rw [hIcc, Finset.sum_Ico_eq_sum_range, Nat.add_sub_cancel_right]
   rw [h1]
   have e : ∀ j : ℕ, (1 : ℚ) / ((1 + j : ℕ) : ℚ) = (1 : ℚ) / (j + 1) := by
     intro j

--- a/Compfiles/Usa2016P2.lean
+++ b/Compfiles/Usa2016P2.lean
@@ -103,7 +103,7 @@ lemma sum_range_period_shift {q : ℕ} {F : ℕ → ℕ} (hF : ∀ j, F (j + q) 
   | succ b ih =>
     have hG : ∀ j, F (j + q + 1) = F (j + 1) := by
       intro j
-      rw [show j + q + 1 = j + 1 + q from by omega, hF (j + 1)]
+      rw [Nat.add_right_comm, hF (j + 1)]
     calc ∑ i ∈ Finset.range q, F (i + (b + 1))
         = ∑ i ∈ Finset.range q, (fun j => F (j + 1)) (i + b) := by
           apply Finset.sum_congr rfl
@@ -185,7 +185,7 @@ lemma sum_mod_le_sum_add_mod (k n q : ℕ) (hq : 0 < q) :
   have hF1 : ∀ j, (j + q) % q = j % q := fun j => Nat.add_mod_right j q
   have hF2 : ∀ j, (j + q + n) % q = (j + n) % q := by
     intro j
-    rw [show j + q + n = j + n + q from by omega, Nat.add_mod_right]
+    rw [Nat.add_right_comm, Nat.add_mod_right]
   have hmod_self : ∀ b : ℕ, b ≤ q →
       ∑ i ∈ Finset.range b, i % q = ∑ i ∈ Finset.range b, i := by
     intro b hb

--- a/Compfiles/Usa2018P3.lean
+++ b/Compfiles/Usa2018P3.lean
@@ -302,13 +302,12 @@ lemma pow_pred_dvd_powSum_prime_pow {p : ℕ} (hp : p.Prime) :
     have hpd : p ∣ p ^ e := dvd_pow_self p (by omega : e ≠ 0)
     have hid := powSum_mul_prime_of_dvd hpe2 hp hpd k
     rw [sum_add_pow_eq] at hid
-    rw [show p ^ (e + 1) = p ^ e * p from (pow_succ p e).symm, hid,
-      show e + 1 - 1 = e from by omega]
+    rw [pow_succ p e, hid, Nat.add_sub_cancel_right]
     apply dvd_add
     · have h := ih k
       have h1 : p ^ e = p * p ^ (e - 1) := by
-        conv_lhs => rw [show e = e - 1 + 1 from by omega]
-        rw [pow_succ']
+        rw [mul_pow_sub_one ?_ p]
+        omega
       nth_rewrite 1 [h1]
       exact mul_dvd_mul_left _ h
     · apply Finset.dvd_sum

--- a/Compfiles/Usa2019P1.lean
+++ b/Compfiles/Usa2019P1.lean
@@ -239,7 +239,7 @@ problem usa2019_p1 (m : ℕ+) :
     · exact hmeq
   · intro h
     obtain ⟨f, hf1, hf2⟩ := h
-    suffices h : Even m.val by exact h
+    suffices h : Even m.val from h
     by_contra H
     have h1 : Odd m.val := Nat.not_even_iff_odd.mp H
     have h2 := lemma_3 f hf1 m h1

--- a/Compfiles/Usa2019P3.lean
+++ b/Compfiles/Usa2019P3.lean
@@ -589,8 +589,7 @@ theorem stable_of_form {e k : ℕ} (hlt : k < 10 ^ e) (hk : k = 0 ∨ k ∈ K) :
     · simp
     · exact hkK.2
   have h7 : 7 ∉ Nat.digits 10 (10 ^ e * n + k) := by
-    rw [show 10 ^ e * n + k = n * 10 ^ e + k from by ring,
-      digits_mul_pow_add hnpos hlt]
+    rw [mul_comm, digits_mul_pow_add hnpos hlt]
     intro h
     rcases List.mem_append.mp h with h | h
     · rcases List.mem_append.mp h with h | h

--- a/Compfiles/Usa2019P4.lean
+++ b/Compfiles/Usa2019P4.lean
@@ -534,7 +534,7 @@ lemma stageC (n : ℕ) : ∀ k, k ≤ n →
       simp only [colZero, topRow, intCols, colPart, Set.mem_union, Set.mem_ofPred_eq]
       constructor <;> intro h <;> omega
     rw [hid, stageC_inner n n (le_refl n) k hk', ih (Nat.le_of_succ_le hk),
-      show n * (k + 1) = n * k + n from by ring, pow_add]
+      Nat.mul_succ, pow_add]
     ring
 
 theorem prod_range_self_sub (n : ℕ) :

--- a/Compfiles/Usa2019P5.lean
+++ b/Compfiles/Usa2019P5.lean
@@ -56,7 +56,8 @@ theorem sum_dvd_cong {p a b c d : ℤ} (hpab : p ∣ a + b) (hpcd : p ∣ c + d)
     rw [e]
     exact dvd_neg.mpr hpcd
   have h := (hab.mul_right d).add (hcd.mul_left b)
-  rwa [show -b * d + b * -d = -2 * b * d from by ring] at h
+  ring_nf at h ⊢
+  exact h
 
 /-- If `p ∣ a * d + b * c` and `a * d + b * c ≡ -2 * b * d (mod p)`,
 then `p ∣ 2 * b * d`. -/
@@ -65,7 +66,7 @@ theorem dvd_two_mul_mul_of_dvd {p a b c d : ℤ}
     p ∣ 2 * b * d := by
   rw [Int.modEq_iff_dvd] at hcong
   have h3 := dvd_add h hcong
-  rw [show a * d + b * c + (-2 * b * d - (a * d + b * c)) = -(2 * b * d) from by ring] at h3
+  rw [add_sub_cancel, neg_mul, neg_mul] at h3
   exact dvd_neg.mp h3
 
 /-- An odd prime dividing neither `b` nor `d` does not divide `2 * b * d`. -/

--- a/Compfiles/Usa2019P6.lean
+++ b/Compfiles/Usa2019P6.lean
@@ -77,22 +77,20 @@ lemma phiPoly_eval {K : Type*} [Field K] (P : Polynomial K) (x y : K)
       (2 * x * y - 1) ^ (P.natDegree + 1) *
         Qfun P x y ((x + y) / (2 * x * y - 1)) := by
   have hw : 2 * x * y - 1 ≠ 0 := sub_ne_zero.mpr hxy
-  have hz1 : ∀ k : ℕ, k ≤ P.natDegree →
+  rw [Polynomial.eval_map, PhiPoly, Polynomial.eval₂_finsetSum]
+  rw [qfun_eq_sum, Finset.mul_sum]
+  refine Finset.sum_congr rfl fun k hk => ?_
+  replace hk : k ≤ P.natDegree := Nat.le_of_lt_succ (Finset.mem_range.mp hk)
+  have hz1 :
       (x + y) / (2 * x * y - 1) * ((x + y) / (2 * x * y - 1)) ^ k *
           (2 * x * y - 1) ^ (P.natDegree + 1) =
         (x + y) ^ (k + 1) * (2 * x * y - 1) ^ (P.natDegree - k) := by
-    intro k hk
-    rw [show (x + y) / (2 * x * y - 1) * ((x + y) / (2 * x * y - 1)) ^ k =
-        ((x + y) / (2 * x * y - 1)) ^ (k + 1) from by rw [pow_succ]; ring,
-      div_pow, div_mul_eq_mul_div, div_eq_iff (pow_ne_zero _ hw),
-      show P.natDegree + 1 = P.natDegree - k + (k + 1) from by omega,
-      pow_add _ (P.natDegree - k) (k + 1)]
-    ring
-  have hz2 : ∀ k : ℕ,
-      x * y * ((x + y) / (2 * x * y - 1)) * (x - y) ^ k * (2 * x * y - 1) ^ (P.natDegree + 1) =
-        x * y * (x + y) * (x - y) ^ k * (2 * x * y - 1) ^ P.natDegree := by
-    intro k
-    rw [mul_div_assoc', div_mul_eq_mul_div, div_mul_eq_mul_div, div_eq_iff hw,
+    rw [← pow_succ', div_pow, div_mul_eq_mul_div, div_eq_iff (pow_ne_zero _ hw),
+      mul_assoc (_ ^ _), ← pow_add (2 * x * y - 1), ← Nat.add_assoc, Nat.sub_add_cancel hk]
+  have hz2 :
+      ((x + y) / (2 * x * y - 1)) * (x - y) ^ k * (2 * x * y - 1) ^ (P.natDegree + 1) =
+        (x + y) * (x - y) ^ k * (2 * x * y - 1) ^ P.natDegree := by
+    rw [div_mul_eq_mul_div, div_mul_eq_mul_div, div_eq_iff hw,
       pow_succ]
     ring
   have hyz : y - (x + y) / (2 * x * y - 1) = (2 * x * y ^ 2 - x - 2 * y) / (2 * x * y - 1) := by
@@ -101,35 +99,24 @@ lemma phiPoly_eval {K : Type*} [Field K] (P : Polynomial K) (x y : K)
   have hzx : (x + y) / (2 * x * y - 1) - x = (2 * x + y - 2 * x ^ 2 * y) / (2 * x * y - 1) := by
     rw [eq_div_iff hw, sub_mul, div_mul_cancel₀ _ hw]
     ring
-  have hz3 : ∀ k : ℕ, k ≤ P.natDegree →
-      x * y * ((x + y) / (2 * x * y - 1)) * (y - (x + y) / (2 * x * y - 1)) ^ k *
+  have hz3 :
+      ((x + y) / (2 * x * y - 1)) * (y - (x + y) / (2 * x * y - 1)) ^ k *
           (2 * x * y - 1) ^ (P.natDegree + 1) =
-        x * y * (x + y) * (2 * x * y ^ 2 - x - 2 * y) ^ k * (2 * x * y - 1) ^ (P.natDegree - k) := by
-    intro k hk
+        (x + y) * (2 * x * y ^ 2 - x - 2 * y) ^ k * (2 * x * y - 1) ^ (P.natDegree - k) := by
     rw [hyz, div_pow, mul_div_assoc', div_mul_eq_mul_div, div_eq_iff (pow_ne_zero _ hw),
-      mul_div_assoc', div_mul_eq_mul_div, div_mul_eq_mul_div, div_eq_iff hw,
-      show P.natDegree + 1 = P.natDegree - k + (k + 1) from by omega,
-      pow_add _ (P.natDegree - k) (k + 1)]
-    ring
-  have hz4 : ∀ k : ℕ, k ≤ P.natDegree →
-      x * y * ((x + y) / (2 * x * y - 1)) * ((x + y) / (2 * x * y - 1) - x) ^ k *
+      div_mul_eq_mul_div, div_mul_eq_mul_div, div_eq_iff hw,
+      mul_assoc (_ * _ ^ _), ← pow_succ, mul_assoc (_ * _ ^ _), ← pow_add, ← Nat.add_assoc, Nat.sub_add_cancel hk]
+  have hz4 :
+       ((x + y) / (2 * x * y - 1)) * ((x + y) / (2 * x * y - 1) - x) ^ k *
           (2 * x * y - 1) ^ (P.natDegree + 1) =
-        x * y * (x + y) * (2 * x + y - 2 * x ^ 2 * y) ^ k * (2 * x * y - 1) ^ (P.natDegree - k) := by
-    intro k hk
+         (x + y) * (2 * x + y - 2 * x ^ 2 * y) ^ k * (2 * x * y - 1) ^ (P.natDegree - k) := by
     rw [hzx, div_pow, mul_div_assoc', div_mul_eq_mul_div, div_eq_iff (pow_ne_zero _ hw),
-      mul_div_assoc', div_mul_eq_mul_div, div_mul_eq_mul_div, div_eq_iff hw,
-      show P.natDegree + 1 = P.natDegree - k + (k + 1) from by omega,
-      pow_add _ (P.natDegree - k) (k + 1)]
-    ring
-  rw [Polynomial.eval_map, PhiPoly, Polynomial.eval₂_finsetSum]
-  rw [qfun_eq_sum, Finset.mul_sum]
-  apply Finset.sum_congr rfl
-  intro k hk
-  have hk2 : k ≤ P.natDegree := Nat.le_of_lt_succ (Finset.mem_range.mp hk)
+      div_mul_eq_mul_div, div_mul_eq_mul_div, div_eq_iff hw,
+      mul_assoc (_ * _ ^ _), ← pow_succ, mul_assoc (_ * _ ^ _), ← pow_add, ← Nat.add_assoc, Nat.sub_add_cancel hk]
   simp only [eval₂_mul, eval₂_add, eval₂_sub, eval₂_pow, eval₂_C, eval₂_X, eval₂_one,
     coe_evalRingHom, eval_C, eval_X, eval_mul, eval_pow, eval_ofNat]
   linear_combination
-    (P.coeff k) * (hz2 k + hz3 k hk2 + hz4 k hk2 - hz1 k hk2)
+    (P.coeff k) * (x * y * (hz2 + hz3 + hz4) - hz1)
 
 /-- If `Qfun P` vanishes at every nonzero real triple on the surface `2xyz = x+y+z`,
 then `PhiPoly P` is the zero polynomial. This is the "real dimension two" argument:
@@ -344,7 +331,7 @@ lemma natDegree_le_two (P : Polynomial ℝ) (hP0 : P ≠ 0) (hPhi : PhiPoly P = 
   obtain ⟨h, hh⟩ : ∃ h : ℂ, h ^ 2 = -1 / 2 := by
     refine ⟨Complex.I * (Real.sqrt 2 / 2 : ℝ), ?_⟩
     rw [mul_pow, Complex.I_sq, ← Complex.ofReal_pow, div_pow,
-      Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
+      Real.sq_sqrt zero_le_two]
     push_cast
     norm_num
   have hne : h ≠ 0 := fun h0 => by rw [h0] at hh; norm_num at hh
@@ -393,16 +380,10 @@ lemma natDegree_le_two (P : Polynomial ℝ) (hP0 : P ≠ 0) (hPhi : PhiPoly P = 
     simpa [eval_comp] using h1
   have hcomp : Pc.comp (C (-h) - X) = Pc.comp (X + C h) := by
     have h2 : (-X : Polynomial ℂ).comp (X + C h) = -(X + C h) := by
-      rw [show (-X : Polynomial ℂ) = X * C (-1 : ℂ) from by simp, mul_comp, X_comp,
-        C_comp]
-      simp [Polynomial.C_neg]
-    have e1 : C (-h) - X = -(X + C h) := by
-      rw [Polynomial.C_neg]
-      ring
-    rw [e1, ← h2, ← comp_assoc, hEvenC]
+      rw [neg_comp, X_comp]
+    rw [Polynomial.C_neg, neg_sub_left, ← h2, ← comp_assoc, hEvenC]
   have hconst : C (h * Pc.eval h) + C ((-h) * Pc.eval h) = (0 : Polynomial ℂ) := by
-    have : h * Pc.eval h + -h * Pc.eval h = 0 := by ring
-    rw [← Polynomial.C_add, this]
+    rw [← Polynomial.C_add]
     simp
   have hhalf : h * (-h) = 1 / 2 := by linear_combination -hh
   rw [sub_neg_eq_add, ← two_mul, hev, hcomp, hhalf] at hD0
@@ -439,7 +420,7 @@ lemma natDegree_le_two (P : Polynomial ℝ) (hP0 : P ≠ 0) (hPhi : PhiPoly P = 
     rw [hPc, hn, natDegree_map_eq_of_injective Complex.ofReal_injective]
   have hcoeff0 : (Pc.comp (X + C h) + Pc.comp (X - C h) - 2 * Pc).coeff (n - 2) = 0 := by
     rw [hE]
-    simp [Polynomial.coeff_C, show n - 2 ≠ 0 from by omega]
+    simp [Polynomial.coeff_C, Nat.sub_ne_zero_iff_lt.mpr hlt]
   have hterm : ∀ k : ℕ,
       (C (Pc.coeff k) * (X + C h) ^ k + C (Pc.coeff k) * (X - C h) ^ k -
         (2 : Polynomial ℂ) * (C (Pc.coeff k) * X ^ k)).coeff (n - 2) =

--- a/Compfiles/Usa2019P6.lean
+++ b/Compfiles/Usa2019P6.lean
@@ -405,7 +405,7 @@ lemma natDegree_le_two (P : Polynomial ℝ) (hP0 : P ≠ 0) (hPhi : PhiPoly P = 
     rw [← Polynomial.C_add, this]
     simp
   have hhalf : h * (-h) = 1 / 2 := by linear_combination -hh
-  rw [show h - (-h) = 2 * h from by ring, hev, hcomp, hhalf] at hD0
+  rw [sub_neg_eq_add, ← two_mul, hev, hcomp, hhalf] at hD0
   -- hD0 : X * Pc + C (h*eh) + C ((-h)*eh) - X * C (1/2) * (comp(X−Ch) + C (eval (2h)) + comp(X+Ch)) = 0
   have hD1 : X * Pc = X * C (1 / 2 : ℂ) *
       (Pc.comp (X - C h) + C (Pc.eval (2 * h)) + Pc.comp (X + C h)) := by

--- a/Compfiles/Usa2022P5.lean
+++ b/Compfiles/Usa2022P5.lean
@@ -344,8 +344,7 @@ lemma gval_step_corrector (x : Fin 2022 → ℝ) {j m : ℕ}
     apply testBit_cval_eq_false_of_ge hm1'
     rw [hmlm]
     omega
-  rw [if_testBit_false hbit1, if_testBit_false hbit2, if_pos hjm,
-    if_pos (show j = lvl (m + 1) - 1 from by rw [hmlm]; exact hjm), zero_add, zero_add]
+  rw [if_testBit_false hbit1, if_testBit_false hbit2, hmlm, if_pos hjm, if_pos hjm, zero_add, zero_add]
   have hcv : cval (m + 1) + 1 = cval m := by
     have e : cval (m + 1) = 2 ^ lvl m - 1 - (m + 1) := by
       show 2 ^ lvl (m + 1) - 1 - (m + 1) = 2 ^ lvl m - 1 - (m + 1)

--- a/Compfiles/Usa2024P2.lean
+++ b/Compfiles/Usa2024P2.lean
@@ -861,7 +861,7 @@ lemma SignatureIntersectionCount_eq_self_add_strict
         ∑ w ∈ (Finset.univ : Finset Signature).erase u, B w := by
     rw [strictSupersetContribution]
     rw [← Finset.sum_erase_add (Finset.univ : Finset Signature) B (Finset.mem_univ u)]
-    have hnss : ¬ u ⊂ u := by exact irrefl u
+    have hnss : ¬ u ⊂ u := irrefl u
     simp [B]
   calc
     SignatureIntersectionCount f u =
@@ -1217,7 +1217,7 @@ noncomputable def signatureCount (S : Fin 100 → Set ℤ) (v : Signature) : ℕ
 
 lemma signatureCount_condition_of_good (S : Fin 100 → Set ℤ) (hS : Good S) :
     SignatureCountCondition (signatureCount S) := by
-  -- Partition the intersection by exact signatures.
+  -- Partition the intersection signatures.
   classical
   intro u hu
   rcases hS.card u hu with ⟨k, hk⟩
@@ -1289,7 +1289,7 @@ lemma signatureObjective_eq_original_objective
     (S : Fin 100 → Set ℤ) (hS : Good S) :
     SignatureObjective (signatureCount S) =
       {z : ℤ | InAtLeastKSubsets S 50 z }.ncard := by
-  -- Partition high-membership elements by exact signature.
+  -- Partition high-membership elements signature.
   classical
   have hsig_card :
       ∀ z : ℤ, {i : Fin 100 | z ∈ S i}.ncard = (signatureOf S z).card := by

--- a/Compfiles/Usa2024P6.lean
+++ b/Compfiles/Usa2024P6.lean
@@ -129,14 +129,11 @@ lemma lhs_eq_sum_v_sq {n k : ℕ} (x : Fin k → ℝ) (A : Fin k → Finset (Fin
             (if p ∈ A i ∧ q ∈ A i then x i / (A i).card else 0) *
               (if p ∈ A j ∧ q ∈ A j then x j / (A j).card else 0) := by
           refine Finset.sum_congr rfl fun p _ => Finset.sum_congr rfl fun q _ => ?_
-          rw [show (e i p * e j p) * (e i q * e j q) =
-              (if p ∈ A i ∧ q ∈ A i then (1 : ℝ) else 0) *
-                (if p ∈ A j ∧ q ∈ A j then (1 : ℝ) else 0) from by
-            by_cases h1 : p ∈ A i <;> by_cases h2 : q ∈ A i <;>
-              by_cases h3 : p ∈ A j <;> by_cases h4 : q ∈ A j <;>
-              simp [he, h1, h2, h3, h4]]
-          by_cases h1 : p ∈ A i ∧ q ∈ A i <;> by_cases h2 : p ∈ A j ∧ q ∈ A j <;>
-            simp [h1, h2, div_mul_div_comm, div_div]
+          simp only [e, ite_zero_mul_ite_zero, one_mul]
+          rw [mul_boole]
+          congr 1
+          · lia
+          · ring
   calc ∑ i : Fin k, ∑ j : Fin k, x i * x j *
         (((A i ∩ A j).card : ℝ) ^ 2 / ((A i).card : ℝ) / ((A j).card : ℝ))
       = ∑ i : Fin k, ∑ j : Fin k, ∑ p : Fin n, ∑ q : Fin n,
@@ -156,16 +153,11 @@ lemma lhs_eq_sum_v_sq {n k : ℕ} (x : Fin k → ℝ) (A : Fin k → Finset (Fin
 lemma sum_diag {n k : ℕ} (x : Fin k → ℝ) (A : Fin k → Finset (Fin n))
     (hA : ∀ i, (A i).card ≠ 0) :
     ∑ p : Fin n, vvv x A p p = ∑ i : Fin k, x i := by
-  classical
   simp only [vvv_def, and_self]
   rw [Finset.sum_comm]
   refine Finset.sum_congr rfl fun i _ => ?_
-  rw [← Finset.sum_filter]
-  rw [show Finset.univ.filter (· ∈ A i) = A i from by ext p; simp]
-  rw [Finset.sum_const, nsmul_eq_mul]
-  have hAi : ((A i).card : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (hA i)
-  rw [← mul_div_assoc]
-  exact mul_div_cancel_left₀ _ hAi
+  rw [Fintype.sum_ite_mem, Finset.sum_const, nsmul_eq_mul, ← mul_div_assoc, mul_div_cancel_left₀ _]
+  exact Nat.cast_ne_zero.mpr (hA i)
 
 /-- Sums over the off-diagonal pairs as double sums. -/
 lemma sum_sigma_erase {n : ℕ} (f : Fin n → Fin n → ℝ) :
@@ -285,12 +277,7 @@ lemma solution_works {n ℓ : ℕ} (hn : 2 < n) (hℓ1 : 1 ≤ ℓ) :
 /-- Counting the elements of a finset with a weight of `1` each. -/
 lemma diag_count {n : ℕ} (B : Finset (Fin n)) :
     ∑ p : Fin n, (if p ∈ B then (1 : ℝ) else 0) = (B.card : ℝ) := by
-  classical
-  have h' : Finset.univ.filter (· ∈ B) = B := by
-    ext p
-    simp
-  rw [show (B.card : ℝ) = ((Finset.univ.filter (· ∈ B)).card : ℝ) from by rw [h'],
-    Finset.natCast_card_filter]
+  rw [← Finset.natCast_card_filter, Finset.filter_univ_mem]
 
 /-- The pairs `(p, q)` with `p ≠ q` inside `B × B`, as a sigma finset. -/
 lemma pair_filter_eq {n : ℕ} (B : Finset (Fin n)) :

--- a/Compfiles/Usa2025P2.lean
+++ b/Compfiles/Usa2025P2.lean
@@ -261,8 +261,7 @@ lemma core_pigeonhole {k : ℕ} (hk : 1 ≤ k) {s : Finset ℝ} (hscard : s.card
   have hcoeff : ∀ c : ℝ, ∀ m : ℕ, 1 ≤ m →
       ((X - C c) * R).coeff m = R.coeff (m - 1) - c * R.coeff m := by
     intro c m hm
-    rw [sub_mul, coeff_sub, coeff_C_mul, show m = m - 1 + 1 by omega, coeff_X_mul,
-      show m - 1 + 1 - 1 = m - 1 from by omega]
+    simp [sub_mul, ← coeff_X_mul R (m-1), ← (Nat.sub_eq_iff_eq_add hm).mp rfl]
   have he1 : R.coeff (t - 1) = i2 * R.coeff t := by
     have h := hc1
     rw [hfac1, hcoeff i2 t ht.1] at h

--- a/Compfiles/Usa2025P6.lean
+++ b/Compfiles/Usa2025P6.lean
@@ -1196,14 +1196,14 @@ lemma mergeOne {m k : ℕ} [NeZero m] (P : CirclePartition m k) (hk : 0 < k) (hk
       by_cases hn0 : n = 0
       · subst hn0
         have h1 : P'.off ⟨0 + 1, hn2⟩ = P'.off ⟨0, hk'⟩ + P'.len ⟨0, hk'⟩ :=
-          off_succ P' ⟨0, hk'⟩ (by exact hn2)
+          off_succ P' ⟨0, hk'⟩ hn2
         rw [h1, off_zero P' hk', hP'len]
         simp only [hlen'_def, if_pos rfl, zero_add]
         rw [hHT, hoff2, hofj]
         omega
       · have ih' := ih (by omega) (by omega)
         have h1 : P'.off ⟨n + 1, hn2⟩ = P'.off ⟨n, by omega⟩ + P'.len ⟨n, by omega⟩ :=
-          off_succ P' ⟨n, by omega⟩ (by exact hn2)
+          off_succ P' ⟨n, by omega⟩ hn2
         have hge : P.off j + l ≤ P.offExt hk (j.val + 1 + n) := by
           have h2 : P.offExt hk (j.val + 2) ≤ P.offExt hk (j.val + 1 + n) := by
             apply P.offExt_mono hk
@@ -1222,7 +1222,7 @@ lemma mergeOne {m k : ℕ} [NeZero m] (P : CirclePartition m k) (hk : 0 < k) (hk
       simp only [hlen'_def, hi0, if_true]
     have hoff0 : P'.off i = 0 := by
       rw [show i = ⟨0, hk'⟩ from Fin.ext hi0]
-      exact off_zero P' hk' 
+      exact off_zero P' hk'
     rw [sum_arcOf P' hk' i (w ∘ skipMap a₀ l), hoff0, hlen0, zero_add]
     have hsplit : ∑ t ∈ Finset.Ico 0 (H + T), P'.perW (w ∘ skipMap a₀ l) t
         = (∑ t ∈ Finset.Ico 0 H, P'.perW (w ∘ skipMap a₀ l) t)


### PR DESCRIPTION
`from by` and `by exact` can be simplified to `by` and `` respectively.

Many usages of `from by` are from `rw` steps, which use tactics like `ring`, `omega` to close the nested `show` term.
In these cases, we can usually replace them with the actual rw steps themselves.

